### PR TITLE
feat(health): exposing commit hash, features, uptime to the health

### DIFF
--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -26,9 +26,13 @@ describe('blockchain api', () => {
   })
   describe('Health', () => {
     it('is healthy', async () => {
-      const { status } = await http.get(`${baseUrl}/health`)
+      const resp: any = await http.get(`${baseUrl}/health`)
 
-      expect(status).toBe(200)
+      expect(resp.status).toBe(200)
+      expect(resp.data).toContain('OK v')
+      expect(resp.data).toContain('hash:')
+      expect(resp.data).toContain('features:')
+      expect(resp.data).toContain('uptime:')
     })
   })
   describe('Identity', () => {

--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -8,6 +8,12 @@ use {
 pub async fn handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     (
         StatusCode::OK,
-        format!("OK v{}", state.compile_info.build().version()),
+        format!(
+            "OK v{}, commit hash: {}, features: {}, uptime: {:?} seconds",
+            state.compile_info.build().version(),
+            state.compile_info.git().short_hash(),
+            state.compile_info.build().features(),
+            state.uptime.elapsed().as_secs()
+        ),
     )
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,6 +26,8 @@ pub struct AppState {
     pub analytics: RPCAnalytics,
     pub compile_info: CompileInfo,
     pub ens_allowlist: Option<HashMap<H160, String>>,
+    /// Service instance uptime measurement
+    pub uptime: std::time::Instant,
 }
 
 pub fn new_state(
@@ -46,6 +48,7 @@ pub fn new_state(
         analytics,
         compile_info: CompileInfo {},
         ens_allowlist,
+        uptime: std::time::Instant::now(),
     }
 }
 


### PR DESCRIPTION
# Description

This PR adds exposing of the following states to the `/health` endpoint:
* Build commit hash - to track what version is alive on the current deployment,
* Features - to track what features are on,
* Uptime - to track the uptime of the service and to know when the instance was restarted.

The updated `/health` response should look like:
```
OK v0.1.0, commit hash: d6ee36e, features: test_localhost, uptime: 294 seconds
```

## How Has This Been Tested?

Tested by the included in this PR integration test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
