### PR TITLE
fix(ci): removing `/health` from the sub-cd validation

### DIFF
--- a/.github/workflows/sub-cd.yml
+++ b/.github/workflows/sub-cd.yml
@@ -50,7 +50,7 @@ jobs:
     secrets: inherit
     with:
       stage: staging
-      stage-url: https://staging.${{ vars.SUBDOMAIN_NAME }}.walletconnect.com/health
+      stage-url: https://staging.${{ vars.SUBDOMAIN_NAME }}.walletconnect.com
 
   cd-prod:
     name: Prod
@@ -76,4 +76,4 @@ jobs:
     secrets: inherit
     with:
       stage: prod
-      stage-url: https://${{ vars.SUBDOMAIN_NAME }}.walletconnect.com/health
+      stage-url: https://${{ vars.SUBDOMAIN_NAME }}.walletconnect.com


### PR DESCRIPTION
# Description

This PR removes the `/health` route from the validation CI workflow, as it causes the [404 error](https://github.com/WalletConnect/blockchain-api/actions/runs/7287794249/job/19859609569#step:5:6) because we are adding routes inside of the integration tests.

## How Has This Been Tested?

Running the CD workflow from the branch.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
