### PR TITLE
fix: change ECS role Prometheus permission to read+write access

### DIFF
--- a/terraform/ecs/cluster_iam.tf
+++ b/terraform/ecs/cluster_iam.tf
@@ -81,7 +81,7 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_write_policy" {
 
 resource "aws_iam_role_policy_attachment" "prometheus_write_policy" {
   role       = data.aws_iam_role.ecs_task_execution_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusFullAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "ssm_read_only_policy" {

--- a/terraform/ecs/cluster_iam.tf
+++ b/terraform/ecs/cluster_iam.tf
@@ -81,7 +81,12 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_write_policy" {
 
 resource "aws_iam_role_policy_attachment" "prometheus_write_policy" {
   role       = data.aws_iam_role.ecs_task_execution_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusFullAccess"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "prometheus_read_policy" {
+  role       = data.aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusQueryAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "ssm_read_only_policy" {


### PR DESCRIPTION
# Description

Change the IAM policy used by ECS role to access Prometheus to read and write access to unblock weight updates.

## How Has This Been Tested?

N/A

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
