### PR TITLE
fix(ci): fixing the `stage-url` variable for the validation

### DIFF
--- a/.github/workflows/dispatch_validate.yml
+++ b/.github/workflows/dispatch_validate.yml
@@ -45,7 +45,7 @@ jobs:
     secrets: inherit
     with:
       stage: staging
-      stage-url: https://staging.${{ vars.SUBDOMAIN_NAME }}.walletconnect.com/health
+      stage-url: https://staging.${{ vars.SUBDOMAIN_NAME }}.walletconnect.com
 
   validate-prod:
     name: Validate - Prod
@@ -54,4 +54,4 @@ jobs:
     secrets: inherit
     with:
       stage: prod
-      stage-url: https://${{ vars.SUBDOMAIN_NAME }}.walletconnect.com/health
+      stage-url: https://${{ vars.SUBDOMAIN_NAME }}.walletconnect.com

--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -12,7 +12,7 @@ on:
         description: 'the URL of the environment'
         required: true
         type: string
-        default: https://${{ vars.SUBDOMAIN_NAME }}.walletconnect.com/health
+        default: https://${{ vars.SUBDOMAIN_NAME }}.walletconnect.com
 
 permissions:
   contents: read
@@ -29,7 +29,7 @@ jobs:
       url: ${{ inputs.stage-url }}
     steps:
       - name: health-check
-        run: curl "${{ inputs.stage-url }}"
+        run: curl "${{ inputs.stage-url }}/health"
 
   integration-tests:
     name: Integration Tests - ${{ inputs.stage }}


### PR DESCRIPTION
# Description

This PR changes the `stage-url` variable to be the host URL without an additional route. 

By passing the variable with the `/health` route the integration tests fail because the testing routes were appended to the `/health` and the server returns `404` as a result. 

As a fix, we should pass the host URL without the `/health` route and append it only where the health check occurs.

## How Has This Been Tested?

Pass the [Validation CI action from this PR branch](https://github.com/WalletConnect/blockchain-api/actions/runs/7275661793/job/19823933620#step:5:11).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
