### PR TITLE
chore: adding `node_modules` to the `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,8 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+#---------------------------------------
+# NPM/Yarn
+
+node_modules/


### PR DESCRIPTION
# Description

This PR adds the `node_modules` directory to the `.gitignore`.
We are using the `yarn` for our integration/validation tests, which causes creating a `node_modules` directory with the yarn cache.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
