### PR TITLE
chore(docker): moving `COPY` before the `cargo chef cook`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,9 @@ ARG                 BUILD_PROFILE="--profile ${PROFILE}"
 WORKDIR             /app
 # Cache dependancies
 COPY --from=plan    /app/recipe.json recipe.json
-RUN                 cargo chef cook ${BUILD_PROFILE} --recipe-path recipe.json 
-# Build the local binary
 COPY                . .
+# Build the local binary
+RUN                 cargo chef cook ${BUILD_PROFILE} --recipe-path recipe.json 
 RUN                 cargo build --bin rpc-proxy ${RELEASE}
 
 ################################################################################


### PR DESCRIPTION
# Description

This PR moving the `COPY . .` before the `cargo chef cook` to copy necessary build files before the build itself, since the `cargo chef cook` invokes the build process.
This should fix the [not found error on build](https://github.com/WalletConnect/blockchain-api/actions/runs/7260672209/job/19782875952#step:8:1594) for the `migrations`.

## How Has This Been Tested?

Successfully [built from this PRs branch](https://github.com/WalletConnect/blockchain-api/actions/runs/7263994163/job/19790969549#step:8:772).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
