### PR TITLE
feat(analytics): adding analytics for transactions history

### DIFF
--- a/src/analytics/history_lookup_info.rs
+++ b/src/analytics/history_lookup_info.rs
@@ -1,0 +1,58 @@
+use {
+    parquet_derive::ParquetRecordWriter,
+    serde::Serialize,
+    std::{sync::Arc, time::Duration},
+};
+
+#[derive(Debug, Clone, Serialize, ParquetRecordWriter)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryLookupInfo {
+    pub timestamp: chrono::NaiveDateTime,
+
+    pub lookup_address: String,
+    pub project_id: String,
+
+    pub transactions_count: usize,
+    pub latency_secs: f64,
+
+    pub transfers_count: usize,
+    pub fungibles_count: usize,
+    pub nft_count: usize,
+
+    pub origin: Option<String>,
+    pub region: Option<String>,
+    pub country: Option<Arc<str>>,
+    pub continent: Option<Arc<str>>,
+}
+
+impl HistoryLookupInfo {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        lookup_address: String,
+        project_id: String,
+        transactions_count: usize,
+        latency: Duration,
+        transfers_count: usize,
+        fungibles_count: usize,
+        nft_count: usize,
+        origin: Option<String>,
+        region: Option<Vec<String>>,
+        country: Option<Arc<str>>,
+        continent: Option<Arc<str>>,
+    ) -> Self {
+        HistoryLookupInfo {
+            timestamp: wc::analytics::time::now(),
+            lookup_address,
+            project_id,
+            transactions_count,
+            latency_secs: latency.as_secs_f64(),
+            transfers_count,
+            fungibles_count,
+            nft_count,
+            origin,
+            region: region.map(|r| r.join(", ")),
+            country,
+            continent,
+        }
+    }
+}

--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -1,6 +1,11 @@
 use {
     super::HANDLER_TASK_METRICS,
-    crate::{error::RpcError, handlers::HistoryQueryParams, state::AppState},
+    crate::{
+        analytics::HistoryLookupInfo,
+        error::RpcError,
+        handlers::HistoryQueryParams,
+        state::AppState,
+    },
     axum::{
         body::Bytes,
         extract::{ConnectInfo, MatchedPath, Path, Query, State},
@@ -31,20 +36,20 @@ pub async fn handler(
 
 async fn handler_internal(
     state: State<Arc<AppState>>,
-    _connect_info: ConnectInfo<SocketAddr>,
+    connect_info: ConnectInfo<SocketAddr>,
     query: Query<HistoryQueryParams>,
     _path: MatchedPath,
-    _headers: HeaderMap,
+    headers: HeaderMap,
     Path(address): Path<String>,
     body: Bytes,
 ) -> Result<Response, RpcError> {
+    let project_id = query.project_id.clone();
+    let address_hash = address.clone();
     address
         .parse::<Address>()
         .map_err(|_| RpcError::IdentityInvalidAddress)?;
 
-    state.validate_project_access(&query.project_id).await?;
-
-    state.metrics.add_history_lookup();
+    state.validate_project_access(&project_id).await?;
     let latency_tracker_start = std::time::SystemTime::now();
     let response = state
         .providers
@@ -54,6 +59,59 @@ async fn handler_internal(
         .tap_err(|e| {
             error!("Failed to call transaction history with {}", e);
         })?;
+    let latency_tracker = latency_tracker_start
+        .elapsed()
+        .unwrap_or(std::time::Duration::from_secs(0));
+
+    {
+        let origin = headers
+            .get("origin")
+            .map(|v| v.to_str().unwrap_or("invalid_header").to_string());
+
+        let (country, continent, region) = state
+            .analytics
+            .lookup_geo_data(connect_info.0.ip())
+            .map(|geo| (geo.country, geo.continent, geo.region))
+            .unwrap_or((None, None, None));
+
+        state.analytics.history_lookup(HistoryLookupInfo::new(
+            address_hash,
+            project_id,
+            response.data.len(),
+            latency_tracker,
+            response
+                .data
+                .iter()
+                .map(|transaction| transaction.transfers.len())
+                .sum(),
+            response
+                .data
+                .iter()
+                .map(|transaction| {
+                    transaction
+                        .transfers
+                        .iter()
+                        .filter(|transfer| transfer.fungible_info.is_some())
+                        .count()
+                })
+                .sum(),
+            response
+                .data
+                .iter()
+                .map(|transaction| {
+                    transaction
+                        .transfers
+                        .iter()
+                        .filter(|transfer| transfer.nft_info.is_some())
+                        .count()
+                })
+                .sum(),
+            origin,
+            region,
+            country,
+            continent,
+        ));
+    }
 
     let latency_tracker = latency_tracker_start
         .elapsed()


### PR DESCRIPTION
# Description

This PR adds the following analytics for the transaction history:
* timestamp
* lookup address: address for the history
* project_id
* transactions_count: number of `transactions` in a history reply
* latency_secs
* transfers_count: total number of transfer objects
* fungibles_count: total number of fungible objects
* nft_count: total number of nft objects
* origin
* region
* country
* continent

Resolves #361 

## How Has This Been Tested?

Not tested, only successful build test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
* [x] Requires adding to the [data lake](https://github.com/WalletConnect/data-lake)
