### PR TITLE
ci: append the `latest` tag for pushed image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,7 +197,9 @@ jobs:
         with:
           context: .
           push: ${{ env.PUSH }}
-          tags: ${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME}}:${{ env.IMAGE_TAG }}
+          tags: |
+            ${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME}}:latest
+            ${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME}}:${{ env.IMAGE_TAG }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 


### PR DESCRIPTION
# Description

This PR adds an additional `latest` tag for the pushed ECR app image to use the `latest` for the most recent image instead of searching for the recent commit (as we are deploying by the commit hash now).
The tags override is not enabled in the ECR repository so we can keep only a single latest tag per image with the commit hash tag.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
