### PR TITLE
fix(providers): unifying Solana chain_id

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -25,7 +25,7 @@ Chain name with associated `chainId` query param to use.
 - zkSync Era Testnet (`eip155:280`)
 - Near (`near`)
 - Gnosis Chain (`eip155:100`)
-- Solana (`solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz` or `solana-mainnet`)
+- Solana Mainnet (`solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz`)
 - Base (`eip155:8453`)
 - Base Goerli (`eip155:84531`)
 - Zora (`eip155:7777777`)

--- a/src/env/omnia.rs
+++ b/src/env/omnia.rs
@@ -65,11 +65,9 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:10".into(),
             ("op".into(), Weight::new(Priority::Normal).unwrap()),
         ),
-        // Solana
+        // Solana Mainnet
         (
-            // TODO: consider changing from `solana-mainnet` to
-            // `solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz` like Pokt provider
-            "solana-mainnet".into(),
+            "solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz".into(),
             ("sol".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         // Avalanche C chain

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -47,7 +47,13 @@ async fn handler_internal(
         .validate_project_access_and_quota(&query_params.project_id)
         .await?;
 
-    let chain_id = query_params.chain_id.to_lowercase();
+    // TODO: Remove the `solana-mainnet` chain_id alias for
+    // `solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz` when ready
+    let chain_id = if query_params.chain_id.to_lowercase() == "solana-mainnet" {
+        "solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz".to_string()
+    } else {
+        query_params.chain_id.to_lowercase()
+    };
 
     let provider = state
         .providers


### PR DESCRIPTION
# Description

We have two chain IDs for the Solana mainnet:
 * [solana-mainnet](https://github.com/WalletConnect/blockchain-api/blob/12f813a52c34651a6b8f66454dee44596518275b/src/env/omnia.rs#L72)
 * [solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz](https://github.com/WalletConnect/blockchain-api/blob/12f813a52c34651a6b8f66454dee44596518275b/src/env/pokt.rs#L43C14-L43C53)

We should unify the Solana mainnet chain IDs into the single standardized `solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz`.

This PR adds the `solana-mainnet` alias for the `solana:4sgjmw1sunhzsxgspuhpqldx6wiyjnt` to support clients that already using the `solana-mainnet`, but moving forward with the unified `solana:4sgjmw1sunhzsxgspuhpqldx6wiyjnt` for all providers.

This will solve the load balancing for the Solana chain as well.

Slack [thread context](https://walletconnect.slack.com/archives/C03SCF66K2T/p1691168793656429).

## How Has This Been Tested?

Integration test for the Solana chain.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
