### PR TITLE
feat(onramp): exposing name and quantity from Coinbase

### DIFF
--- a/src/providers/coinbase.rs
+++ b/src/providers/coinbase.rs
@@ -6,7 +6,10 @@ use {
             HistoryQueryParams,
             HistoryResponseBody,
             HistoryTransaction,
+            HistoryTransactionFungibleInfo,
             HistoryTransactionMetadata,
+            HistoryTransactionTransfer,
+            HistoryTransactionTransferQuantity,
         },
     },
     async_trait::async_trait,
@@ -50,6 +53,13 @@ pub struct CoinbaseTransaction {
     pub transaction_id: String,
     pub tx_hash: String,
     pub created_at: String,
+    pub purchase_amount: CoinbasePurchaseAmount,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct CoinbasePurchaseAmount {
+    pub value: String,
+    pub currency: String,
 }
 
 #[async_trait]
@@ -120,7 +130,20 @@ impl HistoryProvider for CoinbaseProvider {
                     sent_to: address.clone(),
                     status: f.status,
                 },
-                transfers: None,
+                transfers: Some(vec![HistoryTransactionTransfer {
+                    fungible_info: Some(HistoryTransactionFungibleInfo {
+                        name: Some(f.purchase_amount.currency.clone()),
+                        symbol: Some(f.purchase_amount.currency),
+                        icon: None,
+                    }),
+                    direction: "in".to_string(),
+                    quantity: HistoryTransactionTransferQuantity {
+                        numeric: f.purchase_amount.value,
+                    },
+                    nft_info: None,
+                    value: None,
+                    price: None,
+                }]),
             })
             .collect();
 


### PR DESCRIPTION
# Description

According to our UI requirements we need to expose the name and quantity for the onramp transactions history item.
This PR introduces changes to the Coinbase transactions provider to expose the name and quantity.

## How Has This Been Tested?

1. Passing the CI and integration tests.
2. Locally:
  * Start the server by `cargo run`
  * Get the response for the onramp transactions from the Coinbase provider: `curl -v 'http://localhost:3000/v1/account/xxx/history?projectId=xxx&onramp=coinbase' | jq .`
  * The expected result:
    * `data.transfers.quantity.numeric` is fulfilled,
    * `data.transfers.fungible_info.name` is fulfilled.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
