### PR TITLE
feat: annotate HTTP5XX

### DIFF
--- a/src/providers/infura.rs
+++ b/src/providers/infura.rs
@@ -138,7 +138,7 @@ impl RpcProvider for InfuraProvider {
                 if status.is_success() {
                     info!(
                         "Strange: provider returned JSON RPC error, but status {status} is \
-                         success: Pokt: {response:?}"
+                         success: Infura: {response:?}"
                     );
                 }
                 if error.code == -32603 {

--- a/src/providers/infura.rs
+++ b/src/providers/infura.rs
@@ -20,7 +20,7 @@ use {
         response::{IntoResponse, Response},
     },
     axum_tungstenite::WebSocketUpgrade,
-    hyper::{client::HttpConnector, http, Client, Method},
+    hyper::{client::HttpConnector, http, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     tracing::info,
@@ -134,11 +134,16 @@ impl RpcProvider for InfuraProvider {
         let body = hyper::body::to_bytes(response.into_body()).await?;
 
         if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
-            if response.error.is_some() && status.is_success() {
-                info!(
-                    "Strange: provider returned JSON RPC error, but status {status} is success: \
-                     Infura: {response:?}"
-                );
+            if let Some(error) = &response.error {
+                if status.is_success() {
+                    info!(
+                        "Strange: provider returned JSON RPC error, but status {status} is \
+                         success: Pokt: {response:?}"
+                    );
+                }
+                if error.code == -32603 {
+                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
+                }
             }
         }
 

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -101,6 +101,9 @@ impl RpcProvider for PoktProvider {
                 if error.code == -32004 {
                     return Ok((StatusCode::TOO_MANY_REQUESTS, body).into_response());
                 }
+                if error.code == -32603 {
+                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
+                }
             }
         }
 


### PR DESCRIPTION
# Description

Annotates [`Internal Error`](https://docs.infura.io/networks/ethereum/json-rpc-methods) RPC code as such and translates to HTTP5XX for our failover algorithm to take it into account.

## How Has This Been Tested?

Not tested but confirmed that these are legit internal errors.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
