### PR TITLE
fix(ci): adding the branch tag for the sub workflow

### DIFF
--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -73,7 +73,7 @@ jobs:
           args: --test integration
 
       - name: "Run Providers Integration Tests"
-        uses: ./.github/workflows/sub-providers.yml
+        uses: ./.github/workflows/sub-providers.yml@master
         with:
           providers_directory: "src/providers/"
           stage-url: ${{ inputs.stage-url }}


### PR DESCRIPTION
# Description

This PR adds the branch tag to the reusable workflow that should possibly fix the [error](https://github.com/WalletConnect/blockchain-api/actions/runs/7529681429/job/20494837706#step:6:1) where the workflow is treated as action and GitHub Actions throws a following error despite [checkout](https://github.com/WalletConnect/blockchain-api/blob/7cd36df407a78cec72f1bfff752e20a3f83773e0/.github/workflows/sub-validate.yml#L55) and the file [is present](https://github.com/WalletConnect/blockchain-api/blob/master/.github/workflows/sub-providers.yml):
```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/blockchain-api/blockchain-api/.github/workflows/sub-providers.yml'. Did you forget to run actions/checkout before running your local action?
```

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
