### PR TITLE
fix: double scaling capacity

### DIFF
--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cpu    = var.environment != "dev" ? 1024 : 256
+  cpu    = var.environment != "dev" ? 2048 : 256
   memory = 2 * local.cpu # 2x is minimum for ECS
 
   file_descriptor_soft_limit = pow(2, 18)
@@ -227,7 +227,7 @@ resource "aws_appautoscaling_policy" "cpu_scaling" {
     predefined_metric_specification {
       predefined_metric_type = "ECSServiceAverageCPUUtilization"
     }
-    target_value       = 25
+    target_value       = 50
     scale_in_cooldown  = 180
     scale_out_cooldown = 180
   }
@@ -245,7 +245,7 @@ resource "aws_appautoscaling_policy" "memory_scaling" {
     predefined_metric_specification {
       predefined_metric_type = "ECSServiceAverageMemoryUtilization"
     }
-    target_value       = 25
+    target_value       = 50
     scale_in_cooldown  = 180
     scale_out_cooldown = 180
   }

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -227,7 +227,7 @@ resource "aws_appautoscaling_policy" "cpu_scaling" {
     predefined_metric_specification {
       predefined_metric_type = "ECSServiceAverageCPUUtilization"
     }
-    target_value       = 50
+    target_value       = 25
     scale_in_cooldown  = 180
     scale_out_cooldown = 180
   }
@@ -245,7 +245,7 @@ resource "aws_appautoscaling_policy" "memory_scaling" {
     predefined_metric_specification {
       predefined_metric_type = "ECSServiceAverageMemoryUtilization"
     }
-    target_value       = 50
+    target_value       = 25
     scale_in_cooldown  = 180
     scale_out_cooldown = 180
   }

--- a/terraform/vars/prod.tfvars
+++ b/terraform/vars/prod.tfvars
@@ -1,6 +1,6 @@
 project_data_cache_ttl    = 300
 registry_api_endpoint     = "https://registry.walletconnect.org"
-autoscaling_max_instances = 5
+autoscaling_max_instances = 10
 autoscaling_min_instances = 1
 
 analytics_data_lake_kms_key_arn = "arn:aws:kms:eu-central-1:898587786287:key/06e7c9fd-943d-47bf-bcf4-781b44411ba4"

--- a/terraform/vars/prod.tfvars
+++ b/terraform/vars/prod.tfvars
@@ -1,6 +1,6 @@
 project_data_cache_ttl    = 300
 registry_api_endpoint     = "https://registry.walletconnect.org"
-autoscaling_max_instances = 10
+autoscaling_max_instances = 5
 autoscaling_min_instances = 1
 
 analytics_data_lake_kms_key_arn = "arn:aws:kms:eu-central-1:898587786287:key/06e7c9fd-943d-47bf-bcf4-781b44411ba4"


### PR DESCRIPTION
# Description

Decrease scaling threshold from 50% to 25% to allow more burstiness without maxing out CPU/MEM like it does sometimes.

Also increase max instances from 5 to 10. Looks like past couple of days this only got to 4, but not sure if there is a bug here where 4 is the actual limit and I don't see why this shouldn't be higher anyway to accommodate more scale. We need it to double anyway if the scaling threshold is halved.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
