### PR TITLE
chore(docker): Revert: moving `COPY` before the `cargo chef cook`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,9 @@ ARG                 BUILD_PROFILE="--profile ${PROFILE}"
 WORKDIR             /app
 # Cache dependancies
 COPY --from=plan    /app/recipe.json recipe.json
-COPY                . .
-# Build the local binary
 RUN                 cargo chef cook ${BUILD_PROFILE} --recipe-path recipe.json 
+# Build the local binary
+COPY                . .
 RUN                 cargo build --bin rpc-proxy ${RELEASE}
 
 ################################################################################


### PR DESCRIPTION
# Description

This PR reverts the #429 changes because it affects the `cargo-chief` caching strategy and doesn't provide any fix. 
To fix the [image build error](https://github.com/WalletConnect/blockchain-api/actions/runs/7260672209/job/19782875952#step:8:1594), #427 changes was enough.

## How Has This Been Tested?

Successfully built the image by the CI and `docker build .` with this reverted commit.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
