### PR TITLE
chore(tests): adding integration tests for the history

### DIFF
--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -47,4 +47,31 @@ describe('blockchain api', () => {
       expect(resp.data.name).toBe(null)
     })
   })
+  describe('Transactions history', () => {
+    it('fulfilled history', async () => {
+      let resp: any = await http.get(
+        `${baseUrl}/v1/account/0xf3ea39310011333095CFCcCc7c4Ad74034CABA63/history?projectId=${projectId}`,
+      )
+      expect(resp.status).toBe(200)
+      expect(typeof resp.data.data).toBe('object');
+      expect(resp.data.data).toHaveLength(50)
+      expect(typeof resp.data.next).toBe('string');
+      expect(resp.data.next).toHaveLength(80)
+    })
+    it('empty history', async () => {
+      let resp: any = await http.get(
+        `${baseUrl}/v1/account/0x739ff389c8eBd9339E69611d46Eec6212179BB67/history?projectId=${projectId}`,
+      )
+      expect(resp.status).toBe(200)
+      expect(typeof resp.data.data).toBe('object');
+      expect(resp.data.data).toHaveLength(0)
+      expect(resp.data.next).toBeNull();
+    })
+    it('wrong address', async () => {
+      let resp: any = await http.get(
+        `${baseUrl}/v1/account/01739ff389c8eBd9339E69611d46Eec6212179BB67/history?projectId=${projectId}`,
+      )
+      expect(resp.status).toBe(400)
+    })
+  })
 })


### PR DESCRIPTION
# Description

Implementation of the integration test for the history API.
The following checks are made:
- Fulfilled history check,
- Empty history check,
- Wrong address provided check.

Resolves #373

## How Has This Been Tested?

Passing tests by running
```
PROJECT_ID=xxx RPC_URL=https://rpc.walletconnect.com  yarn integration
```

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
