### PR TITLE
fix: update rust version in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Build args
 #
 ################################################################################
-ARG                 base="rust:1.65-buster"
+ARG                 base="rust:buster"
 ARG                 runtime="debian:buster-slim"
 ARG                 bin="rpc-proxy"
 ARG                 version="unknown"


### PR DESCRIPTION
# Description

Update rust to `1.72` in Dockerfile.

Resolves #329 

## How Has This Been Tested?

Local tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
