### PR TITLE
feat: use registry.walletconnect.org

### DIFF
--- a/terraform/vars/dev.tfvars
+++ b/terraform/vars/dev.tfvars
@@ -1,5 +1,5 @@
 project_data_cache_ttl    = 300
-registry_api_endpoint     = "https://registry-prod-cf.walletconnect.com"
+registry_api_endpoint     = "https://registry.walletconnect.org"
 autoscaling_max_instances = 2
 autoscaling_min_instances = 1
 

--- a/terraform/vars/prod.tfvars
+++ b/terraform/vars/prod.tfvars
@@ -1,5 +1,5 @@
 project_data_cache_ttl    = 300
-registry_api_endpoint     = "https://registry-prod-cf.walletconnect.com"
+registry_api_endpoint     = "https://registry.walletconnect.org"
 autoscaling_max_instances = 5
 autoscaling_min_instances = 1
 

--- a/terraform/vars/staging.tfvars
+++ b/terraform/vars/staging.tfvars
@@ -1,5 +1,5 @@
 project_data_cache_ttl    = 300
-registry_api_endpoint     = "https://registry-prod-cf.walletconnect.com"
+registry_api_endpoint     = "https://registry.walletconnect.org"
 autoscaling_max_instances = 2
 autoscaling_min_instances = 1
 


### PR DESCRIPTION
# Description

We observe some shenanigans with cloudflare because of which our rate limiting doesn't work, as registry API always returns `isValid: true`. 
@Cali93's proposed solution was to use `.org`

## How Has This Been Tested?

Existing tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
