### PR TITLE
fix: use task name instead of image name in ECS deploy on `staging`

### DIFF
--- a/.github/workflows/sub-cd.yml
+++ b/.github/workflows/sub-cd.yml
@@ -36,7 +36,7 @@ jobs:
       deploy-infra: ${{ inputs.deploy-infra }}
       deploy-app: ${{ inputs.deploy-app && !inputs.deploy-infra }}
       version: ${{ inputs.version }}
-      task-name: ${{ vars.IMAGE_NAME }}
+      task-name: ${{ vars.TASK_NAME }}
       stage: staging
       stage-url: https://staging.${{ vars.SUBDOMAIN_NAME }}.walletconnect.com/health
       tf-variables: |


### PR DESCRIPTION
# Description

Use the correct name in the staging CD flow (image name and task name are not the same for this repo).

## How Has This Been Tested?

N/A

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
