### PR TITLE
fix: lower autoscaling thresholds

### DIFF
--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -235,7 +235,7 @@ resource "aws_appautoscaling_policy" "cpu_scaling" {
     predefined_metric_specification {
       predefined_metric_type = "ECSServiceAverageCPUUtilization"
     }
-    target_value       = 70
+    target_value       = 50
     scale_in_cooldown  = 180
     scale_out_cooldown = 180
   }
@@ -253,7 +253,7 @@ resource "aws_appautoscaling_policy" "memory_scaling" {
     predefined_metric_specification {
       predefined_metric_type = "ECSServiceAverageMemoryUtilization"
     }
-    target_value       = 70
+    target_value       = 50
     scale_in_cooldown  = 180
     scale_out_cooldown = 180
   }


### PR DESCRIPTION
# Description

Lower autoscaling thresholds so they trigger before the monitoring alerts.
Since the alerts and monitoring are configured with the same levels, alerts are fired before and more often than when autoscaling events are happening.
Looking at the charts, 50% usage for autoscaling seems to be the sweet spot.

Resolves # (issue)

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
