### PR TITLE
chore: adding the span with request-id for handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs#546ea029362a7502365667c6f99fac92ad0aeb9f"
+source = "git+https://github.com/gakonst/ethers-rs#8175f0f97070ad69abd5dfa7b8df31f1c1dcc3d6"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1540,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs#546ea029362a7502365667c6f99fac92ad0aeb9f"
+source = "git+https://github.com/gakonst/ethers-rs#8175f0f97070ad69abd5dfa7b8df31f1c1dcc3d6"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs#546ea029362a7502365667c6f99fac92ad0aeb9f"
+source = "git+https://github.com/gakonst/ethers-rs#8175f0f97070ad69abd5dfa7b8df31f1c1dcc3d6"
 dependencies = [
  "const-hex",
  "ethers-contract-abigen",
@@ -1569,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs#546ea029362a7502365667c6f99fac92ad0aeb9f"
+source = "git+https://github.com/gakonst/ethers-rs#8175f0f97070ad69abd5dfa7b8df31f1c1dcc3d6"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1592,7 +1592,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs#546ea029362a7502365667c6f99fac92ad0aeb9f"
+source = "git+https://github.com/gakonst/ethers-rs#8175f0f97070ad69abd5dfa7b8df31f1c1dcc3d6"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1607,7 +1607,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs#546ea029362a7502365667c6f99fac92ad0aeb9f"
+source = "git+https://github.com/gakonst/ethers-rs#8175f0f97070ad69abd5dfa7b8df31f1c1dcc3d6"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1636,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs#546ea029362a7502365667c6f99fac92ad0aeb9f"
+source = "git+https://github.com/gakonst/ethers-rs#8175f0f97070ad69abd5dfa7b8df31f1c1dcc3d6"
 dependencies = [
  "chrono",
  "ethers-core",
@@ -1651,7 +1651,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs#546ea029362a7502365667c6f99fac92ad0aeb9f"
+source = "git+https://github.com/gakonst/ethers-rs#8175f0f97070ad69abd5dfa7b8df31f1c1dcc3d6"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1677,7 +1677,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs#546ea029362a7502365667c6f99fac92ad0aeb9f"
+source = "git+https://github.com/gakonst/ethers-rs#8175f0f97070ad69abd5dfa7b8df31f1c1dcc3d6"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1713,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs#546ea029362a7502365667c6f99fac92ad0aeb9f"
+source = "git+https://github.com/gakonst/ethers-rs#8175f0f97070ad69abd5dfa7b8df31f1c1dcc3d6"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1731,7 +1731,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs#546ea029362a7502365667c6f99fac92ad0aeb9f"
+source = "git+https://github.com/gakonst/ethers-rs#8175f0f97070ad69abd5dfa7b8df31f1c1dcc3d6"
 dependencies = [
  "cfg-if",
  "const-hex",
@@ -4811,9 +4811,11 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -5073,6 +5075,9 @@ name = "uuid"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hyper-tls = "0.5.0"
 tap = "1.0"
 axum = { version = "0.6", features = ["json", "tokio", "ws"] }
 tower = "0.4.11"
-tower-http = { version = "0.4.0", features = ["cors", "trace"] }
+tower-http = { version = "0.4.0", features = ["cors", "trace", "request-id", "util"] }
 jsonrpc = "0.14.0"
 async-tungstenite = { version = "0.20.0", features = ["tokio", "tokio-runtime", "tokio-native-tls"] }
 url = "2.2"

--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -31,6 +31,16 @@ describe('blockchain api', () => {
       expect(status).toBe(200)
     })
   })
+  describe('Middlewares', () => {
+    it('headers should contain x-request-id', async () => {
+      let resp: any = await http.get(
+        `${baseUrl}/v1/account/0xf3ea39310011333095CFCcCc7c4Ad74034CABA63/history?projectId=${projectId}`,
+      )
+      expect(resp.status).toBe(200)
+      expect(resp.header['x-request-id']).toBe('string');
+      expect(resp.header['x-request-id']).toHaveLength(36); // UUIDv4
+    })
+  })
   describe('Identity', () => {
     it('known ens', async () => {
       let resp: any = await http.get(

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -14,7 +14,7 @@ pub mod ws_proxy;
 
 static HANDLER_TASK_METRICS: TaskMetrics = TaskMetrics::new("handler_task");
 
-#[derive(Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcQueryParams {
     pub chain_id: String,
@@ -26,7 +26,7 @@ pub struct SuccessResponse {
     status: String,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PortfolioQueryParams {
     pub project_id: String,
@@ -48,7 +48,7 @@ pub struct PortfolioPosition {
 }
 
 // TODO: https://developers.zerion.io/reference/listwallettransactions
-#[derive(Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct HistoryQueryParams {
     pub currency: Option<String>,


### PR DESCRIPTION
# Description

This PR adds a request tracing mechanism based on the `x-request-id` header and [tower **request_id** middleware](https://docs.rs/tower-http/latest/tower_http/request_id/index.html).
* If the `x-request-id` is not provided in the request headers it's generated as an UUIDv4,
* The generated/provided `x-request-id` is added to the tracing info span,
* The `x-request-id` is exposed to the response headers set, so it can be get and traced after the request.

🚧 Additional tracing logs are stacked on top of this PR as #391 

Resolves #372

## How Has This Been Tested?

**Integration test**
An [integration test](https://github.com/WalletConnect/blockchain-api/pull/387/commits/13cb54a76c9e908247b824d087c54deefdb992c8) is added in this PR and passed locally.

**Testing manually**
Start the service locally and run the curl command to get the identity, for example:
```
curl -v 'http://localhost:3000/v1/identity/0x621d24169aecf1da1ee8dce6aa2258f277434334?chainId=eip155:1&projectId=xxx'
```
The response will contain the `x-request-id` in the headers:
```
GET /v1/identity/0x621d24169aecf1da1ee8dce6aa2258f277434334?chainId=eip155:1&projectId=002243e654eae5271202b831393246d3 HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/1.1 200 OK
< content-type: application/json
< content-length: 115
< x-request-id: addd1f08-6b76-4c93-a2d3-3ba2b0897ea1    <----
< access-control-allow-origin: *
< vary: origin
< vary: access-control-request-method
< vary: access-control-request-headers
< date: Thu, 23 Nov 2023 17:44:26 GMT
```
The log will contain tracing spans with the same `request_id` value from the response:
```
INFO http-request{method=GET request_id="addd1f08-6b76-4c93-a2d3-3ba2b0897ea1" uri=/v1/identity/0x621d24169aecf1da1ee8dce6aa2258f277434334?chainId=eip155:1&projectId=xxx}:handler_internal:lookup_identity{address=0x621d…4334}: rpc_proxy::handlers::identity: close time.busy=141µs time.idle=13.0µs

INFO http-request{method=GET request_id="addd1f08-6b76-4c93-a2d3-3ba2b0897ea1" uri=/v1/identity/0x621d24169aecf1da1ee8dce6aa2258f277434334?chainId=eip155:1&projectId=xxx}:handler_internal: rpc_proxy::handlers::identity: close time.busy=563µs time.idle=12.9µs
```

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
