### PR TITLE
feat: add transactions and nft info to the history response

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 use {
+    crate::providers::zerion::ZerionTransactionTransfer,
     serde::{Deserialize, Serialize},
     wc::metrics::TaskMetrics,
 };
@@ -45,7 +46,7 @@ pub struct HistoryResponseBody {
 pub struct HistoryTransaction {
     pub id: String,
     pub metadata: HistoryTransactionMetadata,
-    pub transfers: Vec<HistoryTransactionTransferInfo>,
+    pub transfers: Vec<ZerionTransactionTransfer>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
@@ -58,43 +59,4 @@ pub struct HistoryTransactionMetadata {
     pub sent_to: String,
     pub status: String,
     pub nonce: usize,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct HistoryTransactionFungibleInfo {
-    pub name: String,
-    pub symbol: String,
-    pub icon_url: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct HistoryTransactionTransferInfo {
-    pub fungible_info: Option<HistoryTransactionFungibleInfo>,
-    pub nft_info: Option<HistoryTransactionNFTInfo>,
-    pub direction: String,
-    pub value: usize,
-    pub price: usize,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct HistoryTransactionNFTInfo {
-    pub name: String,
-    pub content: HistoryTransactionNFTContent,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct HistoryTransactionNFTContent {
-    pub preview: HistoryTransactionNFTContentItem,
-    pub detail: HistoryTransactionNFTContentItem,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct HistoryTransactionNFTContentItem {
-    pub url: String,
-    pub content_type: String,
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -45,6 +45,7 @@ pub struct HistoryResponseBody {
 pub struct HistoryTransaction {
     pub id: String,
     pub metadata: HistoryTransactionMetadata,
+    pub transfers: Vec<HistoryTransactionTransferInfo>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
@@ -57,4 +58,43 @@ pub struct HistoryTransactionMetadata {
     pub sent_to: String,
     pub status: String,
     pub nonce: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryTransactionFungibleInfo {
+    pub name: String,
+    pub symbol: String,
+    pub icon_url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryTransactionTransferInfo {
+    pub fungible_info: Option<HistoryTransactionFungibleInfo>,
+    pub nft_info: Option<HistoryTransactionNFTInfo>,
+    pub direction: String,
+    pub value: usize,
+    pub price: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryTransactionNFTInfo {
+    pub name: String,
+    pub content: HistoryTransactionNFTContent,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryTransactionNFTContent {
+    pub preview: HistoryTransactionNFTContentItem,
+    pub detail: HistoryTransactionNFTContentItem,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryTransactionNFTContentItem {
+    pub url: String,
+    pub content_type: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ mod analytics;
 pub mod env;
 pub mod error;
 mod extractors;
-mod handlers;
+pub mod handlers;
 mod json_rpc;
 mod metrics;
 pub mod profiler;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -21,7 +21,7 @@ mod omnia;
 mod pokt;
 mod publicnode;
 mod weights;
-mod zerion;
+pub mod zerion;
 mod zksync;
 mod zora;
 

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -6,12 +6,7 @@ use {
             HistoryQueryParams,
             HistoryResponseBody,
             HistoryTransaction,
-            HistoryTransactionFungibleInfo,
             HistoryTransactionMetadata,
-            HistoryTransactionNFTContent,
-            HistoryTransactionNFTContentItem,
-            HistoryTransactionNFTInfo,
-            HistoryTransactionTransferInfo,
         },
     },
     async_trait::async_trait,
@@ -74,8 +69,8 @@ pub struct ZerionTransactionAttributes {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 pub struct ZerionTransactionTransfer {
-    pub fungible_info: ZerionTransactionFungibleInfo,
-    pub nft_info: ZerionTransactionNFTInfo,
+    pub fungible_info: Option<ZerionTransactionFungibleInfo>,
+    pub nft_info: Option<ZerionTransactionNFTInfo>,
     pub direction: String,
     pub value: usize,
     pub price: usize,
@@ -83,9 +78,9 @@ pub struct ZerionTransactionTransfer {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 pub struct ZerionTransactionFungibleInfo {
-    pub name: String,
-    pub symbol: String,
-    pub icon: ZerionTransactionURLItem,
+    pub name: Option<String>,
+    pub symbol: Option<String>,
+    pub icon: Option<ZerionTransactionURLItem>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
@@ -96,19 +91,19 @@ pub struct ZerionTransactionURLItem {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 pub struct ZerionTransactionURLandContentTypeItem {
     pub url: String,
-    pub content_type: String,
+    pub content_type: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 pub struct ZerionTransactionNFTContent {
-    pub preview: ZerionTransactionURLandContentTypeItem,
-    pub detail: ZerionTransactionURLandContentTypeItem,
+    pub preview: Option<ZerionTransactionURLandContentTypeItem>,
+    pub detail: Option<ZerionTransactionURLandContentTypeItem>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 pub struct ZerionTransactionNFTInfo {
-    pub name: String,
-    pub content: ZerionTransactionNFTContent,
+    pub name: Option<String>,
+    pub content: Option<ZerionTransactionNFTContent>,
 }
 
 #[async_trait]
@@ -178,33 +173,7 @@ impl HistoryProvider for ZerionProvider {
                     sent_to: f.attributes.sent_to,
                     status: f.attributes.status,
                 },
-                transfers: f
-                    .transfers
-                    .into_iter()
-                    .map(|t| HistoryTransactionTransferInfo {
-                        fungible_info: Some(HistoryTransactionFungibleInfo {
-                            name: t.fungible_info.name,
-                            symbol: t.fungible_info.symbol,
-                            icon_url: t.fungible_info.icon.url,
-                        }),
-                        nft_info: Some(HistoryTransactionNFTInfo {
-                            name: t.nft_info.name,
-                            content: HistoryTransactionNFTContent {
-                                preview: HistoryTransactionNFTContentItem {
-                                    url: t.nft_info.content.preview.url,
-                                    content_type: t.nft_info.content.preview.content_type,
-                                },
-                                detail: HistoryTransactionNFTContentItem {
-                                    url: t.nft_info.content.detail.url,
-                                    content_type: t.nft_info.content.detail.content_type,
-                                },
-                            },
-                        }),
-                        direction: t.direction,
-                        value: t.value,
-                        price: t.price,
-                    })
-                    .collect(),
+                transfers: f.transfers,
             })
             .collect();
 

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -72,8 +72,14 @@ pub struct ZerionTransactionTransfer {
     pub fungible_info: Option<ZerionTransactionFungibleInfo>,
     pub nft_info: Option<ZerionTransactionNFTInfo>,
     pub direction: String,
+    pub quantity: ZerionTransactionTransferQuantity,
     pub value: usize,
     pub price: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionTransferQuantity {
+    pub float: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -6,7 +6,12 @@ use {
             HistoryQueryParams,
             HistoryResponseBody,
             HistoryTransaction,
+            HistoryTransactionFungibleInfo,
             HistoryTransactionMetadata,
+            HistoryTransactionNFTContent,
+            HistoryTransactionNFTContentItem,
+            HistoryTransactionNFTInfo,
+            HistoryTransactionTransferInfo,
         },
     },
     async_trait::async_trait,
@@ -52,6 +57,7 @@ pub struct ZerionTransactionsReponseBody {
     pub r#type: String,
     pub id: String,
     pub attributes: ZerionTransactionAttributes,
+    pub transfers: Vec<ZerionTransactionTransfer>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
@@ -64,6 +70,45 @@ pub struct ZerionTransactionAttributes {
     pub sent_to: String,
     pub status: String,
     pub nonce: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionTransfer {
+    pub fungible_info: ZerionTransactionFungibleInfo,
+    pub nft_info: ZerionTransactionNFTInfo,
+    pub direction: String,
+    pub value: usize,
+    pub price: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionFungibleInfo {
+    pub name: String,
+    pub symbol: String,
+    pub icon: ZerionTransactionURLItem,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionURLItem {
+    pub url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionURLandContentTypeItem {
+    pub url: String,
+    pub content_type: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionNFTContent {
+    pub preview: ZerionTransactionURLandContentTypeItem,
+    pub detail: ZerionTransactionURLandContentTypeItem,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionNFTInfo {
+    pub name: String,
+    pub content: ZerionTransactionNFTContent,
 }
 
 #[async_trait]
@@ -133,6 +178,33 @@ impl HistoryProvider for ZerionProvider {
                     sent_to: f.attributes.sent_to,
                     status: f.attributes.status,
                 },
+                transfers: f
+                    .transfers
+                    .into_iter()
+                    .map(|t| HistoryTransactionTransferInfo {
+                        fungible_info: Some(HistoryTransactionFungibleInfo {
+                            name: t.fungible_info.name,
+                            symbol: t.fungible_info.symbol,
+                            icon_url: t.fungible_info.icon.url,
+                        }),
+                        nft_info: Some(HistoryTransactionNFTInfo {
+                            name: t.nft_info.name,
+                            content: HistoryTransactionNFTContent {
+                                preview: HistoryTransactionNFTContentItem {
+                                    url: t.nft_info.content.preview.url,
+                                    content_type: t.nft_info.content.preview.content_type,
+                                },
+                                detail: HistoryTransactionNFTContentItem {
+                                    url: t.nft_info.content.detail.url,
+                                    content_type: t.nft_info.content.detail.content_type,
+                                },
+                            },
+                        }),
+                        direction: t.direction,
+                        value: t.value,
+                        price: t.price,
+                    })
+                    .collect(),
             })
             .collect();
 


### PR DESCRIPTION
# Description

This PR adds `transfers` object to the account history response format to add:
* Fiat value of transaction
* Crypto value of transaction
* Url(s) to token(s) images
* Url(s) to nft image
* NFT name / Collection name

The new response format is:
```
data: [
 {
    "id": "1a5a22ea3cb35fdb9080c09fe7b57ecc",
      "metadata": {
        "operationType": "mint", // Enum: approve, borrow, burn, cancel, claim, deploy, deposit, execute, mint, receive, repay, send, stake, trade, unstake, withdraw
        "hash": "0x70783a3580f2eb63f3c35fdcdc8feffbe591eea1beaaec6eb4592b19bfb73e45",
        "minedAt": "2023-10-29T14:25:29Z",
        "sentFrom": "0x66eeb19f3ef93312541009f855ff4c900adb3450",
        "sentTo": "0xa2a829f1fd922f283282d0d2367f69a13167a9b1",
        "status": "confirmed", // Enum: confirmed, failed, pending
        "nonce": 3126
      }

    // New object
    "transfers": [
       {
         direction: "in", // Enum: in, out, self
         quantity: {
              numeric: "35.1234",
         },
         value: 1350,
         price: 10,
         fungible_info: {
           name: "Bankless BED Index",
           symbol: "BED",
           icon_url: "https://token-icons.s3.amazonaws.com/0x0391d2021f89dc339f60fff84546ea23e337750f.png",
         },
         nft_info: {
           name: "#10 De·genesis",
           content: {
             preview: {
               url: "https://token-icons.s3.amazonaws.com/0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b.png",
               content_type: "image/png",
             },
             detail: {
               url: "https://token-icons.s3.amazonaws.com/0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b.png",
               content_type: "image/png",
             }
           }
         }
       }
    ]
 }
]
```

The `transfers` object contains data from the [zerion wallet transactions](https://developers.zerion.io/reference/listwallettransactions).

Resolves #339 

## How Has This Been Tested?

`account_history_check` functional test in this PR.

## Due Diligence

* [ ] Breaking change
* [x] Requires a documentation update
* [ ] Requires a e2e/integration test update
