### PR TITLE
chore(logging): reducing logging for proxy requests

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -14,7 +14,10 @@ use {
         time::{Duration, SystemTime},
     },
     tap::TapFallible,
-    tracing::log::{error, warn},
+    tracing::{
+        log::{error, warn},
+        Span,
+    },
     wc::future::FutureExt,
 };
 
@@ -31,7 +34,7 @@ pub async fn handler(
         .await
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip_all, level = "debug")]
 async fn handler_internal(
     State(state): State<Arc<AppState>>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
@@ -50,6 +53,8 @@ async fn handler_internal(
         .providers
         .get_provider_for_chain_id(&chain_id)
         .ok_or(RpcError::UnsupportedChain(chain_id.clone()))?;
+
+    Span::current().record("provider", &provider.provider_kind().to_string());
 
     state.metrics.add_rpc_call(chain_id.clone());
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -135,7 +135,7 @@ impl ProviderRepository {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), level = "debug")]
     pub fn get_provider_for_chain_id(&self, chain_id: &str) -> Option<Arc<dyn RpcProvider>> {
         let Some(providers) = self.weight_resolver.get(chain_id) else {
             return None;
@@ -161,7 +161,7 @@ impl ProviderRepository {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), level = "debug")]
     pub fn get_ws_provider_for_chain_id(&self, chain_id: &str) -> Option<Arc<dyn RpcWsProvider>> {
         let Some(providers) = self.ws_weight_resolver.get(chain_id) else {
             return None;

--- a/src/state.rs
+++ b/src/state.rs
@@ -14,7 +14,7 @@ use {
     sqlx::PgPool,
     std::sync::Arc,
     tap::TapFallible,
-    tracing::warn,
+    tracing::info,
 };
 
 pub struct AppState {
@@ -68,7 +68,7 @@ impl AppState {
 
         project.validate_access(id, None).tap_err(|e| {
             self.metrics.add_rejected_project();
-            warn!("Denied access for project: {id}, with reason: {e}");
+            info!("Denied access for project: {id}, with reason: {e}");
         })?;
 
         Ok(project)
@@ -84,7 +84,7 @@ impl AppState {
 
         if !project.quota.is_valid {
             self.metrics.add_quota_limited_project();
-            warn!(
+            info!(
                 project_id = id,
                 max = project.quota.max,
                 current = project.quota.current,


### PR DESCRIPTION
# Description

This PR reduces the logging noise for the proxy requests.
The number of logs for the proxy request declined from 6 records to 2 per request to include just valuable info (what provider is used for the request_id) and dropped other logs to the `DEBUG` level. 
We can turn the all logs back if we start the server with the `DEBUG` logging level.

The `provider` span variable includes the used provider name is added to the handler span for proper tracing.

## How Has This Been Tested?

1. Start the server locally by `cargo run`
2. Run the proxy query e.g. `curl 'http://localhost:3000/v1/?chainId=eip155:324&projectId=XXX'  --data-raw '{"jsonrpc":"2.0","id":0,"method":"eth_getBalance","params":["0x262f4f5DC82ad9b803680F07Da7d901D4F71d8D1","latest"]}'`

The expected logs for the request:
```
INFO http-request{method=POST request_id="a507af27-e652-4bdd-849a-12e4b050c3ae" uri=/v1/?chainId=eip155:324&projectId=XXX}:proxy{chain_id="eip155:324" provider=zkSync}: rpc_proxy::providers::zksync: close time.busy=34.0ms time.idle=3.47s

INFO http-request{method=POST request_id="a507af27-e652-4bdd-849a-12e4b050c3ae" uri=/v1/?chainId=eip155:324&projectId=XXX}: rpc_proxy: close time.busy=36.8ms time.idle=3.47s
```

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
