### PR TITLE
fix: fix Pokt rate limit fix PR & log strange JSON RPC errors

### DIFF
--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -30,18 +30,6 @@ mod server;
 mod zksync;
 mod zora;
 
-pub use {
-    base::*,
-    binance::*,
-    infura::*,
-    omnia::*,
-    pokt::*,
-    publicnode::*,
-    server::*,
-    zksync::*,
-    zora::*,
-};
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ChainId(pub String);
 

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -6,7 +6,7 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::info,
@@ -57,19 +57,19 @@ impl RpcProvider for BaseProvider {
             .body(hyper::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
-        let (parts, body) = response.into_parts();
-        let body = hyper::body::to_bytes(body).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-            if response.error.is_some() && parts.status == StatusCode::OK {
+            if response.error.is_some() && status.is_success() {
                 info!(
-                    "Strange: provider returned JSON RPC error, but status was OK: Base: \
-                     {response:?}"
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                     Base: {response:?}"
                 );
             }
         }
 
-        Ok((parts, body).into_response())
+        Ok((status, body).into_response())
     }
 }
 

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -6,9 +6,10 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{client::HttpConnector, http, Client, Method},
+    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
+    tracing::info,
 };
 
 #[derive(Debug)]
@@ -55,9 +56,20 @@ impl RpcProvider for BaseProvider {
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;
 
-        let response = self.client.request(hyper_request).await?.into_response();
+        let response = self.client.request(hyper_request).await?;
+        let (parts, body) = response.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
 
-        Ok(response)
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && parts.status == StatusCode::OK {
+                info!(
+                    "Strange: provider returned JSON RPC error, but status was OK: Base: \
+                     {response:?}"
+                );
+            }
+        }
+
+        Ok((parts, body).into_response())
     }
 }
 

--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -6,9 +6,10 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{client::HttpConnector, http, Client, Method},
+    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
+    tracing::info,
 };
 
 #[derive(Debug)]
@@ -55,9 +56,20 @@ impl RpcProvider for BinanceProvider {
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;
 
-        let response = self.client.request(hyper_request).await?.into_response();
+        let response = self.client.request(hyper_request).await?;
+        let (parts, body) = response.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
 
-        Ok(response)
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && parts.status == StatusCode::OK {
+                info!(
+                    "Strange: provider returned JSON RPC error, but status was OK: Binance: \
+                     {response:?}"
+                );
+            }
+        }
+
+        Ok((parts, body).into_response())
     }
 }
 

--- a/src/providers/infura.rs
+++ b/src/providers/infura.rs
@@ -17,7 +17,7 @@ use {
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
     axum_tungstenite::WebSocketUpgrade,
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::info,
@@ -127,19 +127,19 @@ impl RpcProvider for InfuraProvider {
             .body(hyper::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
-        let (parts, body) = response.into_parts();
-        let body = hyper::body::to_bytes(body).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-            if response.error.is_some() && parts.status == StatusCode::OK {
+            if response.error.is_some() && status.is_success() {
                 info!(
-                    "Strange: provider returned JSON RPC error, but status was OK: Infura: \
-                     {response:?}"
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                     Infura: {response:?}"
                 );
             }
         }
 
-        Ok((parts, body).into_response())
+        Ok((status, body).into_response())
     }
 }
 

--- a/src/providers/infura.rs
+++ b/src/providers/infura.rs
@@ -17,9 +17,10 @@ use {
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
     axum_tungstenite::WebSocketUpgrade,
-    hyper::{client::HttpConnector, http, Client, Method},
+    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
+    tracing::info,
     wc::future::FutureExt,
 };
 
@@ -125,9 +126,20 @@ impl RpcProvider for InfuraProvider {
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;
 
-        let response = self.client.request(hyper_request).await?.into_response();
+        let response = self.client.request(hyper_request).await?;
+        let (parts, body) = response.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
 
-        Ok(response)
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && parts.status == StatusCode::OK {
+                info!(
+                    "Strange: provider returned JSON RPC error, but status was OK: Infura: \
+                     {response:?}"
+                );
+            }
+        }
+
+        Ok((parts, body).into_response())
     }
 }
 

--- a/src/providers/omnia.rs
+++ b/src/providers/omnia.rs
@@ -9,6 +9,7 @@ use {
     hyper::{client::HttpConnector, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
+    tracing::info,
 };
 
 #[derive(Debug)]
@@ -57,9 +58,20 @@ impl RpcProvider for OmniatechProvider {
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;
 
-        let response = self.client.request(hyper_request).await?.into_response();
+        let response = self.client.request(hyper_request).await?;
+        let (parts, body) = response.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
 
-        Ok(response)
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && parts.status == StatusCode::OK {
+                info!(
+                    "Strange: provider returned JSON RPC error, but status was OK: Omnia: \
+                     {response:?}"
+                );
+            }
+        }
+
+        Ok((parts, body).into_response())
     }
 }
 

--- a/src/providers/omnia.rs
+++ b/src/providers/omnia.rs
@@ -59,19 +59,19 @@ impl RpcProvider for OmniatechProvider {
             .body(hyper::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
-        let (parts, body) = response.into_parts();
-        let body = hyper::body::to_bytes(body).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-            if response.error.is_some() && parts.status == StatusCode::OK {
+            if response.error.is_some() && status.is_success() {
                 info!(
-                    "Strange: provider returned JSON RPC error, but status was OK: Omnia: \
-                     {response:?}"
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                     Omnia: {response:?}"
                 );
             }
         }
 
-        Ok((parts, body).into_response())
+        Ok((status, body).into_response())
     }
 }
 

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -9,6 +9,7 @@ use {
     hyper::{self, client::HttpConnector, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
+    tracing::info,
 };
 
 #[derive(Debug)]
@@ -87,7 +88,13 @@ impl RpcProvider for PoktProvider {
         let body = hyper::body::to_bytes(body).await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-            if let Some(error) = response.error {
+            if let Some(error) = &response.error {
+                if parts.status == StatusCode::OK {
+                    info!(
+                        "Strange: provider returned JSON RPC error, but status was OK: Pokt: \
+                         {response:?}"
+                    );
+                }
                 if error.code == -32004 {
                     return Ok((StatusCode::TOO_MANY_REQUESTS, body).into_response());
                 }

--- a/src/providers/publicnode.rs
+++ b/src/providers/publicnode.rs
@@ -6,7 +6,7 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::info,
@@ -56,19 +56,19 @@ impl RpcProvider for PublicnodeProvider {
             .body(hyper::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
-        let (parts, body) = response.into_parts();
-        let body = hyper::body::to_bytes(body).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-            if response.error.is_some() && parts.status == StatusCode::OK {
+            if response.error.is_some() && status.is_success() {
                 info!(
-                    "Strange: provider returned JSON RPC error, but status was OK: PublicNode: \
-                     {response:?}"
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                     PublicNode: {response:?}"
                 );
             }
         }
 
-        Ok((parts, body).into_response())
+        Ok((status, body).into_response())
     }
 }
 

--- a/src/providers/publicnode.rs
+++ b/src/providers/publicnode.rs
@@ -6,9 +6,10 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{client::HttpConnector, http, Client, Method},
+    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
+    tracing::info,
 };
 
 #[derive(Debug)]
@@ -54,9 +55,20 @@ impl RpcProvider for PublicnodeProvider {
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;
 
-        let response = self.client.request(hyper_request).await?.into_response();
+        let response = self.client.request(hyper_request).await?;
+        let (parts, body) = response.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
 
-        Ok(response)
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && parts.status == StatusCode::OK {
+                info!(
+                    "Strange: provider returned JSON RPC error, but status was OK: PublicNode: \
+                     {response:?}"
+                );
+            }
+        }
+
+        Ok((parts, body).into_response())
     }
 }
 

--- a/src/providers/zksync.rs
+++ b/src/providers/zksync.rs
@@ -6,7 +6,7 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::info,
@@ -54,19 +54,19 @@ impl RpcProvider for ZKSyncProvider {
             .body(hyper::body::Body::from(body))?;
 
         let response = self.client.request(hyper_request).await?;
-        let (parts, body) = response.into_parts();
-        let body = hyper::body::to_bytes(body).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-            if response.error.is_some() && parts.status == StatusCode::OK {
+            if response.error.is_some() && status.is_success() {
                 info!(
-                    "Strange: provider returned JSON RPC error, but status was OK: zkSync: \
-                     {response:?}"
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                     zkSync: {response:?}"
                 );
             }
         }
 
-        Ok((parts, body).into_response())
+        Ok((status, body).into_response())
     }
 }
 


### PR DESCRIPTION
# Description

Fixes the Pokt PR https://github.com/WalletConnect/blockchain-api/pull/369/files#diff-aceb22d366624f307c6cbe4a2ffcc3efe0b342432b722d97257176b80789dccfR97 and re-adds strange error logging previously added in https://github.com/WalletConnect/blockchain-api/pull/370.

Fix is to not return all `parts` because Hyper will add a second content-length header, which will then be duplicated.

Context: https://walletconnect.slack.com/archives/C03SCF66K2T/p1700659169053979?thread_ts=1700647203.176389&cid=C03SCF66K2T

## How Has This Been Tested?

Automated tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
