### PR TITLE
fix: ECS task name in version retrieval

### DIFF
--- a/.github/workflows/event_release.yml
+++ b/.github/workflows/event_release.yml
@@ -48,6 +48,7 @@ jobs:
     uses: WalletConnect/ci_workflows/.github/workflows/release.yml@0.1.2
     secrets: inherit
     with:
+      task-name: 'wc-${{ vars.AWS_REGION }}-prod-blockchain-api'
       infra-changed: ${{ needs.paths_filter.outputs.infra == 'true' }}
       app-changed: ${{ needs.paths_filter.outputs.app == 'true' }}
 


### PR DESCRIPTION
# Description

Fix the ECS task name in the version retrieval of the release flow.

## How Has This Been Tested?

Checked the call to `release-get_deployed_version` separately.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
