### PR TITLE
fix(noop): checking providers CI workflow

### DIFF
--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -77,7 +77,6 @@ impl RpcProvider for BinanceProvider {
         response
             .headers_mut()
             .insert("Content-Type", HeaderValue::from_static("application/json"));
-
         Ok(response)
     }
 }


### PR DESCRIPTION
This PR is a noop change in providers code to check the new provider-specific tests from #465, #466, #470 that runs from
the `workflow_call` in the GitHub CI, because we don't have another ability to check it.

## Same noop PR was approved (#474) so this can be force merged to save the reviewer's time as this PR does change nothing.

## How Has This Been Tested?

The reason for this PR is a test.

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
