### PR TITLE
chore(ci): fixing production validation url

### DIFF
--- a/.github/workflows/dispatch_validate.yml
+++ b/.github/workflows/dispatch_validate.yml
@@ -54,4 +54,4 @@ jobs:
     secrets: inherit
     with:
       stage: prod
-      stage-url: https://staging.${{ vars.SUBDOMAIN_NAME }}.walletconnect.com/health
+      stage-url: https://${{ vars.SUBDOMAIN_NAME }}.walletconnect.com/health


### PR DESCRIPTION
# Description

This PR fixes the prod URL for the validation CI workflow. The validation was only using the staging URL for the prod as well.

## How Has This Been Tested?

The workflow can be tested by invoking the CI validation workflow.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
