### PR TITLE
fix(tests): fixing database test for the recent ENSIP-11 update

### DIFF
--- a/src/database/helpers.rs
+++ b/src/database/helpers.rs
@@ -212,7 +212,7 @@ pub async fn get_name_and_addresses_by_name(
 pub async fn delete_address(
     name: String,
     namespace: types::SupportedNamespaces,
-    chain_id: Option<String>,
+    chain_id: String,
     address: String,
     postgres: &PgPool,
 ) -> Result<sqlx::postgres::PgQueryResult, DatabaseError> {
@@ -234,7 +234,7 @@ pub async fn delete_address(
     )
     .bind(&name)
     .bind(&namespace)
-    .bind(chain_id.unwrap_or_default())
+    .bind(chain_id)
     .bind(&address);
 
     query


### PR DESCRIPTION
# Description

This PR fixing the [database test fails](https://github.com/WalletConnect/blockchain-api/actions/runs/7660512571/job/20878285952#step:5:966) that was missed in #489 

## How Has This Been Tested?

1. Start the Postgres locally: `docker run -p 5432:5432 --name postgres -e POSTGRES_HOST_AUTH_METHOD=trust -d postgres`.
2. Run the database tests locally: `RPC_PROXY_POSTGRES_URI=postgres://postgres@localhost/postgres cargo test --test integration`.
3. Tests successfully passed.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
