### PR TITLE
fix: back to string-based address in transactions list

### DIFF
--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -46,7 +46,9 @@ async fn handler_internal(
     body: Bytes,
 ) -> Result<Response, RpcError> {
     let project_id = query.project_id.clone();
-    let address_hash = H160::from_str(&address).map_err(|_| RpcError::IdentityInvalidAddress)?;
+
+    // Checking for the H160 address correctness
+    H160::from_str(&address).map_err(|_| RpcError::IdentityInvalidAddress)?;
 
     state.validate_project_access(&project_id).await?;
     let latency_tracker_start = std::time::SystemTime::now();
@@ -55,7 +57,7 @@ async fn handler_internal(
             state
                 .providers
                 .coinbase_pay_provider
-                .get_transactions(address_hash, body.clone(), query.clone().0)
+                .get_transactions(address.clone(), body.clone(), query.clone().0)
                 .await
                 .tap_err(|e| {
                     error!("Failed to call coinbase transactions history with {}", e);
@@ -67,7 +69,7 @@ async fn handler_internal(
         state
             .providers
             .history_provider
-            .get_transactions(address_hash, body.clone(), query.0.clone())
+            .get_transactions(address.clone(), body.clone(), query.0.clone())
             .await
             .tap_err(|e| {
                 error!("Failed to call transactions history with {}", e);
@@ -93,7 +95,7 @@ async fn handler_internal(
             .unwrap_or((None, None, None));
 
         state.analytics.history_lookup(HistoryLookupInfo::new(
-            address_hash.to_string(),
+            address,
             project_id,
             response.data.len(),
             latency_tracker,

--- a/src/providers/coinbase.rs
+++ b/src/providers/coinbase.rs
@@ -11,7 +11,6 @@ use {
     },
     async_trait::async_trait,
     axum::{body::Bytes, http::method},
-    ethers::types::H160,
     futures_util::StreamExt,
     hyper::Client,
     hyper_tls::HttpsConnector,
@@ -58,14 +57,15 @@ impl HistoryProvider for CoinbaseProvider {
     #[tracing::instrument(skip(self, body, params), fields(provider = "Coinbase"))]
     async fn get_transactions(
         &self,
-        address: H160,
+        address: String,
         body: Bytes,
         params: HistoryQueryParams,
     ) -> RpcResult<HistoryResponseBody> {
         let base = format!(
-            "https://pay.coinbase.com/api/v1/buy/user/{:#x}/transactions",
+            "https://pay.coinbase.com/api/v1/buy/user/{}/transactions",
             &address
         );
+
         let mut url = Url::parse(&base).map_err(|_| RpcError::HistoryParseCursorError)?;
         url.query_pairs_mut().append_pair("page_size", "50");
 
@@ -117,7 +117,7 @@ impl HistoryProvider for CoinbaseProvider {
                     mined_at: f.created_at,
                     nonce: 1, // TODO: get nonce from somewhere
                     sent_from: "Coinbase".to_string(),
-                    sent_to: format!("{:#x}", address),
+                    sent_to: address.clone(),
                     status: f.status,
                 },
                 transfers: None,

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -12,7 +12,6 @@ use {
     },
     axum::response::Response,
     axum_tungstenite::WebSocketUpgrade,
-    ethers::types::H160,
     hyper::http::HeaderValue,
     rand::{distributions::WeightedIndex, prelude::Distribution, rngs::OsRng},
     std::{fmt::Debug, hash::Hash, sync::Arc},
@@ -430,7 +429,7 @@ pub trait RateLimited {
 pub trait HistoryProvider: Send + Sync + Debug {
     async fn get_transactions(
         &self,
-        address: H160,
+        address: String,
         body: hyper::body::Bytes,
         params: HistoryQueryParams,
     ) -> RpcResult<HistoryResponseBody>;

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -14,7 +14,6 @@ use {
     },
     async_trait::async_trait,
     axum::body::Bytes,
-    ethers::types::H160,
     futures_util::StreamExt,
     hyper::Client,
     hyper_tls::HttpsConnector,
@@ -152,12 +151,12 @@ impl HistoryProvider for ZerionProvider {
     #[tracing::instrument(skip(self, body, params), fields(provider = "Zerion"))]
     async fn get_transactions(
         &self,
-        address: H160,
+        address: String,
         body: Bytes,
         params: HistoryQueryParams,
     ) -> RpcResult<HistoryResponseBody> {
         let base = format!(
-            "https://api.zerion.io/v1/wallets/{:#x}/transactions/?",
+            "https://api.zerion.io/v1/wallets/{}/transactions/?",
             &address
         );
         let mut url = Url::parse(&base).map_err(|_| RpcError::HistoryParseCursorError)?;


### PR DESCRIPTION
# Description

This PR reverting to use the string-based `address` argument in `get_transactions`. Coinbase Pay SDK is case-sensitive when passing the address to get the transactions list. When we are using the `H160` type we don't know what exactly address type was used: checksum (mixed case) or not when passing it to the Coinbase API later in the function. To fix this we need to preserve the original address string.

As a security validation for the address format, the [check for the address correct format is used](https://github.com/WalletConnect/blockchain-api/pull/439/files#diff-7a388f4d3745ebf0928c4212d627020683b440683be6530f2c885293f475e146R49) in the handler.

## How Has This Been Tested?

1. Start the server with `cargo run`.
2. Get the transactions list with the `onramp=coinbase` parameter.
3. Expect the list of the onramp transactions.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
