### PR TITLE
fix: adding `Option` to the value and price to handle `null` value

### DIFF
--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -74,8 +74,8 @@ pub struct ZerionTransactionTransfer {
     pub nft_info: Option<ZerionTransactionNFTInfo>,
     pub direction: String,
     pub quantity: ZerionTransactionTransferQuantity,
-    pub value: usize,
-    pub price: usize,
+    pub value: Option<usize>,
+    pub price: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]


### PR DESCRIPTION
# Description

Zerion history response sometimes has a `null` as values for the `value` and `price` fields.
In this case, we have deserialization errors like:
```
rpc_proxy::providers::zerion: Error on parsing zerion transactions response: Error("invalid type: null, expected usize", line: 248, column: 37)
```

To handle `null` value for the `usize` type on serde deserialization we should mark it as an `Option`.

Resolves #339 

## How Has This Been Tested?

Dogfooding Zerion response with the `null` value to the `get_transactions` function. 
The expected result is no deserialization error.
Also, it's covered in by the integration test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
