### PR TITLE
fix(ci): removing write permissions from providers tests workflow

### DIFF
--- a/.github/workflows/sub-providers.yml
+++ b/.github/workflows/sub-providers.yml
@@ -25,11 +25,6 @@ on:
 
 concurrency: cd
 
-permissions:
-  contents: write
-  checks: write
-  id-token: write
-
 jobs:
   providers-list:
     name: "Preparing providers list"


### PR DESCRIPTION
# Description

This PR removes the write permission for the sub-providers workflow (as we don't need it here) and fixes the permission error:
```
[Invalid workflow file: .github/workflows/event_release.yml#L75](https://github.com/WalletConnect/blockchain-api/actions/runs/7541637575/workflow)
The workflow is not valid. WalletConnect/blockchain-api/.github/workflows/sub-validate.yml@ae88560aba66eae1556d389344ab7cbf6dd9b839 (Line: 75, Col: 3): Error calling workflow 'WalletConnect/blockchain-api/.github/workflows/sub-providers.yml@ae88560aba66eae1556d389344ab7cbf6dd9b839'. The workflow is requesting 'contents: write', but is only allowed 'contents: read'.
```

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
