### PR TITLE
chore(refactor): making history-related structures unite, arranging structures

### DIFF
--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -1,9 +1,8 @@
 use {
-    super::HANDLER_TASK_METRICS,
+    super::{RpcQueryParams, HANDLER_TASK_METRICS},
     crate::{
         analytics::IdentityLookupInfo,
         error::RpcError,
-        handlers::RpcQueryParams,
         json_rpc::{JsonRpcError, JsonRpcResponse},
         project::ProjectDataError,
         state::AppState,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,5 +1,4 @@
 use {
-    crate::providers::zerion::ZerionTransactionTransfer,
     serde::{Deserialize, Serialize},
     wc::metrics::TaskMetrics,
 };
@@ -25,62 +24,4 @@ pub struct RpcQueryParams {
 #[derive(Serialize)]
 pub struct SuccessResponse {
     status: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct PortfolioQueryParams {
-    pub project_id: String,
-    pub currency: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct PortfolioResponseBody {
-    pub data: Vec<PortfolioPosition>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct PortfolioPosition {
-    pub id: String,
-    pub name: String,
-    pub symbol: String,
-}
-
-// TODO: https://developers.zerion.io/reference/listwallettransactions
-#[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct HistoryQueryParams {
-    pub currency: Option<String>,
-    pub project_id: String,
-    pub cursor: Option<String>,
-    pub onramp: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct HistoryResponseBody {
-    pub data: Vec<HistoryTransaction>,
-    pub next: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct HistoryTransaction {
-    pub id: String,
-    pub metadata: HistoryTransactionMetadata,
-    pub transfers: Option<Vec<ZerionTransactionTransfer>>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct HistoryTransactionMetadata {
-    pub operation_type: String,
-    pub hash: String,
-    pub mined_at: String,
-    pub sent_from: String,
-    pub sent_to: String,
-    pub status: String,
-    pub nonce: usize,
 }

--- a/src/handlers/portfolio.rs
+++ b/src/handlers/portfolio.rs
@@ -1,5 +1,5 @@
 use {
-    super::{PortfolioQueryParams, HANDLER_TASK_METRICS},
+    super::HANDLER_TASK_METRICS,
     crate::{error::RpcError, state::AppState},
     axum::{
         body::Bytes,
@@ -9,11 +9,33 @@ use {
     },
     ethers::abi::Address,
     hyper::HeaderMap,
+    serde::{Deserialize, Serialize},
     std::{net::SocketAddr, sync::Arc},
     tap::TapFallible,
     tracing::log::error,
     wc::future::FutureExt,
 };
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PortfolioQueryParams {
+    pub project_id: String,
+    pub currency: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PortfolioResponseBody {
+    pub data: Vec<PortfolioPosition>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PortfolioPosition {
+    pub id: String,
+    pub name: String,
+    pub symbol: String,
+}
 
 pub async fn handler(
     state: State<Arc<AppState>>,

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -1,12 +1,6 @@
 use {
-    super::HANDLER_TASK_METRICS,
-    crate::{
-        analytics::MessageInfo,
-        error::RpcError,
-        handlers::RpcQueryParams,
-        state::AppState,
-        utils::network,
-    },
+    super::{RpcQueryParams, HANDLER_TASK_METRICS},
+    crate::{analytics::MessageInfo, error::RpcError, state::AppState, utils::network},
     axum::{
         body::Bytes,
         extract::{ConnectInfo, MatchedPath, Query, State},

--- a/src/providers/coinbase.rs
+++ b/src/providers/coinbase.rs
@@ -2,7 +2,7 @@ use {
     super::HistoryProvider,
     crate::{
         error::{RpcError, RpcResult},
-        handlers::{
+        handlers::history::{
             HistoryQueryParams,
             HistoryResponseBody,
             HistoryTransaction,

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,26 +2,31 @@ use {
     self::{coinbase::CoinbaseProvider, zerion::ZerionProvider},
     crate::{
         env::ProviderConfig,
-        error::RpcError,
+        error::{RpcError, RpcResult},
         handlers::{
-            HistoryQueryParams,
-            HistoryResponseBody,
-            PortfolioQueryParams,
-            PortfolioResponseBody,
+            history::{HistoryQueryParams, HistoryResponseBody},
+            portfolio::{PortfolioQueryParams, PortfolioResponseBody},
+            RpcQueryParams,
         },
     },
+    async_trait::async_trait,
     axum::response::Response,
     axum_tungstenite::WebSocketUpgrade,
     hyper::http::HeaderValue,
     rand::{distributions::WeightedIndex, prelude::Distribution, rngs::OsRng},
-    std::{fmt::Debug, hash::Hash, sync::Arc},
+    std::{
+        collections::HashMap,
+        fmt::{Debug, Display},
+        hash::Hash,
+        sync::Arc,
+    },
     tracing::{info, log::warn},
     wc::metrics::TaskMetrics,
 };
 
 mod base;
 mod binance;
-pub mod coinbase;
+mod coinbase;
 mod infura;
 mod omnia;
 mod pokt;
@@ -31,11 +36,6 @@ pub mod zerion;
 mod zksync;
 mod zora;
 
-use {
-    crate::{error::RpcResult, handlers::RpcQueryParams},
-    async_trait::async_trait,
-    std::{collections::HashMap, fmt::Display},
-};
 pub use {
     base::BaseProvider,
     binance::BinanceProvider,

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -3,13 +3,14 @@ use {
     crate::{
         error::{RpcError, RpcResult},
         handlers::{
-            HistoryQueryParams,
-            HistoryResponseBody,
-            HistoryTransaction,
-            HistoryTransactionMetadata,
-            PortfolioPosition,
-            PortfolioQueryParams,
-            PortfolioResponseBody,
+            history::{
+                HistoryQueryParams,
+                HistoryResponseBody,
+                HistoryTransaction,
+                HistoryTransactionMetadata,
+                HistoryTransactionTransfer,
+            },
+            portfolio::{PortfolioPosition, PortfolioQueryParams, PortfolioResponseBody},
         },
     },
     async_trait::async_trait,
@@ -92,58 +93,7 @@ pub struct ZerionTransactionAttributes {
     pub sent_to: String,
     pub status: String,
     pub nonce: usize,
-    pub transfers: Vec<ZerionTransactionTransfer>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub struct ZerionTransactionTransfer {
-    pub fungible_info: Option<ZerionTransactionFungibleInfo>,
-    pub nft_info: Option<ZerionTransactionNFTInfo>,
-    pub direction: String,
-    pub quantity: ZerionTransactionTransferQuantity,
-    pub value: Option<f64>,
-    pub price: Option<f64>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-pub struct ZerionTransactionTransferQuantity {
-    pub numeric: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-pub struct ZerionTransactionFungibleInfo {
-    pub name: Option<String>,
-    pub symbol: Option<String>,
-    pub icon: Option<ZerionTransactionURLItem>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-pub struct ZerionTransactionURLItem {
-    pub url: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-pub struct ZerionTransactionURLandContentTypeItem {
-    pub url: String,
-    pub content_type: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-pub struct ZerionTransactionNFTContent {
-    pub preview: Option<ZerionTransactionURLandContentTypeItem>,
-    pub detail: Option<ZerionTransactionURLandContentTypeItem>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-pub struct ZerionTransactionNFTInfo {
-    pub name: Option<String>,
-    pub content: Option<ZerionTransactionNFTContent>,
-    pub flags: ZerionTransactionNFTInfoFlags,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-pub struct ZerionTransactionNFTInfoFlags {
-    pub is_spam: bool,
+    pub transfers: Vec<HistoryTransactionTransfer>,
 }
 
 #[async_trait]

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -2,7 +2,7 @@ use {
     crate::{context::ServerContext, utils::send_jsonrpc_request, JSONRPC_VERSION},
     hyper::{Body, Client, Method, Request, StatusCode},
     hyper_tls::HttpsConnector,
-    rpc_proxy::handlers::HistoryResponseBody,
+    rpc_proxy::handlers::history::HistoryResponseBody,
     test_context::test_context,
 };
 


### PR DESCRIPTION
# Description

To extend our history endpoint with new providers and data it's a good point to move from the Zerion-specific structures and make the response structure owned by the `history` handler itself. 

This PR introduces the following refactorings:
* Moving the `history` handler response-related structures from the Zerion provider to the `history` handler itself.
* Moving handler-related structures to corresponding handler files.

The PR #442 is created on top of this refactoring.

## How Has This Been Tested?

Passing CI and integration tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
