### PR TITLE
feat(providers): proxy request for a certain provider

### DIFF
--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -302,4 +302,34 @@ describe('blockchain api', () => {
       expect(resp.status).toBe(400)
     })
   })
+
+  describe('Proxy', () => {
+    it('Exact provider request', async () => {
+      const providerId = 'Binance';
+      const chainId = "eip155:56";
+      const payload = {
+        jsonrpc: "2.0",
+        method: "eth_chainId",
+        params: [],
+        id: 1,
+      };
+      
+      // Allowed projectID
+      // Only allowed projectID can make this type of request
+      let resp: any = await http.post(
+        `${baseUrl}/v1?chainId=${chainId}&projectId=${projectId}&providerId=${providerId}`,
+        payload
+      )
+      expect(resp.status).toBe(200)
+      expect(typeof resp.data).toBe('object')
+
+      // Not allowed projectID for this request type
+      const notAllowedProjectId = 'someprojectid';
+      resp = await http.post(
+        `${baseUrl}/v1?chainId=${chainId}&projectId=${notAllowedProjectId}&providerId=${providerId}`,
+        payload
+      )
+      expect(resp.status).toBe(400)
+    })
+  })
 })

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -103,6 +103,8 @@ mod test {
             ("RPC_PROXY_BLOCKED_COUNTRIES", "KP,IR,CU,SY"),
             ("RPC_PROXY_GEOIP_DB_BUCKET", "GEOIP_DB_BUCKET"),
             ("RPC_PROXY_GEOIP_DB_KEY", "GEOIP_DB_KEY"),
+            // Integration tests config.
+            ("RPC_PROXY_TESTING_PROJECT_ID", "TESTING_PROJECT_ID"),
             // Registry config.
             ("RPC_PROXY_REGISTRY_API_URL", "API_URL"),
             ("RPC_PROXY_REGISTRY_API_AUTH_TOKEN", "API_AUTH_TOKEN"),
@@ -168,6 +170,7 @@ mod test {
                 s3_endpoint: None,
                 geoip_db_bucket: Some("GEOIP_DB_BUCKET".to_owned()),
                 geoip_db_key: Some("GEOIP_DB_KEY".to_owned()),
+                testing_project_id: Some("TESTING_PROJECT_ID".to_owned()),
             },
             registry: project::Config {
                 api_url: Some("API_URL".to_owned()),

--- a/src/env/server.rs
+++ b/src/env/server.rs
@@ -16,6 +16,7 @@ pub struct ServerConfig {
     pub blocked_countries: Vec<String>,
     pub geoip_db_bucket: Option<String>,
     pub geoip_db_key: Option<String>,
+    pub testing_project_id: Option<String>,
 }
 
 impl Default for ServerConfig {
@@ -30,6 +31,7 @@ impl Default for ServerConfig {
             blocked_countries: Vec::new(),
             geoip_db_bucket: None,
             geoip_db_key: None,
+            testing_project_id: None,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,6 +90,9 @@ pub enum RpcError {
 
     #[error("sqlx migration error: {0}")]
     SqlxMigrationError(#[from] sqlx::migrate::MigrateError),
+
+    #[error("invalid parameter: {0}")]
+    InvalidParameter(String),
 }
 
 impl IntoResponse for RpcError {
@@ -167,6 +170,14 @@ impl IntoResponse for RpcError {
                 Json(new_error_response(
                     "address".to_string(),
                     "Project's quota limit reached".to_string(),
+                )),
+            )
+                .into_response(),
+            Self::InvalidParameter(e) => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "".to_string(),
+                    format!("Invalid parameter: {}", e),
                 )),
             )
                 .into_response(),

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -20,6 +20,7 @@ static HANDLER_TASK_METRICS: TaskMetrics = TaskMetrics::new("handler_task");
 pub struct RpcQueryParams {
     pub chain_id: String,
     pub project_id: String,
+    /// Optional provider ID for the exact provider request
     pub provider_id: Option<String>,
 }
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -20,6 +20,7 @@ static HANDLER_TASK_METRICS: TaskMetrics = TaskMetrics::new("handler_task");
 pub struct RpcQueryParams {
     pub chain_id: String,
     pub project_id: String,
+    pub provider_id: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -55,16 +55,35 @@ async fn handler_internal(
         query_params.chain_id.to_lowercase()
     };
 
-    let provider = if let Some(provider_id) = query_params.clone().provider_id {
-        match state.providers.get_provider_by_provider_id(&provider_id) {
-            None => return Err(RpcError::UnsupportedProvider(provider_id)),
-            Some(provider) => provider,
+    // Exact provider proxy request for testing suite
+    // This request is allowed only for the RPC_PROXY_TESTING_PROJECT_ID
+    let provider = match query_params.provider_id.clone() {
+        Some(provider_id) => {
+            let provider = state
+                .providers
+                .get_provider_by_provider_id(&provider_id)
+                .ok_or_else(|| RpcError::UnsupportedProvider(provider_id.clone()))?;
+
+            if let Some(ref testing_project_id) = state.config.server.testing_project_id {
+                if testing_project_id != &query_params.project_id {
+                    return Err(RpcError::InvalidParameter(format!(
+                        "The project ID {} is not allowed to use the exact provider request",
+                        query_params.project_id
+                    )));
+                }
+            } else {
+                return Err(RpcError::InvalidParameter(
+                    "RPC_PROXY_TESTING_PROJECT_ID should be configured for this type of request"
+                        .into(),
+                ));
+            }
+
+            provider
         }
-    } else {
-        state
+        None => state
             .providers
             .get_provider_for_chain_id(&chain_id)
-            .ok_or(RpcError::UnsupportedChain(chain_id.clone()))?
+            .ok_or_else(|| RpcError::UnsupportedChain(chain_id.clone()))?,
     };
 
     Span::current().record("provider", &provider.provider_kind().to_string());

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -55,10 +55,17 @@ async fn handler_internal(
         query_params.chain_id.to_lowercase()
     };
 
-    let provider = state
-        .providers
-        .get_provider_for_chain_id(&chain_id)
-        .ok_or(RpcError::UnsupportedChain(chain_id.clone()))?;
+    let provider = if let Some(provider_id) = query_params.clone().provider_id {
+        match state.providers.get_provider_by_provider_id(&provider_id) {
+            None => return Err(RpcError::UnsupportedProvider(provider_id)),
+            Some(provider) => provider,
+        }
+    } else {
+        state
+            .providers
+            .get_provider_for_chain_id(&chain_id)
+            .ok_or(RpcError::UnsupportedChain(chain_id.clone()))?
+    };
 
     Span::current().record("provider", &provider.provider_kind().to_string());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ mod json_rpc;
 mod metrics;
 pub mod profiler;
 mod project;
-mod providers;
+pub mod providers;
 mod state;
 mod storage;
 mod utils;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -268,6 +268,13 @@ impl ProviderRepository {
             }
         }
     }
+
+    #[tracing::instrument(skip(self), level = "debug")]
+    pub fn get_provider_by_provider_id(&self, provider_id: &str) -> Option<Arc<dyn RpcProvider>> {
+        let provider = ProviderKind::from_str(provider_id)?;
+
+        self.providers.get(&provider).cloned()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -303,6 +310,7 @@ impl Display for ProviderKind {
     }
 }
 
+#[allow(clippy::should_implement_trait)]
 impl ProviderKind {
     pub fn from_str(s: &str) -> Option<Self> {
         match s {

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -55,6 +55,20 @@ pub fn string_chain_id_to_caip2_format(chain_id: &str) -> Result<String, anyhow:
     ))
 }
 
+/// Compare two strings in constant time to prevent timing attacks
+pub fn constant_time_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+
+    let mut result = 0;
+    for (byte_a, byte_b) in a.bytes().zip(b.bytes()) {
+        result |= byte_a ^ byte_b;
+    }
+
+    result == 0
+}
+
 #[cfg(test)]
 mod tests {
     use {
@@ -124,5 +138,13 @@ mod tests {
             assert!(result.is_ok(), "chain_id is not found: {}", chain_id);
             assert_eq!(result.unwrap(), format!("eip155:{}", coin_type));
         }
+    }
+
+    #[test]
+    fn test_constant_time_eq() {
+        let string_one = "some string";
+        let string_two = "some another string";
+        assert!(!constant_time_eq(string_one, string_two));
+        assert!(constant_time_eq(string_one, string_one));
     }
 }

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -75,6 +75,7 @@ resource "aws_ecs_task_definition" "app_task" {
 
         { name = "RPC_PROXY_GEOIP_DB_BUCKET", value = var.geoip_db_bucket_name },
         { name = "RPC_PROXY_GEOIP_DB_KEY", value = var.geoip_db_key },
+        { name = "RPC_PROXY_TESTING_PROJECT_ID", value = var.testing_project_id },
 
         { name = "RPC_PROXY_BLOCKED_COUNTRIES", value = var.ofac_blocked_countries },
 

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -179,6 +179,12 @@ variable "coinbase_app_id" {
   sensitive   = true
 }
 
+variable "testing_project_id" {
+  description = "Project ID used in a testing suite"
+  type        = string
+  sensitive   = true
+}
+
 #-------------------------------------------------------------------------------
 # Project Registry
 

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -83,5 +83,8 @@ module "ecs" {
   geoip_db_bucket_name = data.aws_s3_bucket.geoip.id
   geoip_db_key         = var.geoip_db_key
 
+  # Project ID used in a testing suite
+  testing_project_id = var.testing_project_id
+
   depends_on = [aws_iam_role.application_role]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -109,6 +109,12 @@ variable "coinbase_app_id" {
   sensitive   = true
 }
 
+variable "testing_project_id" {
+  description = "Project ID used in a testing suite"
+  type        = string
+  sensitive   = true
+}
+
 #-------------------------------------------------------------------------------
 # Analytics
 

--- a/tests/functional/http/aurora.rs
+++ b/tests/functional/http/aurora.rs
@@ -1,6 +1,7 @@
 use {
     super::check_if_rpc_is_responding_correctly_for_supported_chain,
     crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind,
     test_context::test_context,
 };
 
@@ -11,12 +12,18 @@ async fn aurora_provider(ctx: &mut ServerContext) {
     // Aurora Mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
+        &ProviderKind::Aurora,
         "eip155:1313161554",
         "0x4e454152",
     )
     .await;
 
     // Aurora Testnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:1313161555", "0x4e454153")
-        .await
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Aurora,
+        "eip155:1313161555",
+        "0x4e454153",
+    )
+    .await
 }

--- a/tests/functional/http/base.rs
+++ b/tests/functional/http/base.rs
@@ -1,6 +1,7 @@
 use {
     super::check_if_rpc_is_responding_correctly_for_supported_chain,
     crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind,
     test_context::test_context,
 };
 
@@ -9,8 +10,20 @@ use {
 #[ignore]
 async fn base_provider_eip155_8453_and_84531(ctx: &mut ServerContext) {
     // Base mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:8453", "0x2105").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Base,
+        "eip155:8453",
+        "0x2105",
+    )
+    .await;
 
     // Base Goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:84531", "0x14a33").await
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Base,
+        "eip155:84531",
+        "0x14a33",
+    )
+    .await
 }

--- a/tests/functional/http/binance.rs
+++ b/tests/functional/http/binance.rs
@@ -1,6 +1,7 @@
 use {
     super::check_if_rpc_is_responding_correctly_for_supported_chain,
     crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind,
     test_context::test_context,
 };
 
@@ -9,8 +10,20 @@ use {
 #[ignore]
 async fn binance_provider_eip155_56_and_97(ctx: &mut ServerContext) {
     // Binance mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:56", "0x38").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Binance,
+        "eip155:56",
+        "0x38",
+    )
+    .await;
 
     // Binance testnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:97", "0x61").await
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Binance,
+        "eip155:97",
+        "0x61",
+    )
+    .await
 }

--- a/tests/functional/http/infura.rs
+++ b/tests/functional/http/infura.rs
@@ -1,6 +1,7 @@
 use {
     super::check_if_rpc_is_responding_correctly_for_supported_chain,
     crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind,
     test_context::test_context,
 };
 
@@ -9,36 +10,101 @@ use {
 #[ignore]
 async fn infura_provider(ctx: &mut ServerContext) {
     // Ethereum mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:1", "0x1").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Infura,
+        "eip155:1",
+        "0x1",
+    )
+    .await;
 
     // Ethereum Goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:5", "0x5").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Infura,
+        "eip155:5",
+        "0x5",
+    )
+    .await;
 
     // Ethereum Sepolia
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:11155111", "0xaa36a7")
-        .await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Infura,
+        "eip155:11155111",
+        "0xaa36a7",
+    )
+    .await;
 
     // Polgyon mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:137", "0x89").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Infura,
+        "eip155:137",
+        "0x89",
+    )
+    .await;
 
     // Polygon mumbai
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:80001", "0x13881").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Infura,
+        "eip155:80001",
+        "0x13881",
+    )
+    .await;
 
     // Optimism mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:10", "0xa").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Infura,
+        "eip155:10",
+        "0xa",
+    )
+    .await;
 
     // Optimism goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:420", "0x1A4").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Infura,
+        "eip155:420",
+        "0x1A4",
+    )
+    .await;
 
     // Arbitrum mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:42161", "0xa4b1").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Infura,
+        "eip155:42161",
+        "0xa4b1",
+    )
+    .await;
 
     // Arbitrum goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:421613", "0x66eed").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Infura,
+        "eip155:421613",
+        "0x66eed",
+    )
+    .await;
 
     // Celo
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:42220", "0xa4ec").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Infura,
+        "eip155:42220",
+        "0xa4ec",
+    )
+    .await;
 
     // Base Goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:84531", "0x14a33").await
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Infura,
+        "eip155:84531",
+        "0x14a33",
+    )
+    .await
 }

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -2,7 +2,7 @@ use {
     crate::{context::ServerContext, utils::send_jsonrpc_request, JSONRPC_VERSION},
     hyper::{Body, Client, Method, Request, StatusCode},
     hyper_tls::HttpsConnector,
-    rpc_proxy::handlers::history::HistoryResponseBody,
+    rpc_proxy::{handlers::history::HistoryResponseBody, providers::ProviderKind},
     test_context::test_context,
 };
 
@@ -16,12 +16,13 @@ pub(crate) mod zora;
 
 async fn check_if_rpc_is_responding_correctly_for_supported_chain(
     ctx: &ServerContext,
+    provider_id: &ProviderKind,
     chaind_id: &str,
     expected_id: &str,
 ) {
     let addr = format!(
-        "{}/v1/?projectId={}&chainId=",
-        ctx.server.public_addr, ctx.server.project_id
+        "{}/v1/?projectId={}&providerId={}&chainId=",
+        ctx.server.public_addr, ctx.server.project_id, provider_id
     );
 
     let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -3,6 +3,7 @@ use {
     crate::{context::ServerContext, utils::send_jsonrpc_request, JSONRPC_VERSION},
     hyper::{Client, StatusCode},
     hyper_tls::HttpsConnector,
+    rpc_proxy::providers::ProviderKind,
     test_context::test_context,
 };
 
@@ -11,37 +12,103 @@ use {
 #[ignore]
 async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     // Avax mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:43114", "0xa86a").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:43114",
+        "0xa86a",
+    )
+    .await;
 
     // Gnosis
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:100", "0x64").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:100",
+        "0x64",
+    )
+    .await;
 
     // Binance mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:56", "0x38").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:56",
+        "0x38",
+    )
+    .await;
 
     // Ethereum
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:1", "0x1").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:1",
+        "0x1",
+    )
+    .await;
 
     // Goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:5", "0x5").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:5",
+        "0x5",
+    )
+    .await;
 
     // Optimism
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:10", "0xa").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:10",
+        "0xa",
+    )
+    .await;
 
     // Arbitrum
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:42161", "0xa4b1").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:42161",
+        "0xa4b1",
+    )
+    .await;
 
     // Polygon mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:137", "0x89").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:137",
+        "0x89",
+    )
+    .await;
 
     // Polygon mumbai
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:80001", "0x13881").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:80001",
+        "0x13881",
+    )
+    .await;
 
     // Polygon zkevm
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:1101", "0x44d").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:1101",
+        "0x44d",
+    )
+    .await;
 
     // Polygon celo
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:42220", "0xa4ec").await
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:42220",
+        "0xa4ec",
+    )
+    .await
 }
 
 #[test_context(ServerContext)]

--- a/tests/functional/http/zksync.rs
+++ b/tests/functional/http/zksync.rs
@@ -1,6 +1,7 @@
 use {
     super::check_if_rpc_is_responding_correctly_for_supported_chain,
     crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind,
     test_context::test_context,
 };
 
@@ -9,8 +10,20 @@ use {
 #[ignore]
 async fn zksync_provider_eip155_324_and_280(ctx: &mut ServerContext) {
     // ZkSync mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:324", "0x144").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::ZKSync,
+        "eip155:324",
+        "0x144",
+    )
+    .await;
 
     // ZkSync testnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:280", "0x118").await
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::ZKSync,
+        "eip155:280",
+        "0x118",
+    )
+    .await
 }

--- a/tests/functional/http/zora.rs
+++ b/tests/functional/http/zora.rs
@@ -1,6 +1,7 @@
 use {
     super::check_if_rpc_is_responding_correctly_for_supported_chain,
     crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind,
     test_context::test_context,
 };
 
@@ -9,9 +10,20 @@ use {
 #[ignore]
 async fn zora_provider_eip155_7777777_and_999(ctx: &mut ServerContext) {
     // Zora mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:7777777", "0x76adf1")
-        .await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Zora,
+        "eip155:7777777",
+        "0x76adf1",
+    )
+    .await;
 
     // Zora Goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:999", "0x3e7").await
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Zora,
+        "eip155:999",
+        "0x3e7",
+    )
+    .await
 }


### PR DESCRIPTION
# Description

This PR adds an ability to request a certain provider in the proxy handler.
At the moment when we are querying the proxy for the certain `chain_id` the [weighted provider is used](https://github.com/WalletConnect/blockchain-api/blob/d093f9532a7e5dd89c964f111778aabbe375d0b8/src/handlers/proxy.rs#L60) and we can't test the request to the certain provider. 

Our integration tests uses the proxy requests and when we are requesting the certain `chain_id` the server requests a weighted provider and not the provider in tests itself. This makes tests flaky and unstable as we can't make sure what provider exactly was requested for test.

This PR making the following changes:
* Adds an optional `providerId` request parameter for the proxy handler.
* Adds [get_provider_by_provider_id](https://github.com/WalletConnect/blockchain-api/pull/487/files#diff-42c368d763b77f38b4ead84b474543a15f0d14d35e53ba7c60a9c9dae1385c7dR272) helper function to get the exact provider.
* Making changes to all provider's integration tests to use the certain provider instead of weighted.
* Allow exact provider requests only for the allowed project ID in `RPC_PROXY_TESTING_PROJECT_ID`.

`ProviderId` should be the same as in the [ProviderKind](https://github.com/WalletConnect/blockchain-api/blob/d093f9532a7e5dd89c964f111778aabbe375d0b8/src/providers/mod.rs#L290-L300).

## How Has This Been Tested?

#### Manual:

* Start the server locally by `RPC_PROXY_TESTING_PROJECT_ID=projectXXX cargo run`
* Run the curl query with the additional `providerId` parameter:

```
curl -v 'http://localhost:3000/v1/?chainId=eip155:999&projectId=projectXXX&providerId=Zora' --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
```

The expected result is the server log where the Zora exact provider was used and successful response:

```
{"jsonrpc":"2.0","result":"0x3e7","id":1}
```

#### CI/CD:

Integration tests are included in this PR.

<!-- If valid for smoke test on feature add screenshots -->

## Merging requirements 🚧

* [x] Sync GitHub Actions `PROJECT_ID` with the Terraform Cloud `testing_project_id` to allow CI/CD tests suite run the exact provider requests on staging and prod.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
