### PR TITLE
chore(logging): reducing logging for identity requests

### DIFF
--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -52,7 +52,7 @@ pub async fn handler(
         .await
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip_all, level = "debug")]
 async fn handler_internal(
     state: State<Arc<AppState>>,
     connect_info: ConnectInfo<SocketAddr>,
@@ -137,7 +137,7 @@ impl IdentityLookupSource {
     }
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip_all, level = "debug")]
 async fn lookup_identity(
     address: H160,
     state: State<Arc<AppState>>,
@@ -181,7 +181,7 @@ async fn lookup_identity(
     Ok((IdentityLookupSource::Rpc, res))
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip_all, level = "debug")]
 async fn lookup_identity_rpc(
     address: H160,
     state: State<Arc<AppState>>,
@@ -235,7 +235,7 @@ async fn lookup_identity_rpc(
 
 const SELF_PROVIDER_ERROR_PREFIX: &str = "SelfProviderError: ";
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip_all, level = "debug")]
 async fn lookup_name(
     provider: &Provider<SelfProvider>,
     address: Address,
@@ -259,7 +259,7 @@ async fn lookup_name(
     )
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip_all, level = "debug")]
 async fn lookup_avatar(
     provider: &Provider<SelfProvider>,
     name: &str,


### PR DESCRIPTION
# Description

This PR reduces the logging noise for identity requests.
The number of logs for the identity request was declined twice, other logs were dropped to the `DEBUG` level.
We can turn all the logs back if we start the server with the `DEBUG` logging level.

The same is done in #447 for the proxy requests.

## How Has This Been Tested?

1. Start the server locally by `cargo run`
2. Call the identity request e.g. `curl 'http://localhost:3000/v1/identity/0xf3ea39310011333095CFCcCc7c4Ad74034CABA63?chainId=eip155%3A1&projectId=XXX'`

The expected result is that logging messages will reduced as twice.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
