### PR TITLE
feat: implement database helpers

### DIFF
--- a/src/database/error.rs
+++ b/src/database/error.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, thiserror::Error)]
+pub enum DatabaseError {
+    #[error("sqlx error: {0}")]
+    SqlxError(#[from] sqlx::Error),
+    #[error("Bad argument were provided for the database helper: {0}")]
+    BadArgument(String),
+    #[error("Address required: {0}")]
+    AddressRequired(String),
+}

--- a/src/database/helpers.rs
+++ b/src/database/helpers.rs
@@ -1,0 +1,228 @@
+use {
+    crate::database::{error::DatabaseError, types, utils},
+    sqlx::{PgPool, Postgres},
+    std::collections::HashMap,
+    tracing::instrument,
+};
+
+/// Initial name registration insert
+#[instrument(skip(postgres))]
+pub async fn insert_name(
+    name: String,
+    attributes: HashMap<String, String>,
+    addresses: Vec<types::Address>,
+    postgres: &PgPool,
+) -> Result<(), DatabaseError> {
+    if addresses.is_empty() {
+        return Err(DatabaseError::BadArgument(
+            "At least one address is required for the new name".to_string(),
+        ));
+    }
+    let mut transaction = postgres.begin().await?;
+    let insert_name_query = "
+      INSERT INTO names (name, attributes)
+        VALUES ($1, $2::hstore)
+    ";
+    sqlx::query::<Postgres>(insert_name_query)
+        .bind(&name.clone())
+        // Convert JSON to String for hstore update
+        .bind(&utils::hashmap_to_hstore(&attributes))
+        .execute(&mut *transaction)
+        .await?;
+    for address in addresses {
+        insert_address(
+            name.clone(),
+            address.namespace,
+            address.chain_id,
+            address.address,
+            &mut *transaction,
+        )
+        .await?;
+    }
+    transaction.commit().await.map_err(DatabaseError::SqlxError)
+}
+
+#[instrument(skip(postgres))]
+pub async fn delete_name(
+    name: String,
+    postgres: &PgPool,
+) -> Result<sqlx::postgres::PgQueryResult, sqlx::error::Error> {
+    let query = "
+      DELETE FROM names WHERE name = $1
+    ";
+    sqlx::query::<Postgres>(query)
+        .bind(name)
+        .execute(postgres)
+        .await
+}
+
+#[instrument(skip(postgres))]
+pub async fn update_name(
+    name: String,
+    attributes: HashMap<String, String>,
+    postgres: &PgPool,
+) -> Result<sqlx::postgres::PgQueryResult, sqlx::error::Error> {
+    let insert_name_query = "
+      UPDATE names SET attributes = $2::hstore, updated_at = NOW()
+        WHERE name = $1
+    ";
+    sqlx::query::<Postgres>(insert_name_query)
+        .bind(&name)
+        // Convert JSON to String for hstore update
+        .bind(&utils::hashmap_to_hstore(&attributes))
+        .execute(postgres)
+        .await
+}
+
+#[instrument(skip(postgres))]
+pub async fn get_name(name: String, postgres: &PgPool) -> Result<types::Name, sqlx::error::Error> {
+    let query = "
+      SELECT name, registered_at, updated_at, hstore_to_json(attributes) AS attributes
+        FROM names
+          WHERE name = $1
+    ";
+    sqlx::query_as::<Postgres, types::Name>(query)
+        .bind(name)
+        .fetch_one(postgres)
+        .await
+}
+
+#[instrument(skip(postgres))]
+pub async fn get_names_by_address(
+    address: String,
+    postgres: &PgPool,
+) -> Result<Vec<types::Name>, sqlx::error::Error> {
+    let query = "
+        SELECT
+            n.name,
+            n.registered_at,
+            n.updated_at,
+            hstore_to_json(n.attributes) AS attributes
+        FROM
+            names n
+        INNER JOIN
+            addresses a ON n.name = a.name
+        WHERE
+            a.address = $1
+    ";
+    sqlx::query_as::<Postgres, types::Name>(query)
+        .bind(address)
+        .fetch_all(postgres)
+        .await
+}
+
+#[instrument(skip(postgres))]
+pub async fn get_addresses_by_name(
+    name: String,
+    postgres: &PgPool,
+) -> Result<Vec<types::Address>, sqlx::error::Error> {
+    let query = "
+      SELECT namespace, chain_id, address, created_at
+      FROM addresses
+        WHERE name = $1
+    ";
+    sqlx::query_as::<Postgres, types::Address>(query)
+        .bind(name)
+        .fetch_all(postgres)
+        .await
+}
+
+#[instrument(skip(postgres))]
+pub async fn get_names_by_address_and_namespace(
+    address: String,
+    namespace: types::SupportedNamespaces,
+    postgres: &PgPool,
+) -> Result<Vec<types::Name>, sqlx::error::Error> {
+    let query = "
+        SELECT 
+            n.name, 
+            n.registered_at, 
+            n.updated_at, 
+            hstore_to_json(n.attributes) AS attributes
+        FROM 
+            names n
+        INNER JOIN 
+            addresses a ON n.name = a.name
+        WHERE 
+            a.address = $1 AND a.namespace = $2
+    ";
+    sqlx::query_as::<Postgres, types::Name>(query)
+        .bind(address)
+        .bind(namespace)
+        .fetch_all(postgres)
+        .await
+}
+
+#[instrument(skip(postgres))]
+pub async fn get_name_and_addresses_by_name(
+    name: String,
+    postgres: &PgPool,
+) -> Result<types::NameAndAddresses, sqlx::error::Error> {
+    let result = get_name(name.clone(), postgres).await?;
+    let addresses = get_addresses_by_name(name, postgres).await?;
+
+    Ok(types::NameAndAddresses {
+        name: result.name,
+        registered_at: result.registered_at,
+        updated_at: result.updated_at,
+        attributes: result.attributes,
+        addresses,
+    })
+}
+
+#[instrument(skip(postgres))]
+pub async fn delete_address(
+    name: String,
+    namespace: types::SupportedNamespaces,
+    chain_id: Option<String>,
+    address: String,
+    postgres: &PgPool,
+) -> Result<sqlx::postgres::PgQueryResult, DatabaseError> {
+    let current_addresses = get_addresses_by_name(name.clone(), postgres).await?;
+    if current_addresses.len() == 1 {
+        return Err(DatabaseError::AddressRequired(
+            "At least one address is required to exist for the name".to_string(),
+        ));
+    }
+    let query = sqlx::query::<Postgres>(
+        "
+        DELETE FROM addresses
+        WHERE
+            name = $1 AND
+            namespace = $2 AND
+            chain_id = $3 AND
+            address = $4
+        ",
+    )
+    .bind(&name)
+    .bind(&namespace)
+    .bind(chain_id.unwrap_or_default())
+    .bind(&address);
+
+    query
+        .execute(postgres)
+        .await
+        .map_err(DatabaseError::SqlxError)
+}
+
+#[instrument(skip(postgres))]
+pub async fn insert_address<'e>(
+    name: String,
+    namespace: types::SupportedNamespaces,
+    chain_id: Option<String>,
+    address: String,
+    postgres: impl sqlx::PgExecutor<'e>,
+) -> Result<sqlx::postgres::PgQueryResult, sqlx::error::Error> {
+    let query = sqlx::query::<Postgres>(
+        "
+        INSERT INTO addresses (name, namespace, chain_id, address)
+        VALUES ($1, $2, $3, $4)
+        ",
+    )
+    .bind(&name)
+    .bind(&namespace)
+    .bind(chain_id.unwrap_or_default())
+    .bind(&address);
+
+    query.execute(postgres).await
+}

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,1 +1,5 @@
 pub mod config;
+pub mod error;
+pub mod helpers;
+pub mod types;
+pub mod utils;

--- a/src/database/types.rs
+++ b/src/database/types.rs
@@ -1,0 +1,57 @@
+use {
+    chrono::{DateTime, Utc},
+    serde::{Deserialize, Serialize, Serializer},
+    sqlx::{FromRow, Type},
+    std::collections::HashMap,
+};
+
+/// Currently supported blockchain namespaces
+#[derive(Type, Serialize, Deserialize, Debug, Clone)]
+#[sqlx(type_name = "namespaces", rename_all = "lowercase")]
+pub enum SupportedNamespaces {
+    /// Ethereum
+    Eip155,
+}
+
+/// Represents the ENS name record
+#[derive(Debug, FromRow, Serialize, Deserialize)]
+pub struct Name {
+    pub name: String,
+    pub registered_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    /// Postgres hstore data type, represented as key-value pairs for attributes
+    pub attributes: Option<sqlx::types::Json<HashMap<String, String>>>,
+}
+
+/// Represents the ENS address record
+#[derive(Debug, FromRow, Serialize, Deserialize)]
+pub struct Address {
+    pub namespace: SupportedNamespaces,
+    #[serde(serialize_with = "serialize_chain_id")]
+    pub chain_id: Option<String>,
+    pub address: String,
+    pub created_at: Option<DateTime<Utc>>,
+}
+
+// Custom serialization function for chain_id to make it None if it's an empty
+// string
+fn serialize_chain_id<S>(chain_id: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match chain_id {
+        Some(id) if id.is_empty() => serializer.serialize_none(),
+        _ => serializer.serialize_some(chain_id),
+    }
+}
+
+/// Represents the ENS name record
+#[derive(FromRow, Debug, Serialize, Deserialize)]
+pub struct NameAndAddresses {
+    pub name: String,
+    pub registered_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    /// Postgres hstore data type, represented as key-value pairs for attributes
+    pub attributes: Option<sqlx::types::Json<HashMap<String, String>>>,
+    pub addresses: Vec<Address>,
+}

--- a/src/database/utils.rs
+++ b/src/database/utils.rs
@@ -1,0 +1,9 @@
+use std::collections::HashMap;
+
+pub fn hashmap_to_hstore(hashmap: &HashMap<String, String>) -> String {
+    hashmap
+        .iter()
+        .map(|(key, value)| format!("\"{}\" => \"{}\"", key, value))
+        .collect::<Vec<_>>()
+        .join(", ")
+}

--- a/tests/functional/database.rs
+++ b/tests/functional/database.rs
@@ -1,0 +1,284 @@
+use {
+    crate::utils::{generate_random_string, get_postgres_pool},
+    rpc_proxy::database::{
+        helpers::{
+            delete_address,
+            delete_name,
+            get_addresses_by_name,
+            get_name,
+            get_name_and_addresses_by_name,
+            get_names_by_address,
+            get_names_by_address_and_namespace,
+            insert_address,
+            insert_name,
+            update_name,
+        },
+        types,
+    },
+    std::collections::HashMap,
+};
+
+#[tokio::test]
+async fn insert_and_get_name_by_name() {
+    let pg_pool = get_postgres_pool().await;
+
+    let name = format!("{}.connect.id", generate_random_string(10));
+    let address = format!("0x{}", generate_random_string(16));
+    let addresses = vec![types::Address {
+        namespace: types::SupportedNamespaces::Eip155,
+        chain_id: None,
+        address,
+        created_at: None,
+    }];
+
+    // create a new hashmap with attributes
+    let attributes: HashMap<String, String> = HashMap::from_iter([
+        (
+            "avatar".to_string(),
+            "http://test.url/avatar.png".to_string(),
+        ),
+        ("bio".to_string(), "just about myself".to_string()),
+    ]);
+
+    let insert_result = insert_name(name.clone(), attributes.clone(), addresses, &pg_pool).await;
+    if let Err(ref e) = insert_result {
+        println!("Error: {:?}", e);
+    }
+    assert!(insert_result.is_ok(), "Inserting a new name should succeed");
+
+    let get_name_result = get_name(name.clone(), &pg_pool).await;
+    assert!(
+        get_name_result.is_ok(),
+        "Getting name after inserting should succeed"
+    );
+
+    let got_name = get_name_result.unwrap();
+    let got_attributes = got_name.attributes.unwrap();
+
+    assert_eq!(got_name.name, name);
+    assert_eq!(got_attributes["avatar"], attributes["avatar"]);
+    assert_eq!(got_attributes["bio"], attributes["bio"]);
+
+    // Cleanup
+    let delete_result = delete_name(name, &pg_pool).await;
+    assert!(delete_result.is_ok(), "Deleting name should succeed");
+}
+
+#[tokio::test]
+async fn insert_and_get_names_by_address() {
+    let pg_pool = get_postgres_pool().await;
+
+    let name = format!("{}.connect.id", generate_random_string(10));
+    let address = format!("0x{}", generate_random_string(16));
+
+    let addresses = vec![types::Address {
+        namespace: types::SupportedNamespaces::Eip155,
+        chain_id: None,
+        address: address.clone(),
+        created_at: None,
+    }];
+
+    let insert_result = insert_name(name.clone(), HashMap::new(), addresses, &pg_pool).await;
+    assert!(insert_result.is_ok(), "Inserting a new name should succeed");
+
+    let get_names_result = get_names_by_address(address, &pg_pool).await;
+    assert!(
+        get_names_result.is_ok(),
+        "Getting name by the address after inserting should succeed"
+    );
+
+    let got_names = get_names_result.unwrap();
+    assert_eq!(got_names[0].name, name);
+
+    // Cleanup
+    let delete_result = delete_name(name, &pg_pool).await;
+    assert!(delete_result.is_ok(), "Deleting name should succeed");
+}
+
+#[tokio::test]
+async fn insert_and_get_names_by_address_and_namespace() {
+    let pg_pool = get_postgres_pool().await;
+
+    let name = format!("{}.connect.id", generate_random_string(10));
+    let address = format!("0x{}", generate_random_string(16));
+    let namespace = types::SupportedNamespaces::Eip155;
+
+    let addresses = vec![types::Address {
+        namespace: namespace.clone(),
+        chain_id: None,
+        address: address.clone(),
+        created_at: None,
+    }];
+
+    let insert_result = insert_name(name.clone(), HashMap::new(), addresses, &pg_pool).await;
+    assert!(insert_result.is_ok(), "Inserting a new name should succeed");
+
+    let get_names_result = get_names_by_address_and_namespace(address, namespace, &pg_pool).await;
+    assert!(
+        get_names_result.is_ok(),
+        "Getting name by the address after inserting should succeed"
+    );
+
+    let got_names = get_names_result.unwrap();
+    assert_eq!(got_names[0].name, name);
+
+    // Cleanup
+    let delete_result = delete_name(name, &pg_pool).await;
+    assert!(delete_result.is_ok(), "Deleting name should succeed");
+}
+
+#[tokio::test]
+async fn insert_and_get_name_and_addresses() {
+    let pg_pool = get_postgres_pool().await;
+
+    let name = format!("{}.connect.id", generate_random_string(10));
+    let address = format!("0x{}", generate_random_string(16));
+    let namespace = types::SupportedNamespaces::Eip155;
+
+    let addresses = vec![types::Address {
+        namespace: namespace.clone(),
+        chain_id: None,
+        address: address.clone(),
+        created_at: None,
+    }];
+
+    let attributes: HashMap<String, String> = HashMap::from_iter([(
+        "avatar".to_string(),
+        "http://test.url/avatar.png".to_string(),
+    )]);
+
+    let insert_result = insert_name(name.clone(), attributes.clone(), addresses, &pg_pool).await;
+    assert!(insert_result.is_ok(), "Inserting a new name should succeed");
+
+    let get_name_result = get_name_and_addresses_by_name(name.clone(), &pg_pool).await;
+    assert!(
+        get_name_result.is_ok(),
+        "Getting name after inserting should succeed"
+    );
+
+    let got_name = get_name_result.unwrap();
+    assert_eq!(got_name.name, name);
+    assert_eq!(got_name.attributes.unwrap()["avatar"], attributes["avatar"]);
+    assert_eq!(got_name.addresses[0].address, address);
+
+    // Cleanup
+    let delete_result = delete_name(name, &pg_pool).await;
+    assert!(delete_result.is_ok(), "Deleting name should succeed");
+}
+
+#[tokio::test]
+async fn insert_and_update_name() {
+    let pg_pool = get_postgres_pool().await;
+
+    let name = format!("{}.connect.id", generate_random_string(10));
+    let address = format!("0x{}", generate_random_string(16));
+    let addresses = vec![types::Address {
+        namespace: types::SupportedNamespaces::Eip155,
+        chain_id: None,
+        address,
+        created_at: None,
+    }];
+
+    // create a new hashmap with attributes
+    let attributes: HashMap<String, String> = HashMap::from_iter([
+        (
+            "avatar".to_string(),
+            "http://test.url/avatar.png".to_string(),
+        ),
+        ("bio".to_string(), "just about myself".to_string()),
+    ]);
+
+    let insert_result = insert_name(name.clone(), attributes.clone(), addresses, &pg_pool).await;
+    assert!(insert_result.is_ok(), "Inserting a new name should succeed");
+
+    let get_name_result = get_name(name.clone(), &pg_pool).await;
+    assert!(
+        get_name_result.is_ok(),
+        "Getting name after inserting should succeed"
+    );
+
+    let got_name = get_name_result.unwrap();
+    let got_attributes = got_name.attributes.unwrap();
+
+    assert_eq!(got_name.name, name.clone());
+    assert_eq!(got_attributes["avatar"], attributes["avatar"]);
+    assert_eq!(got_attributes["bio"], attributes["bio"]);
+
+    // Updating the name with new attributes
+    let updated_attributes: HashMap<String, String> =
+        HashMap::from_iter([("GitHub".to_string(), "SomeProfile".to_string())]);
+    let updated_result = update_name(name.clone(), updated_attributes.clone(), &pg_pool).await;
+    assert!(updated_result.is_ok(), "Updating name should succeed");
+
+    let got_update_name = get_name(name.clone(), &pg_pool).await.unwrap();
+    assert_eq!(got_update_name.name, name.clone());
+    assert_eq!(
+        got_update_name.attributes.unwrap()["GitHub"],
+        updated_attributes["GitHub"]
+    );
+
+    // Cleanup
+    let delete_result = delete_name(name, &pg_pool).await;
+    assert!(delete_result.is_ok(), "Deleting name should succeed");
+}
+
+#[tokio::test]
+async fn insert_update_delete_address() {
+    let pg_pool = get_postgres_pool().await;
+
+    let name = format!("{}.connect.id", generate_random_string(10));
+    let address = format!("0x{}", generate_random_string(16));
+    let addresses = vec![types::Address {
+        namespace: types::SupportedNamespaces::Eip155,
+        chain_id: None,
+        address: address.clone(),
+        created_at: None,
+    }];
+
+    let insert_result = insert_name(name.clone(), HashMap::new(), addresses, &pg_pool).await;
+    assert!(insert_result.is_ok(), "Inserting a new name should succeed");
+
+    let delete_address_result = delete_address(
+        name.clone(),
+        types::SupportedNamespaces::Eip155,
+        None,
+        address.clone(),
+        &pg_pool,
+    )
+    .await;
+    // At least one address is required to exist for the name
+    assert!(delete_address_result.is_err());
+
+    // Inserting a new address
+    let new_address = format!("0x{}", generate_random_string(16));
+    let insert_address_result = insert_address(
+        name.clone(),
+        types::SupportedNamespaces::Eip155,
+        None,
+        new_address.clone(),
+        &pg_pool,
+    )
+    .await;
+    assert!(insert_address_result.is_ok());
+
+    // Check for two addresses for the name
+    let current_addresses = get_addresses_by_name(name.clone(), &pg_pool).await;
+    assert!(insert_address_result.is_ok());
+    let current_addresses = current_addresses.unwrap();
+    assert!(current_addresses.len() == 2);
+
+    // Deleting the address should succeed because there is more than one address
+    let delete_address_result = delete_address(
+        name.clone(),
+        types::SupportedNamespaces::Eip155,
+        None,
+        address.clone(),
+        &pg_pool,
+    )
+    .await;
+    assert!(delete_address_result.is_ok());
+
+    // Cleanup
+    let delete_result = delete_name(name, &pg_pool).await;
+    assert!(delete_result.is_ok(), "Deleting name should succeed");
+}

--- a/tests/functional/mod.rs
+++ b/tests/functional/mod.rs
@@ -1,2 +1,3 @@
+mod database;
 mod http;
 mod websocket;

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -2,6 +2,9 @@ use {
     axum::http::HeaderValue,
     hyper::{body, client::HttpConnector, Body, Client, Method, Request, StatusCode},
     hyper_tls::HttpsConnector,
+    rand::{distributions::Alphanumeric, Rng},
+    sqlx::{postgres::PgPoolOptions, PgPool},
+    std::env,
 };
 
 pub async fn send_jsonrpc_request(
@@ -39,4 +42,28 @@ pub async fn send_jsonrpc_request(
             )
         }),
     )
+}
+
+pub async fn get_postgres_pool() -> PgPool {
+    let postgres = PgPoolOptions::new()
+        .connect(&env::var("RPC_PROXY_POSTGRES_URI").unwrap())
+        .await
+        .unwrap();
+    sqlx::migrate!("./migrations").run(&postgres).await.unwrap();
+    postgres
+}
+
+pub fn generate_random_string(len: usize) -> String {
+    let rng = rand::thread_rng();
+    rng.sample_iter(&Alphanumeric)
+        .filter_map(|b| {
+            let c = b as char;
+            if c.is_ascii_alphanumeric() && c.is_ascii_lowercase() || c.is_ascii_digit() {
+                Some(c)
+            } else {
+                None
+            }
+        })
+        .take(len)
+        .collect()
 }


### PR DESCRIPTION
# Description

This PR adds database helpers function implementations for the tables schema in #411 and according to the [SPEC](https://walletconnect-specs-git-max-feathexlessspec-walletconnect1.vercel.app/2.0/specs/servers/blockchain/blockchain-server-api) that should be further used in the server endpoint handlers for names and addresses manipulations.

The functional tests to cover helpers are added to this PR.

Resolves #405 

## Stacked PRs list 🏗️

* 0: add Postgres to Terraform config #415 
* 1: add Postgres 16 to the docker-compose #410
* 2: add sql schema and migrations for the ENS #411 
* 3: scaffold sqlx and add `RPC_PROXY_POSTGRES_URI` env variable #412
* 4: implement database helpers #413
* 5: enable database functional tests #414 
* 6: add lookup handlers #417 
* 7: name registration handler #418 
* 8: profile names integration tests #419

## How Has This Been Tested?

Tested by the included in this PR functional tests, run by the following #414.
* [Results of passing functional tests in CI](https://github.com/WalletConnect/blockchain-api/actions/runs/7210809023/job/19644779358?pr=414#step:9:956)

To run it locally:
* Start the local postgres server:
  `docker run -p 5432:5432 --name postgres -e POSTGRES_HOST_AUTH_METHOD=trust -d postgres`
* Run the cargo test:
  `RPC_PROXY_POSTGRES_URI=postgres://postgres@localhost:5432/postgres cargo test --lib --bins --tests`

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
