### PR TITLE
fix: retrieve client IP from `X-Forwarded-For` header

### DIFF
--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -5,6 +5,7 @@ use {
         error::RpcError,
         handlers::HistoryQueryParams,
         state::AppState,
+        utils::network,
     },
     axum::{
         body::Bytes,
@@ -72,7 +73,9 @@ async fn handler_internal(
 
         let (country, continent, region) = state
             .analytics
-            .lookup_geo_data(connect_info.0.ip())
+            .lookup_geo_data(
+                network::get_forwarded_ip(headers).unwrap_or_else(|| connect_info.0.ip()),
+            )
             .map(|geo| (geo.country, geo.continent, geo.region))
             .unwrap_or((None, None, None));
 

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -7,6 +7,7 @@ use {
         json_rpc::{JsonRpcError, JsonRpcResponse},
         project::ProjectDataError,
         state::AppState,
+        utils::network,
     },
     async_trait::async_trait,
     axum::{
@@ -99,7 +100,9 @@ async fn handler_internal(
 
         let (country, continent, region) = state
             .analytics
-            .lookup_geo_data(connect_info.0.ip())
+            .lookup_geo_data(
+                network::get_forwarded_ip(headers).unwrap_or_else(|| connect_info.0.ip()),
+            )
             .map(|geo| (geo.country, geo.continent, geo.region))
             .unwrap_or((None, None, None));
 

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -1,6 +1,12 @@
 use {
     super::HANDLER_TASK_METRICS,
-    crate::{analytics::MessageInfo, error::RpcError, handlers::RpcQueryParams, state::AppState},
+    crate::{
+        analytics::MessageInfo,
+        error::RpcError,
+        handlers::RpcQueryParams,
+        state::AppState,
+        utils::network,
+    },
     axum::{
         body::Bytes,
         extract::{ConnectInfo, MatchedPath, Query, State},
@@ -60,7 +66,7 @@ async fn handler_internal(
     if let Ok(rpc_request) = serde_json::from_slice(&body) {
         let (country, continent, region) = state
             .analytics
-            .lookup_geo_data(addr.ip())
+            .lookup_geo_data(network::get_forwarded_ip(headers).unwrap_or_else(|| addr.ip()))
             .map(|geo| (geo.country, geo.continent, geo.region))
             .unwrap_or((None, None, None));
 

--- a/src/utils/network.rs
+++ b/src/utils/network.rs
@@ -1,4 +1,4 @@
-use {ipnet::IpNet, std::net::IpAddr};
+use {axum::http::HeaderMap, ipnet::IpNet, std::net::IpAddr};
 
 #[derive(thiserror::Error, Debug)]
 pub enum NetworkInterfaceError {
@@ -64,4 +64,12 @@ fn is_public_ip_addr(addr: IpAddr) -> bool {
     });
 
     RESERVED_NETWORKS.iter().all(|range| !range.contains(&addr))
+}
+
+pub fn get_forwarded_ip(headers: HeaderMap) -> Option<IpAddr> {
+    headers
+        .get("X-Forwarded-For")
+        .and_then(|header| header.to_str().ok())
+        .and_then(|header| header.split(',').next())
+        .and_then(|client_ip| client_ip.trim().parse::<IpAddr>().ok())
 }

--- a/terraform/context.tf
+++ b/terraform/context.tf
@@ -1,3 +1,13 @@
+module "stage" {
+  source  = "app.terraform.io/wallet-connect/stage/null"
+  version = "0.1.0"
+  project = "blockchain"
+}
+
+locals {
+  stage = module.stage.stage
+}
+
 module "this" {
   source  = "app.terraform.io/wallet-connect/label/null"
   version = "0.3.2"

--- a/terraform/inputs.tf
+++ b/terraform/inputs.tf
@@ -13,7 +13,7 @@ data "terraform_remote_state" "datalake" {
   config = {
     organization = "wallet-connect"
     workspaces = {
-      name = "datalake-${local.is_dev ? "staging" : local.stage}"
+      name = "datalake-${module.stage.dev ? "staging" : local.stage}"
     }
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,24 +5,7 @@ resource "random_pet" "this" {
 }
 
 locals {
-  ecr_repository_url = local.is_dev ? data.terraform_remote_state.org.outputs.accounts.sdlc.dev.ecr-urls.blockchain : data.terraform_remote_state.org.outputs.accounts.wl.blockchain[local.stage].ecr-url
-
-  stage = lookup({
-    "blockchain-wl-staging" = "staging",
-    "blockchain-wl-prod"    = "prod",
-    "blockchain-wl-dev"     = "dev",
-    "blockchain-staging"    = "staging",
-    "blockchain-prod"       = "prod",
-    "wl-staging"            = "staging",
-    "wl-prod"               = "prod",
-    "wl-dev"                = "dev",
-    "staging"               = "staging",
-    "prod"                  = "prod",
-  }, terraform.workspace, terraform.workspace)
-
-  is_dev     = local.stage == "dev"     #tflint-ignore: terraform_unused_declarations
-  is_staging = local.stage == "staging" #tflint-ignore: terraform_unused_declarations
-  is_prod    = local.stage == "prod"    #tflint-ignore: terraform_unused_declarations
+  ecr_repository_url = module.stage.dev ? data.terraform_remote_state.org.outputs.accounts.sdlc.dev.ecr-urls.blockchain : data.terraform_remote_state.org.outputs.accounts.wl.blockchain[local.stage].ecr-url
 }
 
 resource "aws_kms_key" "cloudwatch_logs" {

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -31,8 +31,8 @@ module "ecs" {
   ecr_repository_url        = local.ecr_repository_url
   image_version             = var.image_version
   task_execution_role_name  = aws_iam_role.application_role.name
-  task_cpu                  = local.is_prod ? 2048 : 256
-  task_memory               = local.is_prod ? 8192 : 512
+  task_cpu                  = module.stage.prod ? 2048 : 256
+  task_memory               = module.stage.prod ? 8192 : 512
   autoscaling_desired_count = var.app_autoscaling_desired_count
   autoscaling_min_capacity  = var.app_autoscaling_min_capacity
   autoscaling_max_capacity  = var.app_autoscaling_max_capacity


### PR DESCRIPTION
# Description

Since the migration moved the service behind an ALB, we cannot retrieve the client IP directly for geo-location.
This leverages the `X-Forwarded-For` header injected by the LB instead.

## How Has This Been Tested?

Unit tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
