### PR TITLE
feat: implementing on ramp url generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,6 +2416,16 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
@@ -2423,6 +2433,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "impl-codec"
@@ -4014,6 +4030,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "validator",
  "vergen",
  "wc",
 ]
@@ -5479,7 +5496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
  "serde",
 ]
@@ -5513,6 +5530,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "validator"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b92f40481c04ff1f4f61f304d61793c7b56ff76ac1469f1beb199b1445b253bd"
+dependencies = [
+ "idna 0.4.0",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
+dependencies = [
+ "if_chain",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2 1.0.70",
+ "quote 1.0.33",
+ "regex",
+ "syn 1.0.109",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_types"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
+dependencies = [
+ "proc-macro2 1.0.70",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tower = "0.4.11"
 tower-http = { version = "0.4.0", features = ["cors", "trace", "request-id", "util"] }
 jsonrpc = "0.14.0"
 async-tungstenite = { version = "0.20.0", features = ["tokio", "tokio-runtime", "tokio-native-tls"] }
-url = "2.2"
+url = "2.5"
 
 # Serialization
 rmp-serde = "1.1"
@@ -32,6 +32,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_piecewise_default = "0.2"
 serde-aux = "3.1"
+validator = { version = "0.16", features = ["derive"] }
 
 # Storage
 aws-config = "0.56"

--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -239,4 +239,40 @@ describe('blockchain api', () => {
       expect(first_address.address).toBe(address)
     })
   })
+
+  describe('Generators', () => {
+    it('onramp Pay SDK URL', async () => {
+      const expected_host = 'https://pay.coinbase.com/buy/select-asset';
+      const address = '0x1234567890123456789012345678901234567890';
+      const partnerUserId = 'someUserID';
+      const payload = {
+        partnerUserId,
+        destinationWallets:[{ address }],
+      };
+      let resp: any = await http.post(
+        `${baseUrl}/v1/generators/onrampurl?projectId=${projectId}`,
+        payload
+      )
+      expect(resp.status).toBe(200)
+      expect(typeof resp.data).toBe('object')
+      expect(typeof resp.data.url).toBe('string')
+      expect(resp.data.url).toContain(expected_host)
+      expect(resp.data.url).toContain(address)
+      expect(resp.data.url).toContain(partnerUserId)
+    })
+    it('onramp Pay SDK URL wrong payload', async () => {
+      const address = '0x1234567890123456789012345678901234567890';
+      const partnerUserId = 'someUserID';
+      // Creating the wrong payload
+      const payload = {
+        partner: partnerUserId,
+        someWallets:[{ address }],
+      };
+      let resp: any = await http.post(
+        `${baseUrl}/v1/generators/onrampurl?projectId=${projectId}`,
+        payload
+      )
+      expect(resp.status).toBe(400)
+    })
+  })
 })

--- a/src/handlers/generators/mod.rs
+++ b/src/handlers/generators/mod.rs
@@ -1,0 +1,9 @@
+use serde::Deserialize;
+
+pub mod onrampurl;
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GeneratorQueryParams {
+    pub project_id: String,
+}

--- a/src/handlers/generators/onrampurl.rs
+++ b/src/handlers/generators/onrampurl.rs
@@ -1,0 +1,228 @@
+use {
+    crate::{
+        error::RpcError,
+        handlers::{generators::GeneratorQueryParams, HANDLER_TASK_METRICS},
+        state::AppState,
+    },
+    axum::{
+        body::Bytes,
+        extract::{ConnectInfo, MatchedPath, Query, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    hyper::{HeaderMap, StatusCode},
+    serde::{Deserialize, Serialize},
+    std::{fmt, net::SocketAddr, sync::Arc},
+    tracing::log::{error, info},
+    url::Url,
+    validator::Validate,
+    wc::future::FutureExt,
+};
+
+/// Request according to the Coinbase Pay SDK `generateOnRampURL`
+/// https://docs.cloud.coinbase.com/pay-sdk/docs/generating-url#generateonrampurl-parameters
+#[derive(Debug, Serialize, Deserialize, Clone, Validate)]
+#[serde(rename_all = "camelCase")]
+pub struct OnRampURLRequest {
+    #[serde(skip_deserializing)]
+    pub app_id: String,
+    #[validate(length(min = 1))]
+    pub destination_wallets: Vec<DestinationWallet>,
+    #[validate(length(min = 32, max = 50))]
+    pub partner_user_id: String,
+    pub default_network: Option<String>,
+    pub preset_crypto_amount: Option<usize>,
+    pub preset_fiat_amount: Option<usize>,
+    pub default_experience: Option<ExperienceType>,
+    pub handling_requested_urls: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum ExperienceType {
+    Send,
+    Buy,
+}
+
+impl fmt::Display for ExperienceType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ExperienceType::Send => write!(f, "send"),
+            ExperienceType::Buy => write!(f, "buy"),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DestinationWallet {
+    pub address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blockchains: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assets: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supported_networks: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct OnRampURLResponse {
+    pub url: String,
+}
+
+const CB_PAY_HOST: &str = "https://pay.coinbase.com";
+const CB_PAY_PATH: &str = "/buy/select-asset";
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    addr: ConnectInfo<SocketAddr>,
+    query_params: Query<GeneratorQueryParams>,
+    path: MatchedPath,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, RpcError> {
+    handler_internal(state, addr, query_params, path, headers, body)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("onrampurl"))
+        .await
+}
+
+#[tracing::instrument(skip_all, level = "debug")]
+async fn handler_internal(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(_addr): ConnectInfo<SocketAddr>,
+    Query(query_params): Query<GeneratorQueryParams>,
+    _path: MatchedPath,
+    _headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, RpcError> {
+    state
+        .validate_project_access_and_quota(&query_params.project_id)
+        .await?;
+
+    let cb_app_id = match state.config.providers.clone().coinbase_app_id {
+        Some(app_id) => app_id,
+        None => {
+            error!("Coinbase App ID is not configured");
+            return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
+        }
+    };
+
+    let mut parameters = match serde_json::from_slice::<OnRampURLRequest>(&body) {
+        Ok(parameters) => parameters,
+        Err(e) => {
+            info!("Error deserializing request body: {}", e);
+            return Ok((
+                StatusCode::BAD_REQUEST,
+                "Error deserializing request body: {}",
+            )
+                .into_response());
+        }
+    };
+    parameters.app_id = cb_app_id;
+
+    let on_ramp_url = match generate_on_ramp_url(CB_PAY_HOST, CB_PAY_PATH, parameters) {
+        Ok(on_ramp_url) => on_ramp_url,
+        Err(e) => {
+            error!("Error generating on-ramp URL: {}", e);
+            return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
+        }
+    };
+
+    Ok(Json(OnRampURLResponse { url: on_ramp_url }).into_response())
+}
+
+pub fn generate_on_ramp_url(
+    host: &str,
+    path: &str,
+    parameters: OnRampURLRequest,
+) -> Result<String, anyhow::Error> {
+    let mut url = Url::parse(host)?;
+    url.set_path(path);
+
+    // Required parameters
+    url.query_pairs_mut()
+        .append_pair("appId", &parameters.app_id);
+    url.query_pairs_mut().append_pair(
+        "destinationWallets",
+        &serde_json::to_string(&parameters.destination_wallets)?,
+    );
+    url.query_pairs_mut()
+        .append_pair("partnerUserId", &parameters.partner_user_id);
+
+    // Optional parameters
+    if let Some(default_network) = parameters.default_network {
+        url.query_pairs_mut()
+            .append_pair("defaultNetwork", &default_network);
+    }
+    if let Some(preset_crypto_amount) = parameters.preset_crypto_amount {
+        url.query_pairs_mut()
+            .append_pair("presetCryptoAmount", &preset_crypto_amount.to_string());
+    }
+    if let Some(preset_fiat_amount) = parameters.preset_fiat_amount {
+        url.query_pairs_mut()
+            .append_pair("presetFiatAmount", &preset_fiat_amount.to_string());
+    }
+    if let Some(default_experience) = parameters.default_experience {
+        url.query_pairs_mut()
+            .append_pair("defaultExperience", &default_experience.to_string());
+    }
+    if let Some(handling_requested_urls) = parameters.handling_requested_urls {
+        url.query_pairs_mut().append_pair(
+            "handlingRequestedUrls",
+            &handling_requested_urls.to_string(),
+        );
+    }
+
+    Ok(url.to_string())
+}
+
+#[test]
+fn ensure_generate_on_ramp_url() {
+    let app_id = "CB_TEST_APP_ID".to_string();
+    let address = "0x1234567890123456789012345678901234567890".to_string();
+    let partner_user_id = "1234567890123456789012345678901234567890".to_string();
+
+    let parameters = OnRampURLRequest {
+        app_id: app_id.clone(),
+        destination_wallets: vec![DestinationWallet {
+            address: address.clone(),
+            blockchains: None,
+            assets: None,
+            supported_networks: None,
+        }],
+        partner_user_id: partner_user_id.clone(),
+        default_network: None,
+        preset_crypto_amount: None,
+        preset_fiat_amount: None,
+        default_experience: None,
+        handling_requested_urls: None,
+    };
+
+    let url =
+        Url::parse(&generate_on_ramp_url(CB_PAY_HOST, CB_PAY_PATH, parameters).unwrap()).unwrap();
+
+    assert_eq!(url.scheme(), "https");
+    assert_eq!(
+        url.host_str().unwrap(),
+        Url::parse(CB_PAY_HOST).unwrap().host_str().unwrap()
+    );
+    assert_eq!(url.path(), CB_PAY_PATH);
+    assert_eq!(
+        url.query_pairs().find(|(key, _)| key == "appId").unwrap().1,
+        app_id
+    );
+    assert_eq!(
+        url.query_pairs()
+            .find(|(key, _)| key == "destinationWallets")
+            .unwrap()
+            .1,
+        format!("[{{\"address\":\"{}\"}}]", address)
+    );
+    assert_eq!(
+        url.query_pairs()
+            .find(|(key, _)| key == "partnerUserId")
+            .unwrap()
+            .1,
+        partner_user_id
+    );
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -3,6 +3,7 @@ use {
     wc::metrics::TaskMetrics,
 };
 
+pub mod generators;
 pub mod health;
 pub mod history;
 pub mod identity;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,11 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/profile/reverse/:address",
             get(handlers::profile::reverse::handler),
         )
+        // Generators
+        .route(
+            "/v1/generators/onrampurl",
+            post(handlers::generators::onrampurl::handler),
+        )
         .route_layer(tracing_and_metrics_layer)
         .route("/health", get(handlers::health::handler))
         .layer(cors);


### PR DESCRIPTION
# Description

This PR implements the on ramp url generator based on the [SPEC](https://github.com/WalletConnect/walletconnect-specs/pull/190), [Coinbase js implementation](https://github.com/coinbase/cbpay-js/blob/08a4151a0aa3143e786876fcb7b993cc472a69d4/src/onramp/generateOnRampURL.ts#L9) and [generateOnRampURL](https://docs.cloud.coinbase.com/pay-sdk/docs/generating-url#generateonrampurl-parameters).

* Implements `OnRampURLRequest` according to the [SPEC](https://github.com/WalletConnect/walletconnect-specs/pull/190),
* Implements `generate_on_ramp_url` function to generate the URL according to the [coinbase js implementation](https://github.com/coinbase/cbpay-js/blob/08a4151a0aa3143e786876fcb7b993cc472a69d4/src/onramp/generateOnRampURL.ts#L9),
  * unit test for the `generate_on_ramp_url`,
* Implements new `/v1/generators/onrampurl` endpoint to handle the URL generation.
  * [integration tests](https://github.com/WalletConnect/blockchain-api/pull/453/commits/e8352ddcdb36222c2fffd8089260d651de9863f6) for the new endpoint.

## How Has This Been Tested?

### Integration tests:

* [Integration tests](https://github.com/WalletConnect/blockchain-api/pull/453/commits/e8352ddcdb36222c2fffd8089260d651de9863f6)

### Testing locally:

* Start the server locally by `cargo run`
* Request the on ramp URL by calling: 
```
curl -X POST http://localhost:3000/v1/generators/onrampurl\?projectId\=testestest \
-H "Content-Type: application/json" \
-d '{"partnerUserId":"a2961b","destinationWallets":[{"address":"0xaff392551773ccb2574fae23195cc3afdbe98d18"}]}'
```
* The expected server response is:
```
{
  "url":"https://pay.coinbase.com/buy/select-asset?appId=testcbappid&destinationWallets=%5B%7B%22address%22%3A%220xaff392551773ccb2574fae23195cc3afdbe98d18%22%7D%5D&partnerUserId=a2961b"
}
```

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
