### PR TITLE
fix: adding temporary instrument logging for the avatar lookup

### DIFF
--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -259,7 +259,7 @@ async fn lookup_name(
     )
 }
 
-#[tracing::instrument(skip_all, level = "debug")]
+#[tracing::instrument(skip(provider))]
 async fn lookup_avatar(
     provider: &Provider<SelfProvider>,
     name: &str,


### PR DESCRIPTION
# Description

Temporary enabling logging for the avatar lookup to catch the panic condition for the `ethers-rs` while it's not reproduced locally.

This change will be rolled back soon when the issue will be resolved.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
