### PR TITLE
fix(ci): passing the infura project id to integration tests

### DIFF
--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           RPC_PROXY_POSTGRES_URI: 'postgres://postgres:root@localhost:5432/postgres'
+          RPC_PROXY_INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
           RPC_URL: ${{ inputs.stage-url }}
         with:
           command: test


### PR DESCRIPTION
# Description

This PR should resolve the [flaky integration test](https://github.com/WalletConnect/blockchain-api/actions/runs/7462693040/job/20317899316) for the Infura by using the Infura Project ID when running the test.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
