### PR TITLE
fix(ci): inherit secrets to providers validation workflow

### DIFF
--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -75,6 +75,7 @@ jobs:
   integration-tests-providers:
     name: Providers Integration Tests - ${{ inputs.stage }}
     uses: ./.github/workflows/sub-providers.yml
+    secrets: inherit
     with:
       providers_directory: "src/providers/"
       stage-url: ${{ inputs.stage-url }}


### PR DESCRIPTION
# Description

This PR adds `secrets: inherit` for the providers tests sub workflow.
We are using secrets inside of the sub-workflow, without passing this setting the [CI tasks are skipped](https://github.com/WalletConnect/blockchain-api/actions/runs/7541846605/job/20536188424).

## How Has This Been Tested?

Tested on the forked repo.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
