### PR TITLE
fix: Pokt rate limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # These must be set or some RPC requests will return errors. See https://github.com/WalletConnect/rpc-proxy/issues/294
-export RPC_PROXY_INFURA_PROJECT_ID=""
-export RPC_PROXY_POKT_PROJECT_ID=""
+export RPC_PROXY_PROVIDER_INFURA_PROJECT_ID=""
+export RPC_PROXY_PROVIDER_POKT_PROJECT_ID=""
 
 # Uncomment if you have access to our Project ID registry and want to validate project IDs
 # export RPC_PROXY_REGISTRY_API_URL="https://registry-prod-cf.walletconnect.com"

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -6,7 +6,7 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{self, client::HttpConnector, Client, Method},
+    hyper::{self, client::HttpConnector, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
 };
@@ -83,8 +83,17 @@ impl RpcProvider for PoktProvider {
             .body(hyper::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
+        let body = hyper::body::to_bytes(response.into_body()).await?;
 
-        Ok(response.into_response())
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if let Some(error) = response.error {
+                if error.code == -32004 {
+                    return Ok((StatusCode::TOO_MANY_REQUESTS, body).into_response());
+                }
+            }
+        }
+
+        Ok(body.into_response())
     }
 }
 

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -83,7 +83,8 @@ impl RpcProvider for PoktProvider {
             .body(hyper::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
-        let body = hyper::body::to_bytes(response.into_body()).await?;
+        let (parts, body) = response.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
             if let Some(error) = response.error {
@@ -93,7 +94,7 @@ impl RpcProvider for PoktProvider {
             }
         }
 
-        Ok(body.into_response())
+        Ok((parts, body).into_response())
     }
 }
 


### PR DESCRIPTION
# Description

Pokt returning rate limit errors. It doesn't return 429 status code so this will parse the response and use that to determine rate limit status. The existing `is_rate_limited()` function doesn't automatically adjust weights, so modifying the response code instead.

Context: https://walletconnect.slack.com/archives/C03SCF66K2T/p1700511418157459

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
