### PR TITLE
chore(ci): fix the ECS task name

### DIFF
--- a/.github/workflows/event_release.yml
+++ b/.github/workflows/event_release.yml
@@ -48,7 +48,7 @@ jobs:
     uses: WalletConnect/ci_workflows/.github/workflows/release.yml@0.1.2
     secrets: inherit
     with:
-      task-name: 'wc-${{ vars.AWS_REGION }}-prod-blockchain-api'
+      task-name: 'wc-${{ vars.AWS_REGION }}-prod-blockchain'
       infra-changed: ${{ needs.paths_filter.outputs.infra == 'true' }}
       app-changed: ${{ needs.paths_filter.outputs.app == 'true' }}
 


### PR DESCRIPTION
# Description

This PR changes the release event ECS task name to fix the ECS task name inconsistency.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
