### PR TITLE
fix(grafana): adding history requests panels

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -100,6 +100,11 @@ dashboard.new(
   row.new('Database'),
     panels.db.redis_cpu_memory(ds, vars)             { gridPos: pos._2 },
 
+  row.new('History (Zerion) Metrics'),
+    panels.history.requests(ds, vars)               { gridPos: pos_short._3 },
+    panels.history.latency(ds, vars)                { gridPos: pos_short._3 },
+    panels.history.availability(ds, vars)           { gridPos: pos_short._3 },
+
   row.new('Identity (ENS) Metrics'),
     panels.identity.requests(ds, vars)               { gridPos: pos_short._2 },
     panels.identity.availability(ds, vars)           { gridPos: pos_short._2 },

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -39,4 +39,10 @@
     cache:                (import 'identity/cache.libsonnet'              ).new,
     usage:                (import 'identity/usage.libsonnet'              ).new,
   },
+
+  history: {
+    availability:         (import 'history/availability.libsonnet'        ).new,
+    requests:             (import 'history/requests.libsonnet'            ).new,
+    latency:              (import 'history/latency.libsonnet'             ).new,
+  },
 }


### PR DESCRIPTION
# Description

This PR adds Grafana panels for the history transactions that were lost during the migration in [commit 50f30](https://github.com/WalletConnect/blockchain-api/commit/50f30e96eecc7468d192d3e58b68e398afcc61fb#diff-d7597af1e267afe8593b70399773e045d6702a595ea85348ef041ab0e31f5b45).

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
