### PR TITLE
fix(ci): changing to invoke providers workflow as a job

### DIFF
--- a/.github/workflows/sub-providers.yml
+++ b/.github/workflows/sub-providers.yml
@@ -33,12 +33,13 @@ permissions:
 jobs:
   providers-list:
     name: "Preparing providers list"
-    runs-on: ubuntu-latest
+    runs-on:
+      group: ${{ vars.RUN_GROUP }}
     outputs:
       providers: ${{ steps.set-matrix.outputs.providers }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Creating list of changed providers
@@ -70,7 +71,8 @@ jobs:
   providers-test:
     name: "Run provider tests"
     needs: providers-list
-    runs-on: ubuntu-latest
+    runs-on:
+      group: ${{ vars.RUN_GROUP }}
     if: needs.providers-list.outputs.providers != '[]'
     strategy:
       fail-fast: false
@@ -78,7 +80,7 @@ jobs:
         provider: ${{fromJson(needs.providers-list.outputs.providers)}}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: "Install Rust ${{ vars.RUST_VERSION }}"
         uses: WalletConnect/actions-rs/toolchain@1.0.0

--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -72,11 +72,12 @@ jobs:
           command: test
           args: --test integration
 
-      - name: "Run Providers Integration Tests"
-        uses: ./.github/workflows/sub-providers.yml@master
-        with:
-          providers_directory: "src/providers/"
-          stage-url: ${{ inputs.stage-url }}
+  integration-tests-providers:
+    name: Providers Integration Tests - ${{ inputs.stage }}
+    uses: ./.github/workflows/sub-providers.yml
+    with:
+      providers_directory: "src/providers/"
+      stage-url: ${{ inputs.stage-url }}
 
   integration-tests-ts:
     name: TS Integration Tests - ${{ inputs.stage }}


### PR DESCRIPTION
# Description

This PR changes invoking the providers test sub-workflow as a job instead of as a step, to fix the issue where the local sub-workflow files are not supported as a step.

* [The error](https://github.com/WalletConnect/blockchain-api/actions/runs/7533463980/job/20506321806#step:6:1) that should fix this PR.

Resolves #464

## How Has This Been Tested?

Invoking the sub-workflow as a job is [tested on the forked repository](https://github.com/geekbrother/blockchain-api/blob/0f3952d565c58c285367c81a98bb88533ade5aa8/.github/workflows/test_subcd.yml#L15).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
