### PR TITLE
feat: name registration handler

### DIFF
--- a/src/handlers/profile/mod.rs
+++ b/src/handlers/profile/mod.rs
@@ -1,2 +1,87 @@
+use {
+    ethers::types::H160,
+    serde::{Deserialize, Serialize},
+    std::str::FromStr,
+};
+
 pub mod lookup;
+pub mod register;
 pub mod reverse;
+
+/// Payload to register domain name that should be serialized to JSON
+/// and passed to the RegisterRequest.message
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RegisterPayload {
+    /// Name to register
+    pub name: String,
+    /// Address
+    pub address: String,
+    /// Unixtime
+    pub timestamp: u64,
+}
+/// Data structure representing a request to register a name
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RegisterRequest {
+    /// Serialized JSON register payload
+    pub message: String,
+    /// Message signature
+    pub signature: String,
+    /// Address
+    pub address: String,
+}
+
+#[tracing::instrument]
+pub fn verify_message_signature(
+    message: &str,
+    signature: &str,
+    owner: &H160,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let prefixed_message = format!("\x19Ethereum Signed Message:\n{}{}", message.len(), message);
+    let message_hash = ethers::core::utils::keccak256(prefixed_message.clone());
+    let message_hash = ethers::types::H256::from_slice(&message_hash);
+
+    let sign = ethers::types::Signature::from_str(signature)?;
+    match sign.verify(message_hash, *owner) {
+        Ok(_) => Ok(true),
+        Err(_) => Ok(false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, ethers::types::H160, std::str::FromStr};
+
+    #[test]
+    fn test_verify_message_signature_valid() {
+        let message = "test message signature";
+        let signature = "0x660739ee06920c5f55fbaf0da4f435faaa9c55e2c9da303c50c4b3865191d67e5002a0b10eb0f89bae66823f7f07415ea9d5bbb607ee61ac98b7f2a0a44fcb5c1b";
+        let owner = H160::from_str("0xAff392551773CCb2574fAE23195CC3aFDBe98d18").unwrap();
+
+        let result = verify_message_signature(message, signature, &owner);
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_verify_message_signature_json() {
+        let message = r#"{\"test\":\"some my text\"}"#;
+        let signature = "0x2fe0b640b4036c9c97911e6f22c72a2c934f1d67db02948055c0e0c84dbf4f2b33c2f8c4b000642735dbf5d1c96ba48ccd2a998324c9e4cb7bb776f0c95ee2fc1b";
+        let owner = H160::from_str("0xAff392551773CCb2574fAE23195CC3aFDBe98d18").unwrap();
+
+        let result = verify_message_signature(message, signature, &owner);
+        assert!(result.is_ok());
+        println!("result: {:?}", result);
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_verify_message_signature_invalid() {
+        let message = "wrong message signature";
+        let signature = "0x660739ee06920c5f55fbaf0da4f435faaa9c55e2c9da303c50c4b3865191d67e5002a0b10eb0f89bae66823f7f07415ea9d5bbb607ee61ac98b7f2a0a44fcb5c1b"; // The signature of the message
+        let owner = H160::from_str("0xAff392551773CCb2574fAE23195CC3aFDBe98d18").unwrap(); // The Ethereum address of the signer
+
+        let result = verify_message_signature(message, signature, &owner);
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+}

--- a/src/handlers/profile/register.rs
+++ b/src/handlers/profile/register.rs
@@ -1,0 +1,142 @@
+use {
+    super::{
+        super::HANDLER_TASK_METRICS,
+        verify_message_signature,
+        RegisterPayload,
+        RegisterRequest,
+    },
+    crate::{
+        database::{
+            helpers::{get_name_and_addresses_by_name, insert_name},
+            types::{Address, SupportedNamespaces},
+        },
+        error::RpcError,
+        state::AppState,
+    },
+    axum::{
+        body::Bytes,
+        extract::{Path, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    hyper::StatusCode,
+    sqlx::Error as SqlxError,
+    std::{collections::HashMap, str::FromStr, sync::Arc},
+    tracing::log::{error, info},
+    wc::future::FutureExt,
+};
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    name: Path<String>,
+    body: Bytes,
+) -> Result<Response, RpcError> {
+    handler_internal(state, name, body)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("profile_register"))
+        .await
+}
+
+#[tracing::instrument(skip(state))]
+pub async fn handler_internal(
+    state: State<Arc<AppState>>,
+    Path(name): Path<String>,
+    body: Bytes,
+) -> Result<Response, RpcError> {
+    // Check the request body format
+    let register_request = match serde_json::from_slice::<RegisterRequest>(&body) {
+        Ok(register_request_payload) => register_request_payload,
+        Err(e) => {
+            info!("Failed to deserialize register request: {}", e);
+            return Ok((StatusCode::BAD_REQUEST, "").into_response());
+        }
+    };
+
+    let raw_payload = &register_request.message;
+    let payload = match serde_json::from_str::<RegisterPayload>(raw_payload) {
+        Ok(payload) => payload,
+        Err(e) => {
+            info!("Failed to deserialize register payload: {}", e);
+            return Ok((StatusCode::BAD_REQUEST, "").into_response());
+        }
+    };
+
+    if payload.name != name {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            "Name in payload and path are not equal",
+        )
+            .into_response());
+    }
+
+    if payload.address != register_request.address {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            "Address in payload request and message are not equal",
+        )
+            .into_response());
+    }
+
+    // Check is name already registered
+    if get_name_and_addresses_by_name(name.clone(), &state.postgres.clone())
+        .await
+        .is_ok()
+    {
+        info!("Registration request for registered name {}", name.clone());
+        return Ok((StatusCode::BAD_REQUEST, "Name is already registered").into_response());
+    };
+
+    // TODO: Check the timestamp within 5-10 minutes ttl
+
+    let owner = match ethers::types::H160::from_str(&register_request.address) {
+        Ok(owner) => owner,
+        Err(e) => {
+            info!("Failed to parse H160 address: {}", e);
+            return Ok((StatusCode::BAD_REQUEST, "Invalid H160 address format").into_response());
+        }
+    };
+
+    // Check the signature
+    let sinature_check =
+        match verify_message_signature(raw_payload, &register_request.signature, &owner) {
+            Ok(sinature_check) => sinature_check,
+            Err(e) => {
+                info!("Invalid signature: {}", e);
+                return Ok((
+                    StatusCode::UNAUTHORIZED,
+                    "Invalid signature or message format",
+                )
+                    .into_response());
+            }
+        };
+    if !sinature_check {
+        return Ok((StatusCode::UNAUTHORIZED, "Signature verification error").into_response());
+    }
+
+    // Register (insert) a new domain with address
+    let addresses = vec![Address {
+        namespace: SupportedNamespaces::Eip155,
+        chain_id: None,
+        address: register_request.address,
+        created_at: None,
+    }];
+    let insert_result = insert_name(name.clone(), HashMap::new(), addresses, &state.postgres).await;
+    if let Err(e) = insert_result {
+        error!("Failed to insert new name: {}", e);
+        return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
+    }
+
+    // Return the registered name and addresses
+    match get_name_and_addresses_by_name(name, &state.postgres.clone()).await {
+        Ok(response) => Ok(Json(response).into_response()),
+        Err(e) => match e {
+            SqlxError::RowNotFound => {
+                error!("New registered name is not found in the database: {}", e);
+                Ok((StatusCode::INTERNAL_SERVER_ERROR, "Name is not registered").into_response())
+            }
+            _ => {
+                error!("Error on lookup new registered name: {}", e);
+                Ok((StatusCode::INTERNAL_SERVER_ERROR, "Name is not registered").into_response())
+            }
+        },
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,11 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/profile/account/:name",
             get(handlers::profile::lookup::handler),
         )
+        // Register
+        .route(
+            "/v1/profile/account/:name",
+            post(handlers::profile::register::handler),
+        )
         // Reverse lookup
         .route(
             "/v1/profile/reverse/:address",


### PR DESCRIPTION
# Description

This PR implements the name registration handler according to the [registration SPEC](https://github.com/WalletConnect/walletconnect-specs/pull/184).

The `verify_message_signature` function is introduced to verify the Ethereum message signature.

Resolves #405

## Stacked PRs list 🏗️

* 0: add Postgres to Terraform config #415 
* 1: add Postgres 16 to the docker-compose #410
* 2: add sql schema and migrations for the ENS #411 
* 3: scaffold sqlx and add `RPC_PROXY_POSTGRES_URI` env variable #412
* 4: implement database helpers #413
* 5: enable database functional tests #414 
* 6: add lookup handlers #417 
* 7: name registration handler #418 
* 8: profile names integration tests #419

## How Has This Been Tested?

Local unit tests for the `verify_message_signature` function.
Run the integration tests at https://github.com/WalletConnect/blockchain-api/pull/419

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
