### PR TITLE
fix(noop): this is noop commit to check the provider tests new CI

### DIFF
--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -77,7 +77,6 @@ impl RpcProvider for BinanceProvider {
         response
             .headers_mut()
             .insert("Content-Type", HeaderValue::from_static("application/json"));
-
         Ok(response)
     }
 }


### PR DESCRIPTION
# Description

This PR is a noop change in providers code to check the new provider-specific tests from #465, #466, #470 that runs from
the `workflow_call` in the GitHub CI, because we don't have another ability to check it.

## How Has This Been Tested?

* Manual call for the new CI [was tested and successfully can be run from the CI dashboard](https://github.com/WalletConnect/blockchain-api/actions/workflows/sub-providers.yml).
* `workflow_call` is not tested and should be tested by this noop PR.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
