### PR TITLE
chore(terraform): applying most recent added ECR image

### DIFF
--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -13,7 +13,7 @@ locals {
 
 data "aws_ecr_image" "service_image" {
   repository_name = "rpc-proxy"
-  image_tag       = "latest"
+  most_recent     = true
 }
 
 # Log Group for our App


### PR DESCRIPTION
# Description

Since #395 we are using the short SHA hash for the commit tag instead of the `latest` for the ECR images.
This PR adds changes to the terraform config to use the latest pushed ECR image instead of with the `latest` tag.

Part of the #53

## How Has This Been Tested?

`terraform output` and, `terraform plan` run.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
