### PR TITLE
fix(o11y): dashboards broken

### DIFF
--- a/terraform/monitoring/panels/ecs/availability.libsonnet
+++ b/terraform/monitoring/panels/ecs/availability.libsonnet
@@ -48,7 +48,7 @@ local error_alert(vars) = alert.new(
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = '(1-(sum(rate(http_call_counter_total{code=~"5.+"}[5m])) or vector(0))/(sum(rate(http_call_counter_total{}[5m]))))*100' % [vars.environment, vars.environment],
+      expr        = '(1-(sum(rate(http_call_counter_total{code=~"5.+"}[5m])) or vector(0))/(sum(rate(http_call_counter_total{}[5m]))))*100',
       refId       = "availability",
       exemplar    = false,
     ))

--- a/terraform/monitoring/panels/ecs/availability.libsonnet
+++ b/terraform/monitoring/panels/ecs/availability.libsonnet
@@ -48,7 +48,7 @@ local error_alert(vars) = alert.new(
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = '(1-(sum(rate(http_call_counter_total{aws_ecs_task_family="%s_rpc-proxy",code=~"5.+"}[5m])) or vector(0))/(sum(rate(http_call_counter_total{aws_ecs_task_family="%s_rpc-proxy"}[5m]))))*100' % [vars.environment, vars.environment],
+      expr        = '(1-(sum(rate(http_call_counter_total{code=~"5.+"}[5m])) or vector(0))/(sum(rate(http_call_counter_total{}[5m]))))*100' % [vars.environment, vars.environment],
       refId       = "availability",
       exemplar    = false,
     ))

--- a/terraform/monitoring/panels/proxy/calls.libsonnet
+++ b/terraform/monitoring/panels/proxy/calls.libsonnet
@@ -14,7 +14,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr          = 'sum by(chain_id) (increase(rpc_call_counter_total{}[5m]))' % vars.environment,
+      expr          = 'sum by(chain_id) (increase(rpc_call_counter_total{}[5m]))',
       exemplar      = false,
       legendFormat  = '__auto',
     ))

--- a/terraform/monitoring/panels/proxy/calls.libsonnet
+++ b/terraform/monitoring/panels/proxy/calls.libsonnet
@@ -14,7 +14,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr          = 'sum by(chain_id) (increase(rpc_call_counter_total{aws_ecs_task_family="%s_rpc-proxy"}[5m]))' % vars.environment,
+      expr          = 'sum by(chain_id) (increase(rpc_call_counter_total{}[5m]))' % vars.environment,
       exemplar      = false,
       legendFormat  = '__auto',
     ))

--- a/terraform/monitoring/panels/proxy/http_codes.libsonnet
+++ b/terraform/monitoring/panels/proxy/http_codes.libsonnet
@@ -21,7 +21,7 @@ local _configuration = defaults.configuration.timeseries
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr          = 'sum by (code)(rate(http_call_counter_total{}[5m]))' % vars.environment,
+      expr          = 'sum by (code)(rate(http_call_counter_total{}[5m]))',
       exemplar      = false,
       legendFormat  = '__auto',
     ))

--- a/terraform/monitoring/panels/proxy/http_codes.libsonnet
+++ b/terraform/monitoring/panels/proxy/http_codes.libsonnet
@@ -21,7 +21,7 @@ local _configuration = defaults.configuration.timeseries
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr          = 'sum by (code)(rate(http_call_counter_total{aws_ecs_task_family=\"%s_rpc-proxy\"}[5m]))' % vars.environment,
+      expr          = 'sum by (code)(rate(http_call_counter_total{}[5m]))' % vars.environment,
       exemplar      = false,
       legendFormat  = '__auto',
     ))


### PR DESCRIPTION
# Description

Some widgets were broken as the `ecs task family` name changed. We can remove that entirely as the prometheus datasources this data comes from is already scoped to specific domains.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
