### PR TITLE
fix(o11y): history lookup not tracked

### DIFF
--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -62,6 +62,7 @@ async fn handler_internal(
     let latency_tracker = latency_tracker_start
         .elapsed()
         .unwrap_or(std::time::Duration::from_secs(0));
+    state.metrics.add_history_lookup();
 
     {
         let origin = headers


### PR DESCRIPTION
# Description

Fixes the below panels which depend on `add_history_lookup` which is not called anywhere.

<img width="1714" alt="Screenshot 2023-11-27 at 5 59 06 AM" src="https://github.com/WalletConnect/blockchain-api/assets/966091/d0b54381-9512-43f7-8e87-fd3f806d54c2">


## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
