### PR TITLE
fix: missing Content-Type: application/json

### DIFF
--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -5,7 +5,10 @@ use {
         error::{RpcError, RpcResult},
     },
     async_trait::async_trait,
-    axum::response::{IntoResponse, Response},
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
     hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
@@ -69,7 +72,11 @@ impl RpcProvider for BaseProvider {
             }
         }
 
-        Ok((status, body).into_response())
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
     }
 }
 

--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -5,7 +5,10 @@ use {
         error::{RpcError, RpcResult},
     },
     async_trait::async_trait,
-    axum::response::{IntoResponse, Response},
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
     hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
@@ -69,7 +72,11 @@ impl RpcProvider for BinanceProvider {
             }
         }
 
-        Ok((status, body).into_response())
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
     }
 }
 

--- a/src/providers/infura.rs
+++ b/src/providers/infura.rs
@@ -15,7 +15,10 @@ use {
         ws,
     },
     async_trait::async_trait,
-    axum::response::{IntoResponse, Response},
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
     axum_tungstenite::WebSocketUpgrade,
     hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
@@ -139,7 +142,11 @@ impl RpcProvider for InfuraProvider {
             }
         }
 
-        Ok((status, body).into_response())
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
     }
 }
 

--- a/src/providers/omnia.rs
+++ b/src/providers/omnia.rs
@@ -5,7 +5,10 @@ use {
         error::{RpcError, RpcResult},
     },
     async_trait::async_trait,
-    axum::response::{IntoResponse, Response},
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
     hyper::{client::HttpConnector, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
@@ -71,7 +74,11 @@ impl RpcProvider for OmniatechProvider {
             }
         }
 
-        Ok((status, body).into_response())
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
     }
 }
 

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -5,7 +5,10 @@ use {
         error::{RpcError, RpcResult},
     },
     async_trait::async_trait,
-    axum::response::{IntoResponse, Response},
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
     hyper::{self, client::HttpConnector, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
@@ -101,7 +104,11 @@ impl RpcProvider for PoktProvider {
             }
         }
 
-        Ok((status, body).into_response())
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
     }
 }
 

--- a/src/providers/publicnode.rs
+++ b/src/providers/publicnode.rs
@@ -5,7 +5,10 @@ use {
         error::{RpcError, RpcResult},
     },
     async_trait::async_trait,
-    axum::response::{IntoResponse, Response},
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
     hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
@@ -68,7 +71,11 @@ impl RpcProvider for PublicnodeProvider {
             }
         }
 
-        Ok((status, body).into_response())
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
     }
 }
 

--- a/src/providers/zksync.rs
+++ b/src/providers/zksync.rs
@@ -5,7 +5,10 @@ use {
         error::{RpcError, RpcResult},
     },
     async_trait::async_trait,
-    axum::response::{IntoResponse, Response},
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
     hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
@@ -66,7 +69,11 @@ impl RpcProvider for ZKSyncProvider {
             }
         }
 
-        Ok((status, body).into_response())
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
     }
 }
 

--- a/src/providers/zora.rs
+++ b/src/providers/zora.rs
@@ -15,7 +15,10 @@ use {
         ws,
     },
     async_trait::async_trait,
-    axum::response::{IntoResponse, Response},
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
     axum_tungstenite::WebSocketUpgrade,
     hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
@@ -133,7 +136,11 @@ impl RpcProvider for ZoraProvider {
             }
         }
 
-        Ok((status, body).into_response())
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
     }
 }
 


### PR DESCRIPTION
# Description

Before we returned the raw response from the provider, but now we re-construct the response. But didn't add `Content-Type: application/json` header.

Context: https://walletconnect.slack.com/archives/C03SCF66K2T/p1700666765949029?thread_ts=1700647203.176389&cid=C03SCF66K2T

## How Has This Been Tested?

Not

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
