### PR TITLE
feat(ci): per provider integration tests

### DIFF
--- a/.github/workflows/sub-providers.yml
+++ b/.github/workflows/sub-providers.yml
@@ -1,0 +1,84 @@
+name: ❖ Providers
+
+on:
+  workflow_dispatch:
+    inputs:
+      providers:
+        description: 'Providers list to test (space separated)'
+        required: false
+        default: 'coinbase binance'
+      stage-url:
+        description: 'RPC URL'
+        required: false
+        default: 'https://staging.rpc.walletconnect.org/'
+  workflow_call:
+    inputs:
+      providers_directory:
+        type: string
+        required: true
+        description: 'Directory where providers sources are located'
+      stage-url:
+        type: string
+        required: true
+        description: 'Stage RPC URL'
+        default: 'https://staging.rpc.walletconnect.org/'
+
+concurrency: cd
+
+permissions:
+  contents: write
+  checks: write
+  id-token: write
+
+jobs:
+  providers-test:
+    name: "Providers specific tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: "Determining changed providers list"
+        id: get_list
+        run: |
+          if [[ -n "${{ github.event.inputs.providers }}" ]]; then
+            PROVIDERS_LIST="${{ github.event.inputs.providers }}"
+          else
+            PROVIDERS_DIR="${{ inputs.providers_directory }}"
+            CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+            PROVIDERS_LIST=""
+
+            for file in $CHANGED_FILES; do
+              if [[ $file == $PROVIDERS_DIR* ]]; then
+                PROVIDER_TEST_NAME=$(echo $file | sed "s|^$PROVIDERS_DIR||" | sed 's|/|::|g' | sed 's|\.rs$||')
+                PROVIDERS_LIST+="$PROVIDER_TEST_NAME "
+              fi
+            done
+          fi
+          echo "PROVIDERS_LIST=$PROVIDERS_LIST" >> $GITHUB_ENV
+
+      - name: "Install Rust ${{ vars.RUST_VERSION }}"
+        uses: WalletConnect/actions-rs/toolchain@1.0.0
+        if: env.PROVIDERS_LIST != ''
+        with:
+          toolchain: ${{ vars.RUST_VERSION }}
+          profile: 'default'
+          override: true
+
+      - name: Run providers tests
+        if: env.PROVIDERS_LIST != ''
+        env:
+          PROJECT_ID: ${{ secrets.PROJECT_ID }}
+          RPC_URL: ${{ inputs.stage-url }}
+        run: |
+          for provider in $PROVIDERS_LIST; do
+            echo "Running tests for ${provider} provider"
+            cargo test ${provider}_provider-- --ignored
+            TEST_EXIT_STATUS=$?
+            if [ $TEST_EXIT_STATUS -ne 0 ]; then
+                echo "Test for ${provider} has failed"
+                exit 1
+            fi
+          done

--- a/.github/workflows/sub-providers.yml
+++ b/.github/workflows/sub-providers.yml
@@ -31,17 +31,18 @@ permissions:
   id-token: write
 
 jobs:
-  providers-test:
-    name: "Providers specific tests"
+  providers-list:
+    name: "Preparing providers list"
     runs-on: ubuntu-latest
+    outputs:
+      providers: ${{ steps.set-matrix.outputs.providers }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-
-      - name: "Determining changed providers list"
-        id: get_list
+      - name: Creating list of changed providers
+        id: set-matrix
         run: |
           if [[ -n "${{ github.event.inputs.providers }}" ]]; then
             PROVIDERS_LIST="${{ github.event.inputs.providers }}"
@@ -56,29 +57,39 @@ jobs:
                 PROVIDERS_LIST+="$PROVIDER_TEST_NAME "
               fi
             done
+
+            PROVIDERS_LIST="${PROVIDERS_LIST% }"
           fi
-          echo "PROVIDERS_LIST=$PROVIDERS_LIST" >> $GITHUB_ENV
+
+          JSON_FMT=$(printf '[%s]' "$(echo $PROVIDERS_LIST | awk '{for(i=1;i<=NF;i++) printf "\"%s\",", $i}' | sed 's/,$//')")
+          echo "providers=$JSON_FMT" >> $GITHUB_OUTPUT
+      - name: Print list of changed providers
+        run: |
+          echo "Providers matrix: ${{ steps.set-matrix.outputs.providers }}"
+
+  providers-test:
+    name: "Run provider tests"
+    needs: providers-list
+    runs-on: ubuntu-latest
+    if: needs.providers-list.outputs.providers != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: ${{fromJson(needs.providers-list.outputs.providers)}}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
       - name: "Install Rust ${{ vars.RUST_VERSION }}"
         uses: WalletConnect/actions-rs/toolchain@1.0.0
-        if: env.PROVIDERS_LIST != ''
         with:
           toolchain: ${{ vars.RUST_VERSION }}
           profile: 'default'
           override: true
 
-      - name: Run providers tests
-        if: env.PROVIDERS_LIST != ''
+      - name: Run Tests for ${{ matrix.provider }}
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           RPC_URL: ${{ inputs.stage-url }}
         run: |
-          for provider in $PROVIDERS_LIST; do
-            echo "Running tests for ${provider} provider"
-            cargo test ${provider}_provider-- --ignored
-            TEST_EXIT_STATUS=$?
-            if [ $TEST_EXIT_STATUS -ne 0 ]; then
-                echo "Test for ${provider} has failed"
-                exit 1
-            fi
-          done
+            cargo test ${{ matrix.provider }}_provider -- --ignored

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -1,0 +1,18 @@
+# Functional integration tests
+
+The following functional integration tests are presented:
+
+* Database tests
+* Providers tests
+  * Providers functional tests should be `#[ignore]` by default, because they will run by 
+    the CI workflow specifically when the providers code is changed in the `src/provider`
+    directory.
+  * Providers test names should be in the format `{provider_name}_provider` and 
+    `{provider_name}_provider_*` aligning with the provider name file in the 
+    `src/providers` directory.
+  * Example for the `coinbase` provider:
+    * Implementation source file: `src/provider/coinbase.rs`
+      Tests for the `coinbase` provider will run only if this file is changed.
+    * Tests implementation for the `coinbase` provider can be in any files but should be
+      `#[ignore]` by default and the test names must starts with the 
+      `coinbase_provider`.

--- a/tests/functional/http/base.rs
+++ b/tests/functional/http/base.rs
@@ -6,7 +6,8 @@ use {
 
 #[test_context(ServerContext)]
 #[tokio::test]
-async fn eip155_8453_base(ctx: &mut ServerContext) {
+#[ignore]
+async fn base_provider_eip155_8453_and_84531(ctx: &mut ServerContext) {
     // Base mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:8453", "0x2105").await;
 

--- a/tests/functional/http/binance.rs
+++ b/tests/functional/http/binance.rs
@@ -6,7 +6,8 @@ use {
 
 #[test_context(ServerContext)]
 #[tokio::test]
-async fn binance_provider(ctx: &mut ServerContext) {
+#[ignore]
+async fn binance_provider_eip155_56_and_97(ctx: &mut ServerContext) {
     // Binance mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:56", "0x38").await;
 

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -8,7 +8,8 @@ use {
 
 #[test_context(ServerContext)]
 #[tokio::test]
-async fn pokt_provider(ctx: &mut ServerContext) {
+#[ignore]
+async fn pokt_provider_eip155_43114_and_56_and_100(ctx: &mut ServerContext) {
     // Avax
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:43114", "0xa86a").await;
 

--- a/tests/functional/http/zksync.rs
+++ b/tests/functional/http/zksync.rs
@@ -6,7 +6,8 @@ use {
 
 #[test_context(ServerContext)]
 #[tokio::test]
-async fn eip155_324_zksync_mainnet(ctx: &mut ServerContext) {
+#[ignore]
+async fn zksync_provider_eip155_324_and_280(ctx: &mut ServerContext) {
     // ZkSync mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:324", "0x144").await;
 

--- a/tests/functional/http/zora.rs
+++ b/tests/functional/http/zora.rs
@@ -6,7 +6,8 @@ use {
 
 #[test_context(ServerContext)]
 #[tokio::test]
-async fn eip155_7777777_zora(ctx: &mut ServerContext) {
+#[ignore]
+async fn zora_provider_eip155_7777777_and_999(ctx: &mut ServerContext) {
     // Zora mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:7777777", "0x76adf1")
         .await;

--- a/tests/functional/websocket/infura.rs
+++ b/tests/functional/websocket/infura.rs
@@ -7,7 +7,7 @@ use {
 #[test_context(ServerContext)]
 #[tokio::test]
 #[ignore]
-async fn infura_websocket_provider(ctx: &mut ServerContext) {
+async fn infura_provider_websocket(ctx: &mut ServerContext) {
     // Ethereum mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:1", "0x1").await;
 

--- a/tests/functional/websocket/zora.rs
+++ b/tests/functional/websocket/zora.rs
@@ -6,7 +6,8 @@ use {
 
 #[test_context(ServerContext)]
 #[tokio::test]
-async fn zora_websocket_provider(ctx: &mut ServerContext) {
+#[ignore]
+async fn zora_provider_websocket(ctx: &mut ServerContext) {
     // Zora mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:7777777", "0x76adf1")
         .await;


### PR DESCRIPTION
# Description

The context of the issue (#464):
> At the moment we are running providers integration tests on all changes. Sometimes some of the providers are unavailable (rate-limited etc.) that results in a blocking of the CI/CD process.
> We should run the provider tests only when the provider implementation is changed and run the test only for that provider that was changed.

This PR introduces the following changes:
* Making all provider tests optional by making them `#[ignore]`
* Unifying providers test names to the `{provider_name}_provider` pattern
* Adding the [sub-providers.yml](https://github.com/WalletConnect/blockchain-api/pull/465/commits/fac3317f9dd7de15e369313652e47766fca83bc1) workflow that:
  * Determining what provider was changed
  * Run the specific provider test (or multiple providers that were changed)
  * This workflow can be called manually from actions by providing the list of providers to test
  * This workflow will be called as a dependency step from [sub-validate.yml](https://github.com/WalletConnect/blockchain-api/blob/07e92507dcca4523cb0c327c61f4949aefba9591/.github/workflows/sub-validate.yml#L64) when merged and after testing it manually (to not block the CI until tested and possible fixes are merged) by the following #466 PR.
* Adding [README](https://github.com/WalletConnect/blockchain-api/pull/465/commits/c19b8c9afa1cbd9b2daee552275583dcb22eced9) file with the descriptions on how providers testing work

Resolves #464 

## How Has This Been Tested?

Tested only partly because of the GitHub CI nature.
The `sub-providers.yml` workflow was tested isolated and reduced in the forked repo by pushing different commits on it:
 * [No provider changed](https://github.com/geekbrother/blockchain-api/actions/runs/7503278738/job/20427705989#step:3:1)
 * [One provider changed](https://github.com/geekbrother/blockchain-api/actions/runs/7503257474/job/20427641782#step:4:9)
 * [Few providers changed](https://github.com/geekbrother/blockchain-api/actions/runs/7503323935/job/20427845217#step:4:1)

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
