### PR TITLE
chore(docker): removing `migrations` directory from the ignoring paths

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 !Cargo.*
 !.git
 !bin
+!migrations


### PR DESCRIPTION
# Description

This PR removes ignoring of the `migrations` directory from the ignoring paths in the `.dockerignore`.
This should fix the [build error where the `migrations` directory is required for the sqlx](https://github.com/WalletConnect/blockchain-api/actions/runs/7260672209/job/19782875952#step:8:1594).

The `migrations` directory should be copied into the container after this change by [copying all files in the Dockefile](https://github.com/WalletConnect/blockchain-api/blob/master/Dockerfile#L53).

## How Has This Been Tested?

Built the local Docker image by running `docker build . -t rpc `.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
