### PR TITLE
fix(providers): removing Aurora websocket from the Infura

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -42,6 +42,4 @@ WebSocket RPC is not recommended for production use, and may be removed in the f
 - Optimism Goerli (`eip155:420`)
 - Arbitrum (`eip155:42161`)
 - Arbitrum Goerli (`eip155:421613`)
-- Aurora (`eip155:1313161554`)
-- Aurora Testnet (`eip155:1313161555`)
 - Zora (`eip155:7777777`)

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -162,20 +162,5 @@ fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
-        // Aurora
-        (
-            "eip155:1313161554".into(),
-            (
-                "aurora-mainnet".into(),
-                Weight::new(Priority::Normal).unwrap(),
-            ),
-        ),
-        (
-            "eip155:1313161555".into(),
-            (
-                "aurora-testnet".into(),
-                Weight::new(Priority::Normal).unwrap(),
-            ),
-        ),
     ])
 }

--- a/tests/functional/websocket/infura.rs
+++ b/tests/functional/websocket/infura.rs
@@ -25,20 +25,4 @@ async fn infura_provider_websocket(ctx: &mut ServerContext) {
 
     // Arbitrum goerli
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:421613", "0x66eed").await;
-
-    // Aurora mainnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        "eip155:1313161554",
-        "0x4e454152",
-    )
-    .await;
-
-    // Aurora testnet
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        "eip155:1313161555",
-        "0x4e454153",
-    )
-    .await;
 }


### PR DESCRIPTION
# Description

This PR removing the Aurora chain (websocket) from the Infura provider as it's not supported anymore. 
Also Aurora is removed from the supported websocket chains list as we currently don't have a provider that support the Aurora by the websocket.

The HTTP was removed in #482 and this PR is a follow-up.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
