### PR TITLE
fix(providers): removing Aurora from the Infura provider

### DIFF
--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -107,21 +107,6 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
-        // Aurora
-        (
-            "eip155:1313161554".into(),
-            (
-                "aurora-mainnet".into(),
-                Weight::new(Priority::Normal).unwrap(),
-            ),
-        ),
-        (
-            "eip155:1313161555".into(),
-            (
-                "aurora-testnet".into(),
-                Weight::new(Priority::Normal).unwrap(),
-            ),
-        ),
         // Base Goerli
         (
             "eip155:84531".into(),

--- a/tests/functional/http/infura.rs
+++ b/tests/functional/http/infura.rs
@@ -36,21 +36,8 @@ async fn infura_provider(ctx: &mut ServerContext) {
     // Arbitrum goerli
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:421613", "0x66eed").await;
 
-    // Aurora mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        "eip155:1313161554",
-        "0x4e454152",
-    )
-    .await;
-
-    // Aurora testnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        "eip155:1313161555",
-        "0x4e454153",
-    )
-    .await;
+    // Celo
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:42220", "0xa4ec").await;
 
     // Base Goerli
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:84531", "0x14a33").await


### PR DESCRIPTION
# Description

This PR removed the Aurora chain from the Infura provider as it's no longer supported, and we added the native Aurora RPC.

## How Has This Been Tested?

The Aurora-related subdomains in the Infura provider are not reachable any more:
```
curl -v https://aurora-mainnet.infura.io/v3/test
* Could not resolve host: aurora-mainnet.infura.io
```

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
