### PR TITLE
feat(ens): adding timestamp threshold check

### DIFF
--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -152,7 +152,7 @@ describe('blockchain api', () => {
     const messageObject = {
         name,
         address,
-        timestamp: Date.now()
+        timestamp: Math.round(Date.now() / 1000)
     };
     const message = JSON.stringify(messageObject);
 

--- a/src/handlers/profile/register.rs
+++ b/src/handlers/profile/register.rs
@@ -1,9 +1,11 @@
 use {
     super::{
         super::HANDLER_TASK_METRICS,
+        is_timestamp_within_interval,
         verify_message_signature,
         RegisterPayload,
         RegisterRequest,
+        UNIXTIMESTAMP_SYNC_THRESHOLD,
     },
     crate::{
         database::{
@@ -85,7 +87,14 @@ pub async fn handler_internal(
         return Ok((StatusCode::BAD_REQUEST, "Name is already registered").into_response());
     };
 
-    // TODO: Check the timestamp within 5-10 minutes ttl
+    // Check the timestamp is within the sync threshold interval
+    if !is_timestamp_within_interval(payload.timestamp, UNIXTIMESTAMP_SYNC_THRESHOLD) {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            "Timestamp is too old or in the future",
+        )
+            .into_response());
+    }
 
     let owner = match ethers::types::H160::from_str(&register_request.address) {
         Ok(owner) => owner,


### PR DESCRIPTION
# Description

According to the [SPEC](https://github.com/WalletConnect/walletconnect-specs/pull/184/files#diff-f64bf5c2b17c9c6d32ae9d85d9a1ce5a4aa07cb680c6f4085de94d3c4915b9d9R143) to avoid the repeating attack we should use the UNIX timestamp in the signature within the threshold interval (assuming clocks are not synced between this threshold). 
The threshold interval decreased to 10 seconds according to the discussion.

This PR implements the threshold check.

## How Has This Been Tested?

* New [unit tests](https://github.com/WalletConnect/blockchain-api/pull/491/files#diff-e382530ad7aeb0bbd6f4f0ac9bbddf4cc3944e24c387114ecc2dd640cf9e071fR108).
* Current integration tests for the name registration.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
