### PR TITLE
fix(providers): adding Aurora to the init providers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ use {
         Router,
     },
     env::{
+        AuroraConfig,
         BaseConfig,
         BinanceConfig,
         InfuraConfig,
@@ -30,6 +31,7 @@ use {
     http::Request,
     hyper::{header::HeaderName, http, server::conn::AddrIncoming, Body, Server},
     providers::{
+        AuroraProvider,
         BaseProvider,
         BinanceProvider,
         InfuraProvider,
@@ -311,6 +313,7 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
 
     // Keep in-sync with SUPPORTED_CHAINS.md
 
+    providers.add_provider::<AuroraProvider, AuroraConfig>(AuroraConfig::default());
     providers
         .add_provider::<PoktProvider, PoktConfig>(PoktConfig::new(config.pokt_project_id.clone()));
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -38,6 +38,7 @@ mod zksync;
 mod zora;
 
 pub use {
+    aurora::AuroraProvider,
     base::BaseProvider,
     binance::BinanceProvider,
     infura::{InfuraProvider, InfuraWsProvider},


### PR DESCRIPTION
# Description

This PR fixing the Aurora provider. On the initial adding of the Aurora native RPC in #469 the init part was missed so the native RPC is not in the list of providers.
This issue was not caught by the compilation, lint, and our integration tests, because tests use the weighted provider and we have a few providers for the Aurora (this issue in tests is also fixed in #487 ).

## How Has This Been Tested?

Tested using the Aurora integration test in #487 per provider tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
