### PR TITLE
feat: exposing `implementations` for the transactions history

### DIFF
--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -110,11 +110,21 @@ pub struct ZerionTransactionTransferQuantity {
     pub numeric: String,
 }
 
+/// Implementation details of the fungible on various chains.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionImplementation {
+    /// Unique id of the chain.
+    pub chain_id: String,
+    /// Implementation address on the chain.
+    pub address: Option<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 pub struct ZerionTransactionFungibleInfo {
     pub name: Option<String>,
     pub symbol: Option<String>,
     pub icon: Option<ZerionTransactionURLItem>,
+    pub implementations: Vec<ZerionTransactionImplementation>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]


### PR DESCRIPTION
# Description

Exposing the `chain_id` and `address` from the `implementations` for the `fungible_info`.
The updated response will contain new exposed fields:
* `chain_id` - Unique id of the chain.
* `address` - Implementation address on the chain.

This is a requirement for the transactions history UI to get the chain on where was the transaction and add an icon.

Example updated response:
```
{
...
  "transfers":[
    {
      "fungible_info":
        ...
        "implementations": [
              {
                "chain_id": "polygon",
                "address": "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359"
              }
            ]
...
}
```

Resolves #408 

## How Has This Been Tested?

**Manually:**

Start the server locally by running `cargo run` with a valid Zerion RPC key in `RPC_PROXY_PROVIDER_ZERION_API_KEY` environment variable.
Request the history by the curl command `curl -v 'http://localhost:3000/v1/account/0xf3ea39310011333095CFCcCc7c4Ad74034CABA63/history?projectId=xxx`.
Th expected result is that response should contain the `implementations`.

**CI:**

Integration test for the history endpoint.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
