### PR TITLE
chore: removing `ens_allowlist`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,27 +1202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4002,7 +3981,6 @@ dependencies = [
  "bytes",
  "cerberus",
  "chrono",
- "csv",
  "deadpool-redis",
  "derive_more",
  "dotenv",
@@ -4019,7 +3997,6 @@ dependencies = [
  "pnet_datalink",
  "prometheus-http-query",
  "rand",
- "reqwest",
  "rmp-serde",
  "serde",
  "serde-aux",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,10 +68,6 @@ ethers = { version = "2.0.7", git = "https://github.com/gakonst/ethers-rs" } # u
 bytes = "1.4.0"
 sha256 = "1.2.2"
 
-# ENS Allowlist Remove later
-reqwest = { version = "0.11", features = ["json"] }
-csv = "1"
-
 [dev-dependencies]
 jsonrpc = "0.14.0"
 test-context = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@ use {
         ZoraConfig,
     },
     error::RpcResult,
-    ethers::types::{Address, H160},
     http::Request,
     hyper::{header::HeaderName, http, server::conn::AddrIncoming, Body, Server},
     providers::{
@@ -45,13 +44,10 @@ use {
     },
     sqlx::postgres::PgPoolOptions,
     std::{
-        collections::HashMap,
-        error::Error,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         sync::Arc,
         time::Duration,
     },
-    tap::TapFallible,
     tower::ServiceBuilder,
     tower_http::{
         cors::{Any, CorsLayer},
@@ -132,15 +128,6 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         )
     });
 
-    // TODO: This should be removed in a near future
-    let ens_allowlist = read_google_sheet()
-        .await
-        .tap_err(|e| {
-            warn!("Failed to read google sheet with {}", e);
-        })
-        .ok();
-    info!(?ens_allowlist, "loaded ens allowlist");
-
     let postgres = PgPoolOptions::new()
         .max_connections(config.postgres.max_connections.into())
         .connect(&config.postgres.uri)
@@ -155,7 +142,6 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         registry,
         identity_cache,
         analytics,
-        ens_allowlist,
     );
 
     let port = state.config.server.port;
@@ -357,33 +343,4 @@ async fn get_geoip_resolver(config: &Config, s3_client: &S3Client) -> Option<Arc
         info!("geoip lookup is disabled");
         None
     }
-}
-
-async fn read_google_sheet() -> Result<HashMap<H160, String>, Box<dyn Error>> {
-    // URL to access Google Sheet in CSV format
-    let url = "https://docs.google.com/spreadsheets/d/1YqR9S3YEmYn53It6lPOlZ-wrAmMNwxRtzimzcDBAhzE/gviz/tq?tqx=out:csv";
-
-    // Send GET request to the URL
-    let response = reqwest::get(url).await?.text().await?;
-
-    // Create a CSV reader assuming the first row is headers
-    let mut rdr = csv::ReaderBuilder::new()
-        .has_headers(true)
-        .from_reader(response.as_bytes());
-
-    // Create a HashMap to store the address-name pairs
-    let mut data_map: HashMap<H160, String> = HashMap::new();
-
-    // Iterate over each record
-    for result in rdr.records() {
-        let record = result?;
-        // Assuming first column is address and second column is name
-        if let (Some(address), Some(name)) = (record.get(0), record.get(1)) {
-            if let Ok(address) = address.parse::<Address>() {
-                data_map.insert(address, name.to_string());
-            }
-        }
-    }
-
-    Ok(data_map)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,9 +11,8 @@ use {
         utils::build::CompileInfo,
     },
     cerberus::project::ProjectData,
-    ethers::types::H160,
     sqlx::PgPool,
-    std::{collections::HashMap, sync::Arc},
+    std::sync::Arc,
     tap::TapFallible,
     tracing::info,
 };
@@ -27,7 +26,6 @@ pub struct AppState {
     pub identity_cache: Option<Arc<dyn KeyValueStorage<IdentityResponse>>>,
     pub analytics: RPCAnalytics,
     pub compile_info: CompileInfo,
-    pub ens_allowlist: Option<HashMap<H160, String>>,
     /// Service instance uptime measurement
     pub uptime: std::time::Instant,
 }
@@ -41,7 +39,6 @@ pub fn new_state(
     registry: Registry,
     identity_cache: Option<Arc<dyn KeyValueStorage<IdentityResponse>>>,
     analytics: RPCAnalytics,
-    ens_allowlist: Option<HashMap<H160, String>>,
 ) -> AppState {
     AppState {
         config,
@@ -52,7 +49,6 @@ pub fn new_state(
         identity_cache,
         analytics,
         compile_info: CompileInfo {},
-        ens_allowlist,
         uptime: std::time::Instant::now(),
     }
 }


### PR DESCRIPTION
# Description

This PR removes the usage of the Google Sheets ens allowlist and removes the `ens_allowlist` from the state and dependencies. 
ENS Allowlist was used for the demo and don't need anymore.

## How Has This Been Tested?

Start the server by `cargo run` and run the integration tests by `RPC_URL=http://localhost:3000 yarn integration`.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
