### PR TITLE
chore(monitoring): making history metrics per provider

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -395,21 +395,27 @@ impl Metrics {
             )]);
     }
 
-    pub fn add_history_lookup(&self) {
+    pub fn add_history_lookup(&self, provider: &ProviderKind) {
         self.history_lookup_counter
-            .add(&otel::Context::new(), 1, &[]);
+            .add(&otel::Context::new(), 1, &[otel::KeyValue::new(
+                "provider",
+                provider.to_string(),
+            )]);
     }
 
-    pub fn add_history_lookup_success(&self) {
+    pub fn add_history_lookup_success(&self, provider: &ProviderKind) {
         self.history_lookup_success_counter
-            .add(&otel::Context::new(), 1, &[]);
+            .add(&otel::Context::new(), 1, &[otel::KeyValue::new(
+                "provider",
+                provider.to_string(),
+            )]);
     }
 
-    pub fn add_history_lookup_latency(&self, latency: Duration) {
+    pub fn add_history_lookup_latency(&self, provider: &ProviderKind, latency: Duration) {
         self.history_lookup_latency_tracker.record(
             &otel::Context::new(),
             latency.as_secs_f64(),
-            &[],
+            &[otel::KeyValue::new("provider", provider.to_string())],
         );
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -278,6 +278,8 @@ pub enum ProviderKind {
     Omniatech,
     Base,
     Zora,
+    Zerion,
+    Coinbase,
 }
 
 impl Display for ProviderKind {
@@ -291,6 +293,8 @@ impl Display for ProviderKind {
             ProviderKind::Omniatech => "Omniatech",
             ProviderKind::Base => "Base",
             ProviderKind::Zora => "Zora",
+            ProviderKind::Zerion => "Zerion",
+            ProviderKind::Coinbase => "Coinbase",
         })
     }
 }
@@ -306,6 +310,8 @@ impl ProviderKind {
             "Omniatech" => Some(Self::Omniatech),
             "Base" => Some(Self::Base),
             "Zora" => Some(Self::Zora),
+            "Zerion" => Some(Self::Zerion),
+            "Coinbase" => Some(Self::Coinbase),
             _ => None,
         }
     }

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -100,7 +100,7 @@ dashboard.new(
   row.new('Database'),
     panels.db.redis_cpu_memory(ds, vars)             { gridPos: pos._2 },
 
-  row.new('History (Zerion) Metrics'),
+  row.new('History Metrics'),
     panels.history.requests(ds, vars)               { gridPos: pos_short._3 },
     panels.history.latency(ds, vars)                { gridPos: pos_short._3 },
     panels.history.availability(ds, vars)           { gridPos: pos_short._3 },

--- a/terraform/monitoring/panels/history/availability.libsonnet
+++ b/terraform/monitoring/panels/history/availability.libsonnet
@@ -19,8 +19,9 @@ local targets   = grafana.targets;
         )
     )
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = '(sum(rate(history_lookup_success_counter_total{}[$__rate_interval])) / sum(rate(history_lookup_counter_total{}[$__rate_interval]))) * 100',
-      refId       = "availability",
+      datasource    = ds.prometheus,
+      expr          = '(sum by(provider) (rate(history_lookup_success_counter_total{}[$__rate_interval])) / sum by(provider) (rate(history_lookup_counter_total{}[$__rate_interval]))) * 100',
+      exemplar      = false,
+      legendFormat  = '__auto',
     ))
 }

--- a/terraform/monitoring/panels/history/latency.libsonnet
+++ b/terraform/monitoring/panels/history/latency.libsonnet
@@ -21,8 +21,8 @@ local _configuration = defaults.configuration.timeseries
 
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
-      expr          = 'sum(rate(history_lookup_latency_tracker_sum[$__rate_interval])) / sum(rate(history_lookup_latency_tracker_count[$__rate_interval]))',
-      refId         = 'EndpointLatency',
-      legendFormat  = 'Endpoint',
+      expr          = 'sum by(provider) (rate(history_lookup_latency_tracker_sum[$__rate_interval])) / sum by(provider) (rate(history_lookup_latency_tracker_count[$__rate_interval]))',
+      exemplar      = false,
+      legendFormat  = '__auto',
     ))
 }

--- a/terraform/monitoring/panels/history/requests.libsonnet
+++ b/terraform/monitoring/panels/history/requests.libsonnet
@@ -14,8 +14,8 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
-      expr          = 'sum(rate(history_lookup_counter_total{}[$__rate_interval]))',
-      refId         = "Requests",
-      legendFormat  = "Requests",
+      expr          = 'sum by(provider) (rate(history_lookup_counter_total{}[$__rate_interval]))',
+      exemplar      = false,
+      legendFormat  = '__auto',
     ))
 }


### PR DESCRIPTION
# Description

This PR changing the current metrics for the transactions history to be per-provider instead of sticking to the one (Zerion) as we have a few history providers now.
The following changes are made:
* `provider` tag is added to history metrics,
* `add_history_lookup` functions modified to pass the provider argument,
* Grafana panels modified to reflect per `provider` tag data.

## How Has This Been Tested?

Validation only-tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
