### PR TITLE
chore(terraform): downgrade rds aurora version

### DIFF
--- a/terraform/postgres/main.tf
+++ b/terraform/postgres/main.tf
@@ -13,7 +13,7 @@ module "db_cluster" {
   name               = module.this.id
   database_name      = var.db_name
   engine             = "aurora-postgresql"
-  engine_version     = "16.1"
+  engine_version     = "15.5"
   engine_mode        = "provisioned"
   ca_cert_identifier = "rds-ca-ecc384-g1"
   instance_class     = "db.serverless"


### PR DESCRIPTION
# Description

This PR changes the rds aurora postgres engine version `16` -> `15.5`.

Despite its presence in the documentation, the new engine version [is not present](https://github.com/WalletConnect/blockchain-api/actions/runs/7260015231/job/19778451096#step:9:582) in the engines list for the region yet. 

To get the list of the available engine versions
`aws rds describe-db-engine-versions --engine aurora-postgresql --query '*[].[EngineVersion]' --output text --region eu-central-1`

Version `15.5` is the latest in the list.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
