### PR TITLE
feat: add lookup handlers

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -9,6 +9,7 @@ pub mod history;
 pub mod identity;
 pub mod metrics;
 pub mod portfolio;
+pub mod profile;
 pub mod proxy;
 pub mod ws_proxy;
 

--- a/src/handlers/profile/lookup.rs
+++ b/src/handlers/profile/lookup.rs
@@ -1,0 +1,45 @@
+use {
+    super::super::HANDLER_TASK_METRICS,
+    crate::{database::helpers::get_name_and_addresses_by_name, error::RpcError, state::AppState},
+    axum::{
+        extract::{Path, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    hyper::StatusCode,
+    sqlx::Error as SqlxError,
+    std::sync::Arc,
+    tracing::log::error,
+    wc::future::FutureExt,
+};
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    name: Path<String>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, name)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("profile"))
+        .await
+}
+
+#[tracing::instrument(skip(state))]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> Result<Response, RpcError> {
+    match get_name_and_addresses_by_name(name, &state.postgres).await {
+        Ok(response) => Ok(Json(response).into_response()),
+        Err(e) => match e {
+            SqlxError::RowNotFound => {
+                // Respond with a "Not Found" status code if name was found
+                let not_found_response = (StatusCode::NOT_FOUND, "Name is not registered");
+                Ok(not_found_response.into_response())
+            }
+            _ => {
+                // Handle other types of errors
+                error!("Failed to lookup name: {}", e);
+                return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
+            }
+        },
+    }
+}

--- a/src/handlers/profile/mod.rs
+++ b/src/handlers/profile/mod.rs
@@ -1,0 +1,2 @@
+pub mod lookup;
+pub mod reverse;

--- a/src/handlers/profile/reverse.rs
+++ b/src/handlers/profile/reverse.rs
@@ -1,0 +1,62 @@
+use {
+    super::super::HANDLER_TASK_METRICS,
+    crate::{
+        database::helpers::{get_name_and_addresses_by_name, get_names_by_address},
+        error::RpcError,
+        state::AppState,
+    },
+    axum::{
+        extract::{Path, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    hyper::StatusCode,
+    std::sync::Arc,
+    tracing::log::error,
+    wc::future::FutureExt,
+};
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    address: Path<String>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, address)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("reverse_lookup"))
+        .await
+}
+
+#[tracing::instrument(skip(state))]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    Path(address): Path<String>,
+) -> Result<Response, RpcError> {
+    let names = match get_names_by_address(address, &state.postgres).await {
+        Ok(names) => names,
+        Err(e) => {
+            error!("Error on get names by address: {}", e);
+            return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
+        }
+    };
+
+    if names.is_empty() {
+        // Respond with a "Not Found" status code if no name was found for the address
+        let not_found_response = (StatusCode::NOT_FOUND, "No rigistered names for the address");
+        return Ok(not_found_response.into_response());
+    }
+
+    let mut result = Vec::new();
+    for name in names {
+        match get_name_and_addresses_by_name(name.name, &state.postgres).await {
+            Ok(response) => result.push(response),
+            Err(e) => {
+                // Unexpected behavior when looking up a name for an address
+                error!(
+                    "Unexpected behavior when looking up a name for an address: {}",
+                    e
+                );
+                return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
+            }
+        }
+    }
+    Ok(Json(result).into_response())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,16 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/account/:address/portfolio",
             get(handlers::portfolio::handler),
         )
+        // Forward lookup
+        .route(
+            "/v1/profile/account/:name",
+            get(handlers::profile::lookup::handler),
+        )
+        // Reverse lookup
+        .route(
+            "/v1/profile/reverse/:address",
+            get(handlers::profile::reverse::handler),
+        )
         .route_layer(tracing_and_metrics_layer)
         .route("/health", get(handlers::health::handler))
         .layer(cors);


### PR DESCRIPTION
# Description

This PR implements the following lookup handlers according to the [SPEC](https://github.com/WalletConnect/walletconnect-specs/pull/179):
* Forward lookup `/v1/profile/account/:name`: name -> addresses,
* Reverse lookup `/v1/profile/reverse/:address`: address -> names.

Resolves #405

## Stacked PRs list 🏗️

* 0: add Postgres to Terraform config #415 
* 1: add Postgres 16 to the docker-compose #410
* 2: add sql schema and migrations for the ENS #411 
* 3: scaffold sqlx and add `RPC_PROXY_POSTGRES_URI` env variable #412
* 4: implement database helpers #413
* 5: enable database functional tests #414 
* 6: add lookup handlers #417 
* 7: name registration handler #418 
* 8: profile names integration tests #419

## How Has This Been Tested?

Run local integration tests in #419

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
