### PR TITLE
docs: adding requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ See [SUPPORTED_CHAINS.md](./SUPPORTED_CHAINS.md) for which chains we support and
 
 ## Development
 
+### Requirements
+
+- [Rust](https://www.rust-lang.org/tools/install) >= 1.56 version,
+- [Just](https://github.com/casey/just#packages) as a command runner,
+- [Docker](https://www.docker.com/) for building and running Docker containers.
+
+### Building and running
+
 ```bash
 cp .env.example .env
 nano .env


### PR DESCRIPTION
# Description

Adding the `Requirements` section to the `README.md` with the requirements below:
- [Rust](https://www.rust-lang.org/tools/install) >= 1.56 version,
- [Just](https://github.com/casey/just#packages) as a command runner,
- [Docker](https://www.docker.com/) for building and running Docker containers.

`Curl` and `Nano` which are used in the `README.md` are pretty common and can be pre-installed on some distributions. On the other side `Rust`, `Just`, and `Docker` are not (especially `Just` is not a common bird), so it's good to let the developer know to install the requirements for building the project.

Resolves #318

## How Has This Been Tested?

N/A: Doesn't require a test as it's a documentation update.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
