### PR TITLE
fix: changing price and value to f64 type

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -34,14 +34,14 @@ pub struct HistoryQueryParams {
     pub cursor: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct HistoryResponseBody {
     pub data: Vec<HistoryTransaction>,
     pub next: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct HistoryTransaction {
     pub id: String,

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -35,7 +35,7 @@ impl ZerionProvider {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ZerionResponseBody {
     pub links: ZerionResponseLinks,
     pub data: Vec<ZerionTransactionsReponseBody>,
@@ -48,14 +48,14 @@ pub struct ZerionResponseLinks {
     pub next: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ZerionTransactionsReponseBody {
     pub r#type: String,
     pub id: String,
     pub attributes: ZerionTransactionAttributes,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ZerionTransactionAttributes {
     pub operation_type: String,
     pub hash: String,
@@ -68,14 +68,14 @@ pub struct ZerionTransactionAttributes {
     pub transfers: Vec<ZerionTransactionTransfer>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ZerionTransactionTransfer {
     pub fungible_info: Option<ZerionTransactionFungibleInfo>,
     pub nft_info: Option<ZerionTransactionNFTInfo>,
     pub direction: String,
     pub quantity: ZerionTransactionTransferQuantity,
-    pub value: Option<usize>,
-    pub price: Option<usize>,
+    pub value: Option<f64>,
+    pub price: Option<f64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]


### PR DESCRIPTION
# Description

`value` and `price` fields in the `transfer` object in the Zerion response for the history can be **float** type (not just an integer) in some responses (ex. `191.2148374268388`).
This PR converts the type from `usize` to `f64` and removing `Hash` and `Eq` derives from structures that uses `f64`.

Resolves #339

## How Has This Been Tested?

1. Dogfooding Zerion fake response with the `123`, `123.12345`, `null` values to the `get_transactions` function.
    The expected result is no deserialization error.
2. CI build and test workflow.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
