### PR TITLE
chore(terraform): adding Postgres

### DIFF
--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -94,6 +94,8 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_STORAGE_IDENTITY_CACHE_REDIS_ADDR_READ", value = "redis://${var.identity_cache_endpoint_read}/1" },
         { name = "RPC_PROXY_STORAGE_IDENTITY_CACHE_REDIS_ADDR_WRITE", value = "redis://${var.identity_cache_endpoint_write}/1" },
 
+        { name = "RPC_PROXY_POSTGRES_URI", value = var.postgres_url },
+
         { name = "RPC_PROXY_ANALYTICS_EXPORT_BUCKET", value = var.analytics_datalake_bucket_name },
       ],
 

--- a/terraform/ecs/network.tf
+++ b/terraform/ecs/network.tf
@@ -75,7 +75,7 @@ resource "aws_lb_target_group" "target_group" {
 
   health_check {
     protocol            = "HTTP"
-    path                = "/health" # KeysServer's health path
+    path                = "/health" # Blockchain-API health path
     port                = var.port
     interval            = 15
     timeout             = 10

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -141,6 +141,11 @@ variable "ofac_blocked_countries" {
   type        = string
 }
 
+variable "postgres_url" {
+  description = "The connection URL for the PostgreSQL instance"
+  type        = string
+}
+
 #-------------------------------------------------------------------------------
 # Providers
 

--- a/terraform/postgres/context.tf
+++ b/terraform/postgres/context.tf
@@ -1,0 +1,179 @@
+module "this" {
+  source  = "app.terraform.io/wallet-connect/label/null"
+  version = "0.3.2"
+
+  namespace           = var.namespace
+  region              = var.region
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+
+  context = var.context
+}
+
+################################################################################
+# Copy contents of label/variables.tf here
+
+#tflint-ignore: terraform_standard_module_structure
+variable "context" {
+  type        = any
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes and tags, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+#tflint-ignore: terraform_standard_module_structure
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually the organization name, i.e. 'walletconnect' to help ensure generated IDs are globally unique."
+}
+
+#tflint-ignore: terraform_standard_module_structure
+variable "region" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2'."
+}
+
+#tflint-ignore: terraform_standard_module_structure
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'."
+}
+
+#tflint-ignore: terraform_standard_module_structure
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component name.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+#tflint-ignore: terraform_standard_module_structure
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+#tflint-ignore: terraform_standard_module_structure
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+#tflint-ignore: terraform_standard_module_structure
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags."
+}
+
+#tflint-ignore: terraform_standard_module_structure
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "region", "stage", "name", "attributes"].
+    You can omit any of the 5 labels, but at least one must be present.
+    EOT
+}
+
+#tflint-ignore: terraform_standard_module_structure
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+#tflint-ignore: terraform_standard_module_structure
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+#tflint-ignore: terraform_standard_module_structure
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+#tflint-ignore: terraform_standard_module_structure
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}

--- a/terraform/postgres/main.tf
+++ b/terraform/postgres/main.tf
@@ -1,0 +1,37 @@
+module "db_cluster" {
+  source  = "terraform-aws-modules/rds-aurora/aws"
+  version = "8.5.0"
+
+  name           = "${var.app_name}-postgres-cluster"
+  engine         = "aurora-postgresql"
+  engine_version = "16.1"
+  engine_mode    = "provisioned"
+  instance_class = "db.serverless"
+  instances      = { for i in range(1, var.instances + 1) : i => {} }
+
+  database_name               = var.db_name
+  manage_master_user_password = false
+  master_username             = var.db_master_username
+  master_password             = local.db_master_password
+
+  vpc_id = var.vpc_id
+  security_group_rules = {
+    vpc_ingress = {
+      cidr_blocks = var.ingress_cidr_blocks
+    }
+  }
+
+  performance_insights_enabled = true
+  storage_encrypted            = true
+  allow_major_version_upgrade  = true
+  apply_immediately            = true
+  skip_final_snapshot          = true
+  deletion_protection          = true
+
+  monitoring_interval = 30
+
+  serverlessv2_scaling_configuration = {
+    min_capacity = var.min_capacity
+    max_capacity = var.max_capacity
+  }
+}

--- a/terraform/postgres/main.tf
+++ b/terraform/postgres/main.tf
@@ -8,12 +8,12 @@ resource "aws_db_subnet_group" "db_subnets" {
 
 module "db_cluster" {
   source  = "terraform-aws-modules/rds-aurora/aws"
-  version = "8.3.1"
+  version = "8.5.0"
 
   name               = module.this.id
   database_name      = var.db_name
   engine             = "aurora-postgresql"
-  engine_version     = "15.3"
+  engine_version     = "16.1"
   engine_mode        = "provisioned"
   ca_cert_identifier = "rds-ca-ecc384-g1"
   instance_class     = "db.serverless"

--- a/terraform/postgres/main.tf
+++ b/terraform/postgres/main.tf
@@ -1,20 +1,30 @@
+data "aws_caller_identity" "this" {}
+
+resource "aws_db_subnet_group" "db_subnets" {
+  name        = module.this.id
+  description = "Subnet group for the ${module.this.id} RDS cluster"
+  subnet_ids  = var.subnet_ids
+}
+
 module "db_cluster" {
   source  = "terraform-aws-modules/rds-aurora/aws"
-  version = "8.5.0"
+  version = "8.3.1"
 
-  name           = "${var.app_name}-postgres-cluster"
-  engine         = "aurora-postgresql"
-  engine_version = "16.1"
-  engine_mode    = "provisioned"
-  instance_class = "db.serverless"
-  instances      = { for i in range(1, var.instances + 1) : i => {} }
+  name               = module.this.id
+  database_name      = var.db_name
+  engine             = "aurora-postgresql"
+  engine_version     = "15.3"
+  engine_mode        = "provisioned"
+  ca_cert_identifier = "rds-ca-ecc384-g1"
+  instance_class     = "db.serverless"
+  instances          = { for i in range(1, var.instances + 1) : i => {} }
 
-  database_name               = var.db_name
-  manage_master_user_password = false
   master_username             = var.db_master_username
+  manage_master_user_password = false
   master_password             = local.db_master_password
 
-  vpc_id = var.vpc_id
+  vpc_id               = var.vpc_id
+  db_subnet_group_name = aws_db_subnet_group.db_subnets.name
   security_group_rules = {
     vpc_ingress = {
       cidr_blocks = var.ingress_cidr_blocks
@@ -28,7 +38,10 @@ module "db_cluster" {
   skip_final_snapshot          = true
   deletion_protection          = true
 
-  monitoring_interval = 30
+  monitoring_interval                    = 30
+  enabled_cloudwatch_logs_exports        = ["postgresql"]
+  cloudwatch_log_group_kms_key_id        = var.cloudwatch_logs_key_arn
+  cloudwatch_log_group_retention_in_days = var.cloudwatch_retention_in_days
 
   serverlessv2_scaling_configuration = {
     min_capacity = var.min_capacity

--- a/terraform/postgres/outputs.tf
+++ b/terraform/postgres/outputs.tf
@@ -1,0 +1,29 @@
+output "database_name" {
+  description = "The name of the default database in the cluster"
+  value       = var.db_name
+}
+
+output "master_username" {
+  description = "The username for the master DB user"
+  value       = var.db_master_username
+}
+
+output "rds_cluster_arn" {
+  description = "The ARN of the cluster"
+  value       = module.db_cluster.cluster_arn
+}
+
+output "rds_cluster_id" {
+  description = "The ID of the cluster"
+  value       = module.db_cluster.cluster_id
+}
+
+output "rds_cluster_endpoint" {
+  description = "The cluster endpoint"
+  value       = module.db_cluster.cluster_endpoint
+}
+
+output "database_url" {
+  description = "The URL used to connect to the cluster"
+  value       = "postgres://${module.db_cluster.cluster_master_username}:${module.db_cluster.cluster_master_password}@${module.db_cluster.cluster_endpoint}:${module.db_cluster.cluster_port}/${var.db_name}"
+}

--- a/terraform/postgres/outputs.tf
+++ b/terraform/postgres/outputs.tf
@@ -8,6 +8,11 @@ output "master_username" {
   value       = var.db_master_username
 }
 
+output "master_password_id" {
+  description = "The ID of the database master password in Secrets Manager"
+  value       = aws_secretsmanager_secret.db_master_password.id
+}
+
 output "rds_cluster_arn" {
   description = "The ARN of the cluster"
   value       = module.db_cluster.cluster_arn

--- a/terraform/postgres/password.tf
+++ b/terraform/postgres/password.tf
@@ -7,3 +7,38 @@ resource "random_password" "db_master_password" {
   length  = 16
   special = false
 }
+
+resource "aws_kms_key" "db_master_password" {
+  description         = "KMS key for the ${module.this.id} RDS cluster master password"
+  enable_key_rotation = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = data.aws_caller_identity.this.account_id
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_kms_alias" "db_master_password" {
+  name          = "alias/${module.this.id}-master-password"
+  target_key_id = aws_kms_key.db_master_password.id
+}
+
+resource "aws_secretsmanager_secret" "db_master_password" {
+  name       = "${module.this.id}-master-password"
+  kms_key_id = aws_kms_key.db_master_password.arn
+}
+
+resource "aws_secretsmanager_secret_version" "db_master_password" {
+  secret_id     = aws_secretsmanager_secret.db_master_password.id
+  secret_string = local.db_master_password
+}

--- a/terraform/postgres/password.tf
+++ b/terraform/postgres/password.tf
@@ -1,0 +1,9 @@
+locals {
+  db_master_password = var.db_master_password == "" ? random_password.db_master_password[0].result : var.db_master_password
+}
+
+resource "random_password" "db_master_password" {
+  count   = var.db_master_password == "" ? 1 : 0
+  length  = 16
+  special = false
+}

--- a/terraform/postgres/terraform.tf
+++ b/terraform/postgres/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.7"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}

--- a/terraform/postgres/variables.tf
+++ b/terraform/postgres/variables.tf
@@ -41,6 +41,20 @@ variable "max_capacity" {
 }
 
 #-------------------------------------------------------------------------------
+# Logs
+
+variable "cloudwatch_logs_key_arn" {
+  description = "The ARN of the KMS key to use for encrypting CloudWatch logs"
+  type        = string
+}
+
+variable "cloudwatch_retention_in_days" {
+  description = "The number of days to retain CloudWatch logs for the DB instance"
+  type        = number
+  default     = 14
+}
+
+#-------------------------------------------------------------------------------
 # Networking
 
 variable "vpc_id" {
@@ -48,15 +62,12 @@ variable "vpc_id" {
   type        = string
 }
 
-variable "ingress_cidr_blocks" {
-  description = "The CIDR blocks to allow ingress from"
+variable "subnet_ids" {
+  description = "The IDs of the subnets to deploy to"
   type        = list(string)
 }
 
-#-------------------------------------------------------------------------------
-# Naming
-
-variable "app_name" {
-  description = "App name for naming resources"
-  type        = string
+variable "ingress_cidr_blocks" {
+  description = "The CIDR blocks to allow ingress from"
+  type        = list(string)
 }

--- a/terraform/postgres/variables.tf
+++ b/terraform/postgres/variables.tf
@@ -1,0 +1,62 @@
+#-------------------------------------------------------------------------------
+# Database configuration
+
+variable "db_name" {
+  description = "The name of the default database in the cluster"
+  type        = string
+  default     = "postgres"
+}
+
+variable "db_master_username" {
+  description = "The username for the master DB user"
+  type        = string
+  default     = "pgadmin"
+}
+
+variable "db_master_password" {
+  description = "The password for the master DB user"
+  type        = string
+  default     = ""
+}
+
+#-------------------------------------------------------------------------------
+# Capacity
+
+variable "instances" {
+  description = "The number of database instances to create"
+  type        = number
+  default     = 1
+}
+
+variable "min_capacity" {
+  description = "The minimum capacity for the Aurora cluster (in Aurora Capacity Units)"
+  type        = number
+  default     = 2
+}
+
+variable "max_capacity" {
+  description = "The maximum capacity for the Aurora cluster (in Aurora Capacity Units)"
+  type        = number
+  default     = 10
+}
+
+#-------------------------------------------------------------------------------
+# Networking
+
+variable "vpc_id" {
+  description = "The VPC ID to create the security group in"
+  type        = string
+}
+
+variable "ingress_cidr_blocks" {
+  description = "The CIDR blocks to allow ingress from"
+  type        = list(string)
+}
+
+#-------------------------------------------------------------------------------
+# Naming
+
+variable "app_name" {
+  description = "App name for naming resources"
+  type        = string
+}

--- a/terraform/res_db.tf
+++ b/terraform/res_db.tf
@@ -1,0 +1,23 @@
+module "db_context" {
+  source  = "app.terraform.io/wallet-connect/label/null"
+  version = "0.3.2"
+  context = module.this
+
+  attributes = [
+    "db"
+  ]
+}
+
+module "postgres" {
+  source     = "./postgres"
+  context    = module.db_context
+  attributes = ["postgres"]
+
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.intra_subnets
+  ingress_cidr_blocks = module.vpc.private_subnets_cidr_blocks
+
+  cloudwatch_logs_key_arn = aws_kms_key.cloudwatch_logs.arn
+
+  depends_on = [aws_iam_role.application_role]
+}

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -57,6 +57,7 @@ module "ecs" {
   identity_cache_endpoint_read  = module.redis.endpoint
   identity_cache_endpoint_write = module.redis.endpoint
   ofac_blocked_countries        = var.ofac_blocked_countries
+  postgres_url = module.postgres.database_url
 
   # Providers
   infura_project_id = var.infura_project_id

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -57,7 +57,7 @@ module "ecs" {
   identity_cache_endpoint_read  = module.redis.endpoint
   identity_cache_endpoint_write = module.redis.endpoint
   ofac_blocked_countries        = var.ofac_blocked_countries
-  postgres_url = module.postgres.database_url
+  postgres_url                  = module.postgres.database_url
 
   # Providers
   infura_project_id = var.infura_project_id

--- a/terraform/res_postgres.tf
+++ b/terraform/res_postgres.tf
@@ -1,0 +1,7 @@
+module "postgres" {
+  source = "./postgres"
+
+  app_name            = local.app_name
+  vpc_id              = module.vpc.vpc_id
+  ingress_cidr_blocks = [module.vpc.vpc_cidr_block]
+}

--- a/terraform/res_postgres.tf
+++ b/terraform/res_postgres.tf
@@ -1,7 +1,0 @@
-module "postgres" {
-  source = "./postgres"
-
-  app_name            = local.app_name
-  vpc_id              = module.vpc.vpc_id
-  ingress_cidr_blocks = [module.vpc.vpc_cidr_block]
-}


### PR DESCRIPTION
# Description

This PR adds the Amazon RDS Postgres engine to the AWS terraform configuration and exposes the `database_uri` to the ECS cluster instances to connect to the Database.

Resolves #405 

## Stacked PRs list 🏗️

* 0: add Postgres to Terraform config #415 
* 1: add Postgres 16 to the docker-compose #410
* 2: add sql schema and migrations for the ENS #411 
* 3: scaffold sqlx and add `RPC_PROXY_POSTGRES_URI` env variable #412
* 4: implement database helpers #413
* 5: enable database functional tests #414 
* 6: add lookup handlers #417 
* 7: name registration handler #418 
* 8: profile names integration tests #419

## How Has This Been Tested?

Tested only by the `terraform plan`.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
