### PR TITLE
test(integration): fixing check for UUIDv4 format and check on errors

### DIFF
--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -32,13 +32,26 @@ describe('blockchain api', () => {
     })
   })
   describe('Middlewares', () => {
-    it('headers should contain x-request-id', async () => {
+    it('OK response should contain x-request-id header', async () => {
       let resp: any = await http.get(
         `${baseUrl}/v1/account/0xf3ea39310011333095CFCcCc7c4Ad74034CABA63/history?projectId=${projectId}`,
       )
-      expect(resp.status).toBe(200)
-      expect(resp.header['x-request-id']).toBe('string');
-      expect(resp.header['x-request-id']).toHaveLength(36); // UUIDv4
+      expect(resp.headers).toBeDefined();
+      expect(resp.status).toBe(200);
+      // Check if the header value is a valid UUIDv4
+      const uuidv4Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      expect(resp.headers['x-request-id']).toMatch(uuidv4Pattern);
+    })
+    it('Error response should contain x-request-id header', async () => {
+      // Wrong address request
+      let resp: any = await http.get(
+        `${baseUrl}/v1/account/0Ff3ea39310011333095CFCcCc7c4Ad74034CABA63/history?projectId=${projectId}`,
+      )
+      expect(resp.headers).toBeDefined();
+      expect(resp.status).toBe(400);
+      // Check if the header value is a valid UUIDv4
+      const uuidv4Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      expect(resp.headers['x-request-id']).toMatch(uuidv4Pattern);
     })
   })
   describe('Identity', () => {


### PR DESCRIPTION
# Description

This PR adds a check for the UUIDv4 format for the `x-request-id` header for the OK response and for the Not OK responses and fixing a nit `header` -> `headers`.

## How Has This Been Tested?

Start a local server with `cargo run`.
Run integration test with `RPC_URL=http://localhost:3000  yarn integration`.

Also passing tests on staging:
`RPC_URL=https://staging.rpc.walletconnect.com  yarn integration`

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
