### PR TITLE
chore: adding tracing instrument spans to handlers and providers

### DIFF
--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -34,6 +34,7 @@ pub async fn handler(
         .await
 }
 
+#[tracing::instrument(skip_all)]
 async fn handler_internal(
     state: State<Arc<AppState>>,
     connect_info: ConnectInfo<SocketAddr>,

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -255,7 +255,7 @@ async fn lookup_identity_rpc(
 
 const SELF_PROVIDER_ERROR_PREFIX: &str = "SelfProviderError: ";
 
-#[tracing::instrument]
+#[tracing::instrument(skip_all)]
 async fn lookup_name(
     provider: &Provider<SelfProvider>,
     address: Address,
@@ -279,7 +279,7 @@ async fn lookup_name(
     )
 }
 
-#[tracing::instrument]
+#[tracing::instrument(skip_all)]
 async fn lookup_avatar(
     provider: &Provider<SelfProvider>,
     name: &str,

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -52,6 +52,7 @@ pub async fn handler(
         .await
 }
 
+#[tracing::instrument(skip_all)]
 async fn handler_internal(
     state: State<Arc<AppState>>,
     connect_info: ConnectInfo<SocketAddr>,
@@ -134,6 +135,7 @@ impl IdentityLookupSource {
     }
 }
 
+#[tracing::instrument(skip_all)]
 async fn lookup_identity(
     address: H160,
     state: State<Arc<AppState>>,
@@ -199,6 +201,7 @@ async fn lookup_identity(
     Ok((IdentityLookupSource::Rpc, res))
 }
 
+#[tracing::instrument(skip_all)]
 async fn lookup_identity_rpc(
     address: H160,
     state: State<Arc<AppState>>,
@@ -252,6 +255,7 @@ async fn lookup_identity_rpc(
 
 const SELF_PROVIDER_ERROR_PREFIX: &str = "SelfProviderError: ";
 
+#[tracing::instrument]
 async fn lookup_name(
     provider: &Provider<SelfProvider>,
     address: Address,
@@ -275,6 +279,7 @@ async fn lookup_name(
     )
 }
 
+#[tracing::instrument]
 async fn lookup_avatar(
     provider: &Provider<SelfProvider>,
     name: &str,

--- a/src/handlers/portfolio.rs
+++ b/src/handlers/portfolio.rs
@@ -29,6 +29,7 @@ pub async fn handler(
         .await
 }
 
+#[tracing::instrument(skip_all)]
 async fn handler_internal(
     state: State<Arc<AppState>>,
     _connect_info: ConnectInfo<SocketAddr>,

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -31,6 +31,7 @@ pub async fn handler(
         .await
 }
 
+#[tracing::instrument(skip_all)]
 async fn handler_internal(
     State(state): State<Arc<AppState>>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,

--- a/src/handlers/ws_proxy.rs
+++ b/src/handlers/ws_proxy.rs
@@ -20,6 +20,7 @@ pub async fn handler(
         .await
 }
 
+#[tracing::instrument(skip_all)]
 async fn handler_internal(
     State(state): State<Arc<AppState>>,
     Query(query_params): Query<RpcQueryParams>,

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -47,6 +47,7 @@ impl RateLimited for BaseProvider {
 
 #[async_trait]
 impl RpcProvider for BaseProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()))]
     async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
@@ -81,6 +82,7 @@ impl RpcProvider for BaseProvider {
 }
 
 impl RpcProviderFactory<BaseConfig> for BaseProvider {
+    #[tracing::instrument]
     fn new(provider_config: &BaseConfig) -> Self {
         let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
         let supported_chains: HashMap<String, String> = provider_config

--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -47,6 +47,7 @@ impl RateLimited for BinanceProvider {
 
 #[async_trait]
 impl RpcProvider for BinanceProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()))]
     async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
@@ -81,6 +82,7 @@ impl RpcProvider for BinanceProvider {
 }
 
 impl RpcProviderFactory<BinanceConfig> for BinanceProvider {
+    #[tracing::instrument]
     fn new(provider_config: &BinanceConfig) -> Self {
         let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
         let supported_chains: HashMap<String, String> = provider_config

--- a/src/providers/infura.rs
+++ b/src/providers/infura.rs
@@ -66,6 +66,7 @@ impl RateLimited for InfuraWsProvider {
 
 #[async_trait]
 impl RpcWsProvider for InfuraWsProvider {
+    #[tracing::instrument(skip_all, fields(provider = %self.provider_kind()))]
     async fn proxy(
         &self,
         ws: WebSocketUpgrade,
@@ -115,6 +116,7 @@ impl RateLimited for InfuraProvider {
 
 #[async_trait]
 impl RpcProvider for InfuraProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()))]
     async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let chain = &self
             .supported_chains
@@ -156,6 +158,7 @@ impl RpcProvider for InfuraProvider {
 }
 
 impl RpcProviderFactory<InfuraConfig> for InfuraProvider {
+    #[tracing::instrument]
     fn new(provider_config: &InfuraConfig) -> Self {
         let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
         let supported_chains: HashMap<String, String> = provider_config
@@ -173,6 +176,7 @@ impl RpcProviderFactory<InfuraConfig> for InfuraProvider {
 }
 
 impl RpcProviderFactory<InfuraConfig> for InfuraWsProvider {
+    #[tracing::instrument]
     fn new(provider_config: &InfuraConfig) -> Self {
         let supported_chains: HashMap<String, String> = provider_config
             .supported_ws_chains

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -114,6 +114,7 @@ impl ProviderRepository {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_provider_for_chain_id(&self, chain_id: &str) -> Option<Arc<dyn RpcProvider>> {
         let Some(providers) = self.weight_resolver.get(chain_id) else {
             return None;
@@ -139,6 +140,7 @@ impl ProviderRepository {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_ws_provider_for_chain_id(&self, chain_id: &str) -> Option<Arc<dyn RpcWsProvider>> {
         let Some(providers) = self.ws_weight_resolver.get(chain_id) else {
             return None;
@@ -214,6 +216,7 @@ impl ProviderRepository {
         info!("Added provider: {}", provider_kind);
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn update_weights(&self, metrics: &crate::Metrics) {
         info!("Updating weights");
 

--- a/src/providers/omnia.rs
+++ b/src/providers/omnia.rs
@@ -47,6 +47,7 @@ impl RateLimited for OmniatechProvider {
 
 #[async_trait]
 impl RpcProvider for OmniatechProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()))]
     async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let chain = self
             .supported_chains
@@ -83,6 +84,7 @@ impl RpcProvider for OmniatechProvider {
 }
 
 impl RpcProviderFactory<OmniatechConfig> for OmniatechProvider {
+    #[tracing::instrument]
     fn new(provider_config: &OmniatechConfig) -> Self {
         let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
         let supported_chains: HashMap<String, String> = provider_config

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -69,6 +69,7 @@ impl RateLimited for PoktProvider {
 
 #[async_trait]
 impl RpcProvider for PoktProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()))]
     async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let chain = &self
             .supported_chains
@@ -116,6 +117,7 @@ impl RpcProvider for PoktProvider {
 }
 
 impl RpcProviderFactory<PoktConfig> for PoktProvider {
+    #[tracing::instrument]
     fn new(provider_config: &PoktConfig) -> Self {
         let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
         let supported_chains: HashMap<String, String> = provider_config

--- a/src/providers/publicnode.rs
+++ b/src/providers/publicnode.rs
@@ -44,6 +44,7 @@ impl RateLimited for PublicnodeProvider {
 
 #[async_trait]
 impl RpcProvider for PublicnodeProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()))]
     async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let chain = &self
             .supported_chains
@@ -80,6 +81,7 @@ impl RpcProvider for PublicnodeProvider {
 }
 
 impl RpcProviderFactory<PublicnodeConfig> for PublicnodeProvider {
+    #[tracing::instrument]
     fn new(provider_config: &PublicnodeConfig) -> Self {
         let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
         let supported_chains: HashMap<String, String> = provider_config

--- a/src/providers/weights.rs
+++ b/src/providers/weights.rs
@@ -14,6 +14,7 @@ pub struct Availability(u64, u64);
 
 pub type ParsedWeights = HashMap<String, (HashMap<ChainId, Availability>, Availability)>;
 
+#[tracing::instrument(skip_all)]
 pub fn parse_weights(prometheus_data: PromqlResult) -> ParsedWeights {
     let mut weights_data = HashMap::new();
     // fill weights with pair of ProviderKind -> HashMap<ChainId, Availability>
@@ -60,6 +61,7 @@ pub fn parse_weights(prometheus_data: PromqlResult) -> ParsedWeights {
 
 const PERFECT_RATIO: f64 = 1.0;
 
+#[tracing::instrument]
 fn calculate_chain_weight(
     provider_availability: Availability,
     chain_availability: Availability,
@@ -111,6 +113,7 @@ fn calculate_chain_weight(
     weight as u64
 }
 
+#[tracing::instrument(skip_all)]
 pub fn update_values(weight_resolver: &WeightResolver, parsed_weights: ParsedWeights) {
     for (provider, (chain_availabilities, provider_availability)) in parsed_weights {
         for (chain_id, chain_availability) in chain_availabilities {

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -148,6 +148,7 @@ pub struct ZerionTransactionNFTInfoFlags {
 
 #[async_trait]
 impl HistoryProvider for ZerionProvider {
+    #[tracing::instrument(skip(self, body, params), fields(provider = "Zerion"))]
     async fn get_transactions(
         &self,
         address: String,
@@ -237,6 +238,7 @@ impl HistoryProvider for ZerionProvider {
 
 #[async_trait]
 impl PortfolioProvider for ZerionProvider {
+    #[tracing::instrument(skip(self, body, params), fields(provider = "Zerion"))]
     async fn get_portfolio(
         &self,
         address: String,

--- a/src/providers/zksync.rs
+++ b/src/providers/zksync.rs
@@ -44,6 +44,7 @@ impl RateLimited for ZKSyncProvider {
 
 #[async_trait]
 impl RpcProvider for ZKSyncProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()))]
     async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
@@ -78,6 +79,7 @@ impl RpcProvider for ZKSyncProvider {
 }
 
 impl RpcProviderFactory<ZKSyncConfig> for ZKSyncProvider {
+    #[tracing::instrument]
     fn new(provider_config: &ZKSyncConfig) -> Self {
         let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
         let supported_chains: HashMap<String, String> = provider_config

--- a/src/providers/zora.rs
+++ b/src/providers/zora.rs
@@ -64,6 +64,7 @@ impl RateLimited for ZoraWsProvider {
 
 #[async_trait]
 impl RpcWsProvider for ZoraWsProvider {
+    #[tracing::instrument(skip_all, fields(provider = %self.provider_kind()))]
     async fn proxy(
         &self,
         ws: WebSocketUpgrade,
@@ -111,6 +112,7 @@ impl RateLimited for ZoraProvider {
 
 #[async_trait]
 impl RpcProvider for ZoraProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()))]
     async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
@@ -145,6 +147,7 @@ impl RpcProvider for ZoraProvider {
 }
 
 impl RpcProviderFactory<ZoraConfig> for ZoraProvider {
+    #[tracing::instrument]
     fn new(provider_config: &ZoraConfig) -> Self {
         let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
         let supported_chains: HashMap<String, String> = provider_config
@@ -161,6 +164,7 @@ impl RpcProviderFactory<ZoraConfig> for ZoraProvider {
 }
 
 impl RpcProviderFactory<ZoraConfig> for ZoraWsProvider {
+    #[tracing::instrument]
     fn new(provider_config: &ZoraConfig) -> Self {
         let supported_chains: HashMap<String, String> = provider_config
             .supported_ws_chains

--- a/src/state.rs
+++ b/src/state.rs
@@ -57,6 +57,7 @@ impl AppState {
         self.providers.update_weights(&self.metrics).await;
     }
 
+    #[tracing::instrument(skip(self))]
     async fn get_project_data_validated(&self, id: &str) -> Result<ProjectData, RpcError> {
         let project = self
             .registry
@@ -76,6 +77,7 @@ impl AppState {
         self.get_project_data_validated(id).await.map(drop)
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn validate_project_access_and_quota(&self, id: &str) -> Result<(), RpcError> {
         let project = self.get_project_data_validated(id).await?;
 

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -4,6 +4,7 @@ use {
     tracing::log::info,
 };
 
+#[tracing::instrument(skip(client_ws, provider_ws))]
 pub async fn proxy(
     project_id: String,
     client_ws: axum_tungstenite::WebSocket,


### PR DESCRIPTION
# Description

This PR adds additional tracing `instruments` to handlers and providers for the additional span logs in case of errors and for proper debugging.

Resolves #372 

🚧 Stacked on top of the #387 

## How Has This Been Tested?

Logs are exposed with proper tracing instrument spans.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
