### PR TITLE
feat(identity): remove ENS demo

### DIFF
--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -66,13 +66,6 @@ describe('blockchain api', () => {
       expect(resp.status).toBe(200)
       expect(resp.data.name).toBe('cyberdrk.eth')
     })
-    it('known ens demo', async () => {
-      let resp: any = await http.get(
-        `${baseUrl}/v1/identity/0x621D24169AeCf1da1eE8dce6aA2258F277434334?chainId=eip155%3A1&projectId=${projectId}`,
-      )
-      expect(resp.status).toBe(200)
-      expect(resp.data.name).toBe('DerekDiscoDude.connect.id')
-    })
     it('unknown ens', async () => {
       let resp: any = await http.get(
         `${baseUrl}/v1/identity/0xf3ea39310011333095CFCcCc7c4Ad74034CABA64?chainId=eip155%3A1&projectId=${projectId}`,

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -175,7 +175,7 @@ async fn lookup_identity(
             debug!("Setting cache success");
         });
     }
-    
+
     Ok((IdentityLookupSource::Rpc, res))
 }
 

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -28,7 +28,7 @@ use {
         time::{Duration, SystemTime, UNIX_EPOCH},
     },
     tap::TapFallible,
-    tracing::{debug, info, warn},
+    tracing::{debug, warn},
     wc::future::FutureExt,
 };
 
@@ -146,39 +146,8 @@ async fn lookup_identity(
 ) -> Result<(IdentityLookupSource, IdentityResponse), RpcError> {
     let cache_key = format!("{}", address);
 
-    // Skipping the cache for testing addresses
-    let ens_demo_addresses = state.ens_allowlist.clone().unwrap_or_default();
-    if !ens_demo_addresses.contains_key(&address) {
-        if let Some(cache) = &state.identity_cache {
-            debug!("Checking cache for identity");
-            let cache_start = SystemTime::now();
-            let value = cache.get(&cache_key).await?;
-            state.metrics.add_identity_lookup_cache_latency(cache_start);
-            if let Some(response) = value {
-                return Ok((IdentityLookupSource::Cache, response));
-            }
-        }
-    };
-
-    info!("Looking up identity for address: {}", address);
-
-    // check if address equals derek address
-    let res = if !ens_demo_addresses.contains_key(&address) {
-        lookup_identity_rpc(address, state.clone(), connect_info, query, path, headers).await?
-    } else {
-        let fallback = "unknown".to_string();
-        let ens = ens_demo_addresses
-            .get(&address)
-            .unwrap_or(&fallback)
-            .as_str();
-        IdentityResponse {
-            name: Some(format!("{}.connect.id", ens)),
-            avatar: Some(
-                "https://ipfs.io/ipfs/bafybeiabkgjlpf35cbo4jdskt4llbb7pdhqh25nmra7imsam233z65an2y"
-                    .to_string(),
-            ),
-        }
-    };
+    let res =
+        lookup_identity_rpc(address, state.clone(), connect_info, query, path, headers).await?;
 
     if let Some(cache) = &state.identity_cache {
         debug!("Saving to cache");


### PR DESCRIPTION
# Description

Removes the mocked reverse ENS lookup until we actually ship the feature.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
