### PR TITLE
chore(providers): removing zora goerli websocket api

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -44,4 +44,3 @@ WebSocket RPC is not recommended for production use, and may be removed in the f
 - Aurora (`eip155:1313161554`)
 - Aurora Testnet (`eip155:1313161555`)
 - Zora (`eip155:7777777`)
-- Zora Goerli (`eip155:999`)

--- a/src/env/zora.rs
+++ b/src/env/zora.rs
@@ -68,13 +68,5 @@ fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
-        // Zora Goerli
-        (
-            "eip155:999".into(),
-            (
-                "wss://testnet.rpc.zora.energy".into(),
-                Weight::new(Priority::Normal).unwrap(),
-            ),
-        ),
     ])
 }

--- a/tests/functional/websocket/zora.rs
+++ b/tests/functional/websocket/zora.rs
@@ -10,7 +10,4 @@ async fn zora_websocket_provider(ctx: &mut ServerContext) {
     // Zora mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:7777777", "0x76adf1")
         .await;
-
-    // Zora Goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:999", "0x3e7").await;
 }


### PR DESCRIPTION
# Description

Removing Zora Goerli eip155:999 websocket API from providers.
The reason: WebSocket API constantly returns empty responses for any requests.

Resolves #367 

## How Has This Been Tested?

Sending the request to the Zora websocket rpc using `wscat` CLI command:
```
 wscat -c wss://rpc.zora.energy -x '{"id":"1","jsonrpc":"2.0","method":"eth_chainId","params":[]}'
```
response:
```
{"jsonrpc":"2.0","result":"0x76adf1","id":"1"}
```

Sending the request to the [Zora Goerly websocket rpc](https://github.com/WalletConnect/blockchain-api/blob/master/src/env/zora.rs#L75) using `wscat`:
```
wscat -c wss://testnet.rpc.zora.energy -x '{"id":"1","jsonrpc":"2.0","method":"eth_chainId","params":[]}'
```
response:
```
empty response
```

It seems that this RPC is not working so it should be removed until resolution.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
