### PR TITLE
fix(ci): image tag version as a short commit SHA instead of `latest`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,7 +192,7 @@ jobs:
         uses: docker/build-push-action@v2
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: latest # TODO #85: use proper tag list
+          IMAGE_TAG: ${GITHUB_SHA::7}
           PUSH: true
         with:
           context: .
@@ -216,4 +216,5 @@ jobs:
       deploy_app: true
       deploy_infra: false
       deploy_production: true
+      image_version: ${GITHUB_SHA::7}
     secrets: inherit


### PR DESCRIPTION
# Description

This PR adds an ECR image version tag as a short SHA commit (eg. `d6ee36e`) instead of always be `latest`.
With this change, we can track what version was shipped and can ship a certain version to revert.

[GITHUB_SHA](https://docs.github.com/en/actions/learn-github-actions/variables) GitHub CI variable is used to get the commit SHA and shorten it by the `::7`.

Resolves #53 

## How Has This Been Tested?

Not tested, but should babysit it when merging and test it.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
