### PR TITLE
fix(providers): changing the mainnet URL for zksync

### DIFF
--- a/src/env/zksync.rs
+++ b/src/env/zksync.rs
@@ -47,7 +47,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         (
             "eip155:324".into(),
             (
-                "https://zksync2-mainnet.zksync.io".into(),
+                "https://mainnet.era.zksync.io".into(),
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),


### PR DESCRIPTION
# Description

This PR changes the mainnet URL for the ZkSync to the `mainnet.era.zksync.io` to fix the rate-limiting issue and update it according to the [zksync docs](https://era.zksync.io/docs/dev/building-on-zksync/interacting.html#connecting-to-zksync-era-on-metamask).

## How Has This Been Tested?

1. Start the server locally by `cargo run`.
2. Request the RPC for the `eip155:324`:
```
curl 'http://localhost:3000/v1/?chainId=eip155:324&projectId=XXX'  --data-raw '{"jsonrpc":"2.0","id":0,"method":"eth_getBalance","params":["0x262f4f5DC82ad9b803680F07Da7d901D4F71d8D1","latest"]}'
```
3. The expected response is:
```
{"jsonrpc":"2.0","result":"0x0","id":0}
```

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
