### PR TITLE
fix(ci): adding Postgres requirements to the `sub-validate`

### DIFF
--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -35,6 +35,18 @@ jobs:
     name: Integration Tests - ${{ inputs.stage }}
     runs-on:
       group: ${{ vars.RUN_GROUP }}
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     environment:
       name: ${{ inputs.stage }}
       url: ${{ inputs.stage-url }}
@@ -53,6 +65,7 @@ jobs:
         uses: WalletConnect/actions-rs/cargo@1.0.0
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
+          RPC_PROXY_POSTGRES_URI: 'postgres://postgres:root@localhost:5432/postgres'
           RPC_URL: ${{ inputs.stage-url }}
         with:
           command: test


### PR DESCRIPTION
# Description

This PR adds the Postgres container and `RPC_PROXY_POSTGRES_URI` to the CI `sub-validate` testing to fix the functional tests run.

## How Has This Been Tested?

[Successfully passed the Validate](https://github.com/WalletConnect/blockchain-api/actions/runs/7288508632/job/19861438226) tests from this branch. 

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
