### PR TITLE
fix: changing to `validate_project_access_and_quota` in history and portfolio handlers

### DIFF
--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -138,11 +138,12 @@ async fn handler_internal(
     // Checking for the H160 address correctness
     H160::from_str(&address).map_err(|_| RpcError::IdentityInvalidAddress)?;
 
-    state.validate_project_access_and_quota(&project_id).await?;
     let latency_tracker_start = std::time::SystemTime::now();
     let history_provider: ProviderKind;
     let response: HistoryResponseBody = if let Some(onramp) = query.onramp.clone() {
         if onramp == "coinbase" {
+            // We don't want to validate the quota for the onramp
+            state.validate_project_access(&project_id).await?;
             history_provider = ProviderKind::Coinbase;
             state
                 .providers
@@ -156,6 +157,7 @@ async fn handler_internal(
             return Err(RpcError::UnsupportedProvider(onramp));
         }
     } else {
+        state.validate_project_access_and_quota(&project_id).await?;
         history_provider = ProviderKind::Zerion;
         state
             .providers

--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -138,7 +138,7 @@ async fn handler_internal(
     // Checking for the H160 address correctness
     H160::from_str(&address).map_err(|_| RpcError::IdentityInvalidAddress)?;
 
-    state.validate_project_access(&project_id).await?;
+    state.validate_project_access_and_quota(&project_id).await?;
     let latency_tracker_start = std::time::SystemTime::now();
     let history_provider: ProviderKind;
     let response: HistoryResponseBody = if let Some(onramp) = query.onramp.clone() {

--- a/src/handlers/portfolio.rs
+++ b/src/handlers/portfolio.rs
@@ -67,7 +67,7 @@ async fn handler_internal(
         .parse::<Address>()
         .map_err(|_| RpcError::IdentityInvalidAddress)?;
 
-    state.validate_project_access(&project_id).await?;
+    state.validate_project_access_and_quota(&project_id).await?;
 
     let response = state
         .providers


### PR DESCRIPTION
# Description

This PR changes the `validate_project_access` to the `validate_project_access_and_quota` for the history and portfolio endpoints to check the project quota as well. 
Adds `validate_project_access` without a quota check for the onramp history.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
