### PR TITLE
feat: add sql schema and migrations for the ENS

### DIFF
--- a/migrations/20231209213851_init-names.sql
+++ b/migrations/20231209213851_init-names.sql
@@ -1,0 +1,15 @@
+-- Creating the hstore extension for the attributes column
+CREATE EXTENSION hstore;
+
+-- Initializing the names table
+CREATE TABLE names (
+  name VARCHAR(255) PRIMARY KEY,
+  registered_at TIMESTAMPTZ NOT NULL  DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- We are using the hstore as a key-value for the extensible attributes list
+  attributes hstore,
+
+  -- Check for the standartized name format
+  CONSTRAINT ens_name_standard CHECK (name ~ '^[a-z0-9.-]*$')
+);

--- a/migrations/20231209213904_init-addresses.sql
+++ b/migrations/20231209213904_init-addresses.sql
@@ -1,0 +1,33 @@
+-- List of supported blockchain namespaces
+CREATE TYPE namespaces AS ENUM (
+  'eip155' -- Ethereum
+);
+
+-- Initializing the addresses table
+CREATE TABLE addresses (
+  -- Breakdown of the CAP-10 address format into namespace:chain_id:address
+  namespace namespaces,
+  /*
+  chain_id can represent a chain id e.g. (Cosmos and cosmoshub-3 chain):
+    cosmos:cosmoshub-3:cosmos1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0
+  chain_id can be empty e.g. (Litecoin mainnet):
+    bip122:12a765e31ffd4059bada1e25190f6e98
+  */
+  chain_id VARCHAR(255) NOT NULL,
+  address VARCHAR(255) NOT NULL,
+
+  name  VARCHAR(255) REFERENCES  names (name) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  PRIMARY KEY (name, namespace, chain_id, address)
+);
+
+-- Creating indexes for the address lookups
+CREATE INDEX index_cap_10_format_address
+  ON addresses (namespace, chain_id, address);
+CREATE INDEX index_namespace_address
+  ON addresses (namespace, address);
+CREATE INDEX index_address
+  ON addresses (address);
+CREATE INDEX index_name
+  ON addresses (name);

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,17 @@
+# Migrations
+
+This folder contains SQL migration scripts and they are automatically run on start-up.
+
+## New Migration
+
+To create new migration file sqlx-cli must be installed:
+
+```
+cargo install sqlx-cli
+```
+
+Create a new migration with the `name`:
+
+```
+sqlx migrate add <name>
+```


### PR DESCRIPTION
# Description

This PR adds the SQL database tables schema migration files for the sqlx according to the [SPECS](https://walletconnect-specs-git-max-feathexlessspec-walletconnect1.vercel.app/2.0/specs/servers/blockchain/blockchain-server-api).

Resolves #405 

## Stacked PRs list 🏗️

* 0: add Postgres to Terraform config #415 
* 1: add Postgres 16 to the docker-compose #410
* 2: add sql schema and migrations for the ENS #411 
* 3: scaffold sqlx and add `RPC_PROXY_POSTGRES_URI` env variable #412
* 4: implement database helpers #413
* 5: enable database functional tests #414 
* 6: add lookup handlers #417 
* 7: name registration handler #418 
* 8: profile names integration tests #419

## How Has This Been Tested?

When the server is started the migration procedure is invoked in #412 . The expected result is a successful server start.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
