### PR TITLE
fix: log JSON RPC errors with OK status code

### DIFF
--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -6,9 +6,10 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{client::HttpConnector, http, Client, Method},
+    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
+    tracing::info,
 };
 
 #[derive(Debug)]
@@ -55,9 +56,20 @@ impl RpcProvider for BaseProvider {
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;
 
-        let response = self.client.request(hyper_request).await?.into_response();
+        let response = self.client.request(hyper_request).await?;
+        let (parts, body) = response.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
 
-        Ok(response)
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && parts.status == StatusCode::OK {
+                info!(
+                    "Strange: provider returned JSON RPC error, but status was OK: Base: \
+                     {response:?}"
+                );
+            }
+        }
+
+        Ok((parts, body).into_response())
     }
 }
 

--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -6,9 +6,10 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{client::HttpConnector, http, Client, Method},
+    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
+    tracing::info,
 };
 
 #[derive(Debug)]
@@ -55,9 +56,20 @@ impl RpcProvider for BinanceProvider {
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;
 
-        let response = self.client.request(hyper_request).await?.into_response();
+        let response = self.client.request(hyper_request).await?;
+        let (parts, body) = response.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
 
-        Ok(response)
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && parts.status == StatusCode::OK {
+                info!(
+                    "Strange: provider returned JSON RPC error, but status was OK: Binance: \
+                     {response:?}"
+                );
+            }
+        }
+
+        Ok((parts, body).into_response())
     }
 }
 

--- a/src/providers/infura.rs
+++ b/src/providers/infura.rs
@@ -17,9 +17,10 @@ use {
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
     axum_tungstenite::WebSocketUpgrade,
-    hyper::{client::HttpConnector, http, Client, Method},
+    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
+    tracing::info,
     wc::future::FutureExt,
 };
 
@@ -125,9 +126,20 @@ impl RpcProvider for InfuraProvider {
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;
 
-        let response = self.client.request(hyper_request).await?.into_response();
+        let response = self.client.request(hyper_request).await?;
+        let (parts, body) = response.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
 
-        Ok(response)
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && parts.status == StatusCode::OK {
+                info!(
+                    "Strange: provider returned JSON RPC error, but status was OK: Infura: \
+                     {response:?}"
+                );
+            }
+        }
+
+        Ok((parts, body).into_response())
     }
 }
 

--- a/src/providers/omnia.rs
+++ b/src/providers/omnia.rs
@@ -9,6 +9,7 @@ use {
     hyper::{client::HttpConnector, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
+    tracing::info,
 };
 
 #[derive(Debug)]
@@ -57,9 +58,20 @@ impl RpcProvider for OmniatechProvider {
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;
 
-        let response = self.client.request(hyper_request).await?.into_response();
+        let response = self.client.request(hyper_request).await?;
+        let (parts, body) = response.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
 
-        Ok(response)
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && parts.status == StatusCode::OK {
+                info!(
+                    "Strange: provider returned JSON RPC error, but status was OK: Omnia: \
+                     {response:?}"
+                );
+            }
+        }
+
+        Ok((parts, body).into_response())
     }
 }
 

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -9,6 +9,7 @@ use {
     hyper::{self, client::HttpConnector, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
+    tracing::info,
 };
 
 #[derive(Debug)]
@@ -87,7 +88,13 @@ impl RpcProvider for PoktProvider {
         let body = hyper::body::to_bytes(body).await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-            if let Some(error) = response.error {
+            if let Some(error) = &response.error {
+                if parts.status == StatusCode::OK {
+                    info!(
+                        "Strange: provider returned JSON RPC error, but status was OK: Pokt: \
+                         {response:?}"
+                    );
+                }
                 if error.code == -32004 {
                     return Ok((StatusCode::TOO_MANY_REQUESTS, body).into_response());
                 }

--- a/src/providers/publicnode.rs
+++ b/src/providers/publicnode.rs
@@ -6,9 +6,10 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{client::HttpConnector, http, Client, Method},
+    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
+    tracing::info,
 };
 
 #[derive(Debug)]
@@ -54,9 +55,20 @@ impl RpcProvider for PublicnodeProvider {
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;
 
-        let response = self.client.request(hyper_request).await?.into_response();
+        let response = self.client.request(hyper_request).await?;
+        let (parts, body) = response.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
 
-        Ok(response)
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && parts.status == StatusCode::OK {
+                info!(
+                    "Strange: provider returned JSON RPC error, but status was OK: PublicNode: \
+                     {response:?}"
+                );
+            }
+        }
+
+        Ok((parts, body).into_response())
     }
 }
 


### PR DESCRIPTION
# Description

Logs all provider responses that contain a JSON RPC error, but use the OK status code. This is strange, and we may want to consider automatically retrying them in the future, and factoring them into the weighting.

Context: https://walletconnect.slack.com/archives/CB247BW9F/p1700522001797329?thread_ts=1700521059.160949&cid=CB247BW9F

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
