### PR TITLE
feat(ci): run provider specific tests from sub-validate

### DIFF
--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -72,6 +72,12 @@ jobs:
           command: test
           args: --test integration
 
+      - name: "Run Providers Integration Tests"
+        uses: ./.github/workflows/sub-providers.yml
+        with:
+          providers_directory: "src/providers/"
+          stage-url: ${{ inputs.stage-url }}
+
   integration-tests-ts:
     name: TS Integration Tests - ${{ inputs.stage }}
     runs-on:


### PR DESCRIPTION
# Description

This PR introduces changes to the sub-validate CI workflow to run the `sub-providers` workflow for provider-specific integration tests during the CI/CD validation.

* Sub-providers workflow context #465 

Resolves #464

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
