### PR TITLE
feat(ens): changes to ENSIP-11 compatible responses

### DIFF
--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -142,6 +142,11 @@ describe('blockchain api', () => {
     // Generate a new eth wallet
     const wallet = ethers.Wallet.createRandom();
     const address = wallet.address;
+    const coin_type = 60; // SLIP-44 Ethereum
+    const chain_id = 1; // Ethereum mainnet
+    const attributes = {
+      bio: 'integration test domain',
+    };
 
     // Generate a random name
     const randomString = Array.from({ length: 10 }, 
@@ -151,7 +156,10 @@ describe('blockchain api', () => {
     // Create a message to sign
     const messageObject = {
         name,
+        coin_type,
+        chain_id,
         address,
+        attributes,
         timestamp: Math.round(Date.now() / 1000)
     };
     const message = JSON.stringify(messageObject);
@@ -163,6 +171,7 @@ describe('blockchain api', () => {
       const payload = {
         message,
         signature,
+        coin_type,
         address,
       };
       let resp: any = await http.post(
@@ -178,6 +187,7 @@ describe('blockchain api', () => {
       const payload = {
         message,
         signature,
+        coin_type,
         address,
       };
       let resp: any = await http.post(
@@ -193,6 +203,7 @@ describe('blockchain api', () => {
       const payload = {
         message,
         signature,
+        coin_type,
         address,
       };
       let resp: any = await http.post(
@@ -208,6 +219,7 @@ describe('blockchain api', () => {
       const payload = {
         message,
         signature,
+        coin_type,
         address,
       };
       let resp: any = await http.post(
@@ -223,7 +235,8 @@ describe('blockchain api', () => {
       expect(resp.status).toBe(200)
       expect(resp.data.name).toBe(name)
       expect(typeof resp.data.addresses).toBe('object')
-      const first = resp.data.addresses[0]
+      // ENSIP-11 using the 60 for the Ethereum mainnet
+      const first = resp.data.addresses["60"]
       expect(first.address).toBe(address)
     })
     it('name reverse lookup', async () => {
@@ -235,7 +248,8 @@ describe('blockchain api', () => {
       const first_name = resp.data[0]
       expect(first_name.name).toBe(name)
       expect(typeof first_name.addresses).toBe('object')
-      const first_address = first_name.addresses[0]
+      // ENSIP-11 using the 60 for the Ethereum mainnet
+      const first_address = first_name.addresses["60"]
       expect(first_address.address).toBe(address)
     })
   })

--- a/src/handlers/profile/mod.rs
+++ b/src/handlers/profile/mod.rs
@@ -2,6 +2,7 @@ use {
     ethers::types::H160,
     serde::{Deserialize, Serialize},
     std::{
+        collections::HashMap,
         str::FromStr,
         time::{SystemTime, UNIX_EPOCH},
     },
@@ -16,15 +17,22 @@ pub const UNIXTIMESTAMP_SYNC_THRESHOLD: u64 = 10;
 
 /// Payload to register domain name that should be serialized to JSON
 /// and passed to the RegisterRequest.message
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RegisterPayload {
     /// Name to register
     pub name: String,
+    /// Coin type SLIP-44
+    pub coin_type: u32,
+    /// Chain ID for the EVM
+    pub chain_id: u32,
     /// Address
     pub address: String,
+    /// Attributes
+    pub attributes: Option<HashMap<String, String>>,
     /// Unixtime
     pub timestamp: u64,
 }
+
 /// Data structure representing a request to register a name
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RegisterRequest {
@@ -32,6 +40,8 @@ pub struct RegisterRequest {
     pub message: String,
     /// Message signature
     pub signature: String,
+    /// Coin type SLIP-44
+    pub coin_type: u32,
     /// Address
     pub address: String,
 }

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -1,0 +1,79 @@
+use {ethers::types::H160, std::str::FromStr};
+
+/// Veryfy message signature signed by the keccak256
+#[tracing::instrument]
+pub fn verify_message_signature(
+    message: &str,
+    signature: &str,
+    owner: &H160,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let prefixed_message = format!("\x19Ethereum Signed Message:\n{}{}", message.len(), message);
+    let message_hash = ethers::core::utils::keccak256(prefixed_message.clone());
+    let message_hash = ethers::types::H256::from_slice(&message_hash);
+
+    let sign = ethers::types::Signature::from_str(signature)?;
+    match sign.verify(message_hash, *owner) {
+        Ok(_) => Ok(true),
+        Err(_) => Ok(false),
+    }
+}
+
+/// Convert EVM chain ID to coin type ENSIP-11
+#[tracing::instrument]
+pub fn convert_evm_chain_id_to_coin_type(chain_id: u32) -> u32 {
+    0x80000000 | chain_id
+}
+
+/// Convert coin type ENSIP-11 to EVM chain ID
+#[tracing::instrument]
+pub fn convert_coin_type_to_evm_chain_id(coin_type: u32) -> u32 {
+    0x7FFFFFFF & coin_type
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, ethers::types::H160, std::str::FromStr};
+
+    #[test]
+    fn test_verify_message_signature_valid() {
+        let message = "test message signature";
+        let signature = "0x660739ee06920c5f55fbaf0da4f435faaa9c55e2c9da303c50c4b3865191d67e5002a0b10eb0f89bae66823f7f07415ea9d5bbb607ee61ac98b7f2a0a44fcb5c1b";
+        let owner = H160::from_str("0xAff392551773CCb2574fAE23195CC3aFDBe98d18").unwrap();
+
+        let result = verify_message_signature(message, signature, &owner);
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_verify_message_signature_json() {
+        let message = r#"{\"test\":\"some my text\"}"#;
+        let signature = "0x2fe0b640b4036c9c97911e6f22c72a2c934f1d67db02948055c0e0c84dbf4f2b33c2f8c4b000642735dbf5d1c96ba48ccd2a998324c9e4cb7bb776f0c95ee2fc1b";
+        let owner = H160::from_str("0xAff392551773CCb2574fAE23195CC3aFDBe98d18").unwrap();
+
+        let result = verify_message_signature(message, signature, &owner);
+        assert!(result.is_ok());
+        println!("result: {:?}", result);
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_verify_message_signature_invalid() {
+        let message = "wrong message signature";
+        let signature = "0x660739ee06920c5f55fbaf0da4f435faaa9c55e2c9da303c50c4b3865191d67e5002a0b10eb0f89bae66823f7f07415ea9d5bbb607ee61ac98b7f2a0a44fcb5c1b"; // The signature of the message
+        let owner = H160::from_str("0xAff392551773CCb2574fAE23195CC3aFDBe98d18").unwrap(); // The Ethereum address of the signer
+
+        let result = verify_message_signature(message, signature, &owner);
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_convert_coin_type_to_evm_chain_id() {
+        // Polygon
+        let chain_id = 137;
+        let coin_type = 2147483785;
+        assert_eq!(convert_evm_chain_id_to_coin_type(chain_id), coin_type);
+        assert_eq!(convert_coin_type_to_evm_chain_id(coin_type), chain_id);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod build;
+pub mod crypto;
 pub mod network;

--- a/tests/functional/database.rs
+++ b/tests/functional/database.rs
@@ -24,12 +24,11 @@ async fn insert_and_get_name_by_name() {
 
     let name = format!("{}.connect.id", generate_random_string(10));
     let address = format!("0x{}", generate_random_string(16));
-    let addresses = vec![types::Address {
-        namespace: types::SupportedNamespaces::Eip155,
-        chain_id: None,
+    let chain_id = 1;
+    let addresses = HashMap::from([(chain_id, types::Address {
         address,
         created_at: None,
-    }];
+    })]);
 
     // create a new hashmap with attributes
     let attributes: HashMap<String, String> = HashMap::from_iter([
@@ -40,7 +39,14 @@ async fn insert_and_get_name_by_name() {
         ("bio".to_string(), "just about myself".to_string()),
     ]);
 
-    let insert_result = insert_name(name.clone(), attributes.clone(), addresses, &pg_pool).await;
+    let insert_result = insert_name(
+        name.clone(),
+        attributes.clone(),
+        types::SupportedNamespaces::Eip155,
+        addresses,
+        &pg_pool,
+    )
+    .await;
     if let Err(ref e) = insert_result {
         println!("Error: {:?}", e);
     }
@@ -70,15 +76,20 @@ async fn insert_and_get_names_by_address() {
 
     let name = format!("{}.connect.id", generate_random_string(10));
     let address = format!("0x{}", generate_random_string(16));
-
-    let addresses = vec![types::Address {
-        namespace: types::SupportedNamespaces::Eip155,
-        chain_id: None,
+    let chain_id = 1;
+    let addresses = HashMap::from([(chain_id, types::Address {
         address: address.clone(),
         created_at: None,
-    }];
+    })]);
 
-    let insert_result = insert_name(name.clone(), HashMap::new(), addresses, &pg_pool).await;
+    let insert_result = insert_name(
+        name.clone(),
+        HashMap::new(),
+        types::SupportedNamespaces::Eip155,
+        addresses,
+        &pg_pool,
+    )
+    .await;
     assert!(insert_result.is_ok(), "Inserting a new name should succeed");
 
     let get_names_result = get_names_by_address(address, &pg_pool).await;
@@ -102,15 +113,20 @@ async fn insert_and_get_names_by_address_and_namespace() {
     let name = format!("{}.connect.id", generate_random_string(10));
     let address = format!("0x{}", generate_random_string(16));
     let namespace = types::SupportedNamespaces::Eip155;
-
-    let addresses = vec![types::Address {
-        namespace: namespace.clone(),
-        chain_id: None,
+    let chain_id = 1;
+    let addresses = HashMap::from([(chain_id, types::Address {
         address: address.clone(),
         created_at: None,
-    }];
+    })]);
 
-    let insert_result = insert_name(name.clone(), HashMap::new(), addresses, &pg_pool).await;
+    let insert_result = insert_name(
+        name.clone(),
+        HashMap::new(),
+        types::SupportedNamespaces::Eip155,
+        addresses,
+        &pg_pool,
+    )
+    .await;
     assert!(insert_result.is_ok(), "Inserting a new name should succeed");
 
     let get_names_result = get_names_by_address_and_namespace(address, namespace, &pg_pool).await;
@@ -134,20 +150,19 @@ async fn insert_and_get_name_and_addresses() {
     let name = format!("{}.connect.id", generate_random_string(10));
     let address = format!("0x{}", generate_random_string(16));
     let namespace = types::SupportedNamespaces::Eip155;
-
-    let addresses = vec![types::Address {
-        namespace: namespace.clone(),
-        chain_id: None,
+    let chain_id = 1;
+    let addresses = HashMap::from([(chain_id, types::Address {
         address: address.clone(),
         created_at: None,
-    }];
+    })]);
 
     let attributes: HashMap<String, String> = HashMap::from_iter([(
         "avatar".to_string(),
         "http://test.url/avatar.png".to_string(),
     )]);
 
-    let insert_result = insert_name(name.clone(), attributes.clone(), addresses, &pg_pool).await;
+    let insert_result =
+        insert_name(name.clone(), HashMap::new(), namespace, addresses, &pg_pool).await;
     assert!(insert_result.is_ok(), "Inserting a new name should succeed");
 
     let get_name_result = get_name_and_addresses_by_name(name.clone(), &pg_pool).await;
@@ -159,7 +174,7 @@ async fn insert_and_get_name_and_addresses() {
     let got_name = get_name_result.unwrap();
     assert_eq!(got_name.name, name);
     assert_eq!(got_name.attributes.unwrap()["avatar"], attributes["avatar"]);
-    assert_eq!(got_name.addresses[0].address, address);
+    assert_eq!(got_name.addresses.get(&chain_id).unwrap().address, address);
 
     // Cleanup
     let delete_result = delete_name(name, &pg_pool).await;
@@ -172,12 +187,11 @@ async fn insert_and_update_name() {
 
     let name = format!("{}.connect.id", generate_random_string(10));
     let address = format!("0x{}", generate_random_string(16));
-    let addresses = vec![types::Address {
-        namespace: types::SupportedNamespaces::Eip155,
-        chain_id: None,
+    let chain_id = 1;
+    let addresses = HashMap::from([(chain_id, types::Address {
         address,
         created_at: None,
-    }];
+    })]);
 
     // create a new hashmap with attributes
     let attributes: HashMap<String, String> = HashMap::from_iter([
@@ -188,7 +202,14 @@ async fn insert_and_update_name() {
         ("bio".to_string(), "just about myself".to_string()),
     ]);
 
-    let insert_result = insert_name(name.clone(), attributes.clone(), addresses, &pg_pool).await;
+    let insert_result = insert_name(
+        name.clone(),
+        attributes.clone(),
+        types::SupportedNamespaces::Eip155,
+        addresses,
+        &pg_pool,
+    )
+    .await;
     assert!(insert_result.is_ok(), "Inserting a new name should succeed");
 
     let get_name_result = get_name(name.clone(), &pg_pool).await;
@@ -228,14 +249,20 @@ async fn insert_update_delete_address() {
 
     let name = format!("{}.connect.id", generate_random_string(10));
     let address = format!("0x{}", generate_random_string(16));
-    let addresses = vec![types::Address {
-        namespace: types::SupportedNamespaces::Eip155,
-        chain_id: None,
+    let chain_id = 1;
+    let addresses = HashMap::from([(chain_id, types::Address {
         address: address.clone(),
         created_at: None,
-    }];
+    })]);
 
-    let insert_result = insert_name(name.clone(), HashMap::new(), addresses, &pg_pool).await;
+    let insert_result = insert_name(
+        name.clone(),
+        HashMap::new(),
+        types::SupportedNamespaces::Eip155,
+        addresses,
+        &pg_pool,
+    )
+    .await;
     assert!(insert_result.is_ok(), "Inserting a new name should succeed");
 
     let delete_address_result = delete_address(
@@ -254,7 +281,7 @@ async fn insert_update_delete_address() {
     let insert_address_result = insert_address(
         name.clone(),
         types::SupportedNamespaces::Eip155,
-        None,
+        format!("{}", chain_id),
         new_address.clone(),
         &pg_pool,
     )
@@ -272,7 +299,7 @@ async fn insert_update_delete_address() {
         name.clone(),
         types::SupportedNamespaces::Eip155,
         None,
-        address.clone(),
+        address,
         &pg_pool,
     )
     .await;


### PR DESCRIPTION
# Description

This PR implementing changes to the ENS Gateway to address the updated [SPEC](https://github.com/WalletConnect/walletconnect-specs/pull/197).

The updated resolver response should be in the [ENSIP-11](https://alpha-docs.ens.domains/ensip/11) compatible format and should looks like:
```
{
  "name": "maxim.connect.id",
  "registered_at": "2024-01-23T18:50:02.083933Z",
  "updated_at": "2024-01-23T18:50:02.083933Z",
  "attributes": {
    "bio": "im a test"
  },
  "addresses": {
    "60": { // ENSIP-11 coin type. 60 - Ethereum Mainnet
        "address": "0xAff392551773CCb2574fAE23195CC3aFDBe98d18",
        "created_at": "2024-01-23T18:50:02.083933Z"
    }
  }
}
```

## How Has This Been Tested?

[Integration tests](https://github.com/WalletConnect/blockchain-api/pull/489/files#diff-29ee1e76a6651d33c3e1a5117e948675ccda1e60165c885696a9accdc1bf0bb9) for the name registration, lookup and reverse lookup are updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
