### PR TITLE
fix(ci): removing the trailing slash from the RPC url

### DIFF
--- a/.github/workflows/sub-providers.yml
+++ b/.github/workflows/sub-providers.yml
@@ -10,7 +10,7 @@ on:
       stage-url:
         description: 'RPC URL'
         required: false
-        default: 'https://staging.rpc.walletconnect.org/'
+        default: 'https://staging.rpc.walletconnect.org'
   workflow_call:
     inputs:
       providers_directory:
@@ -21,7 +21,7 @@ on:
         type: string
         required: true
         description: 'Stage RPC URL'
-        default: 'https://staging.rpc.walletconnect.org/'
+        default: 'https://staging.rpc.walletconnect.org'
 
 concurrency: cd
 


### PR DESCRIPTION
# Description

Removing the trailing slash from the RPC URL from the manual workflow call for the `Providers`.
The trailing slash causes the test to fail if a user is not modifying it. It's better to fix it to be valid by default.

## How Has This Been Tested?

With trailing slash - [Fail](https://github.com/WalletConnect/blockchain-api/actions/runs/7526690884/job/20485346285)
Without trailing slash - [Success](https://github.com/WalletConnect/blockchain-api/actions/runs/7527159789)

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
