### PR TITLE
feat: add Postgres 16 to the docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,13 @@ services:
     volumes:
       - redis:/data
 
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+    - "5432:5432"
+
   proxy:
     platform: linux/x86_64
     build:
@@ -30,6 +37,7 @@ services:
       - SYS_PTRACE    # Enabling GDB to attach to a running process
     depends_on:
       - redis
+      - postgres
 
 volumes:
   redis:


### PR DESCRIPTION
# Description

This PR adds the Postgres 16 to the docker-compose to use in the further CI tests.

Resolves #405

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
