### PR TITLE
feat(history): exposing dapp and chain info

### DIFF
--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -89,12 +89,18 @@ describe('blockchain api', () => {
       expect(typeof resp.data.next).toBe('string')
       expect(resp.data.next).toHaveLength(80)
       
-      const first = resp.data.data[0]
-      expect(first.id).toBeDefined()
-      expect(typeof first.metadata).toBe('object')
-      expect(first.metadata.chain).toBeDefined()
-      expect(typeof first.metadata.application).toBe('object')
-      expect(typeof first.transfers).toBe('object')
+      for (const item of resp.data.data) {
+        expect(item.id).toBeDefined()
+        expect(typeof item.metadata).toBe('object')
+        // expect chain to be null or caip-2 format
+        if (item.metadata.chain !== null) {
+          expect(item.metadata.chain).toEqual(expect.stringMatching(/^(eip155:)?\d+$/));
+        } else {
+          expect(item.metadata.chain).toBeNull();
+        }
+        expect(typeof item.metadata.application).toBe('object')
+        expect(typeof item.transfers).toBe('object')
+      }
     })
     it('empty history', async () => {
       let resp: any = await http.get(

--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -88,6 +88,13 @@ describe('blockchain api', () => {
       expect(resp.data.data).toHaveLength(50)
       expect(typeof resp.data.next).toBe('string')
       expect(resp.data.next).toHaveLength(80)
+      
+      const first = resp.data.data[0]
+      expect(first.id).toBeDefined()
+      expect(typeof first.metadata).toBe('object')
+      expect(first.metadata.chain).toBeDefined()
+      expect(typeof first.metadata.application).toBe('object')
+      expect(typeof first.transfers).toBe('object')
     })
     it('empty history', async () => {
       let resp: any = await http.get(

--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -56,6 +56,15 @@ pub struct HistoryTransactionMetadata {
     pub sent_to: String,
     pub status: String,
     pub nonce: usize,
+    pub application: Option<HistoryTransactionMetadataApplication>,
+    pub chain: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryTransactionMetadataApplication {
+    pub name: Option<String>,
+    pub icon_url: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]

--- a/src/providers/coinbase.rs
+++ b/src/providers/coinbase.rs
@@ -127,6 +127,8 @@ impl HistoryProvider for CoinbaseProvider {
                     sent_from: "Coinbase".to_string(),
                     sent_to: address.clone(),
                     status: f.status,
+                    application: None,
+                    chain: None,
                 },
                 transfers: Some(vec![HistoryTransactionTransfer {
                     fungible_info: Some(HistoryTransactionFungibleInfo {

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -7,8 +7,16 @@ use {
                 HistoryQueryParams,
                 HistoryResponseBody,
                 HistoryTransaction,
+                HistoryTransactionFungibleInfo,
                 HistoryTransactionMetadata,
+                HistoryTransactionMetadataApplication,
+                HistoryTransactionNFTContent,
+                HistoryTransactionNFTInfo,
+                HistoryTransactionNFTInfoFlags,
                 HistoryTransactionTransfer,
+                HistoryTransactionTransferQuantity,
+                HistoryTransactionURLItem,
+                HistoryTransactionURLandContentTypeItem,
             },
             portfolio::{PortfolioPosition, PortfolioQueryParams, PortfolioResponseBody},
         },
@@ -81,6 +89,23 @@ pub struct ZerionTransactionsReponseBody {
     pub r#type: String,
     pub id: String,
     pub attributes: ZerionTransactionAttributes,
+    pub relationships: ZerionTransactionsRelationships,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ZerionTransactionsRelationships {
+    pub chain: ZerionTransactionsRelationshipsChain,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ZerionTransactionsRelationshipsChain {
+    pub data: ZerionTransactionsRelationshipsChainData,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ZerionTransactionsRelationshipsChainData {
+    pub r#type: String,
+    pub id: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -93,7 +118,70 @@ pub struct ZerionTransactionAttributes {
     pub sent_to: String,
     pub status: String,
     pub nonce: usize,
-    pub transfers: Vec<HistoryTransactionTransfer>,
+    pub transfers: Vec<ZerionTransactionTransfer>,
+    pub application_metadata: Option<ZerionTransactionApplicationMetadata>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ZerionTransactionTransfer {
+    pub fungible_info: Option<ZerionTransactionFungibleInfo>,
+    pub nft_info: Option<ZerionTransactionNFTInfo>,
+    pub direction: String,
+    pub quantity: ZerionTransactionTransferQuantity,
+    pub value: Option<f64>,
+    pub price: Option<f64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionFungibleInfo {
+    pub name: Option<String>,
+    pub symbol: Option<String>,
+    pub icon: Option<ZerionTransactionURLItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionURLItem {
+    pub url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionTransferQuantity {
+    pub numeric: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionNFTInfo {
+    pub name: Option<String>,
+    pub content: Option<ZerionTransactionNFTContent>,
+    pub flags: ZerionTransactionNFTInfoFlags,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionNFTInfoFlags {
+    pub is_spam: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionNFTContent {
+    pub preview: Option<ZerionTransactionURLandContentTypeItem>,
+    pub detail: Option<ZerionTransactionURLandContentTypeItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionTransactionURLandContentTypeItem {
+    pub url: String,
+    pub content_type: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ZerionTransactionApplicationMetadata {
+    pub name: Option<String>,
+    pub icon: Option<ZerionUrlItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ZerionUrlItem {
+    pub url: String,
 }
 
 #[async_trait]
@@ -174,8 +262,60 @@ impl HistoryProvider for ZerionProvider {
                     sent_from: f.attributes.sent_from,
                     sent_to: f.attributes.sent_to,
                     status: f.attributes.status,
+                    application: f.attributes.application_metadata.map(|f| {
+                        HistoryTransactionMetadataApplication {
+                            name: f.name,
+                            icon_url: f.icon.map(|f| f.url),
+                        }
+                    }),
+                    chain: if f.relationships.chain.data.r#type != "chains" {
+                        None
+                    } else {
+                        Some(f.relationships.chain.data.id)
+                    },
                 },
-                transfers: Some(f.attributes.transfers),
+                transfers: f
+                    .attributes
+                    .transfers
+                    .into_iter()
+                    .map(|f| {
+                        Some(HistoryTransactionTransfer {
+                            fungible_info: f.fungible_info.map(|f| {
+                                HistoryTransactionFungibleInfo {
+                                    name: f.name,
+                                    symbol: f.symbol,
+                                    icon: f.icon.map(|f| HistoryTransactionURLItem { url: f.url }),
+                                }
+                            }),
+                            nft_info: f.nft_info.map(|f| HistoryTransactionNFTInfo {
+                                name: f.name,
+                                content: f.content.map(|f| HistoryTransactionNFTContent {
+                                    preview: f.preview.map(|f| {
+                                        HistoryTransactionURLandContentTypeItem {
+                                            url: f.url,
+                                            content_type: f.content_type,
+                                        }
+                                    }),
+                                    detail: f.detail.map(|f| {
+                                        HistoryTransactionURLandContentTypeItem {
+                                            url: f.url,
+                                            content_type: f.content_type,
+                                        }
+                                    }),
+                                }),
+                                flags: HistoryTransactionNFTInfoFlags {
+                                    is_spam: f.flags.is_spam,
+                                },
+                            }),
+                            direction: f.direction,
+                            quantity: HistoryTransactionTransferQuantity {
+                                numeric: f.quantity.numeric,
+                            },
+                            value: f.value,
+                            price: f.price,
+                        })
+                    })
+                    .collect(),
             })
             .collect();
 

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -282,7 +282,7 @@ impl HistoryProvider for ZerionProvider {
                                     "Error on parsing chain id to caip2 format: {:?}",
                                     f.relationships.chain.data.id
                                 );
-                                Some(f.relationships.chain.data.id)
+                                None
                             }
                         }
                     },


### PR DESCRIPTION
# Description

This PR exposes the `chain` from the [Zerion history](https://developers.zerion.io/reference/listwallettransactions) `relationships` object and the dapp info from the `attributes.application_metadata`.

Following new objects were added into the history response:

* metadata.application
  * name (Optional, String) - DApp name
  * iconUrl (Optional, String) - DApp icon url
* metadata.chain (Optional, String) - String representation of the chain from the `relationships` Zerion response in CAIP-2 format.

The example response:

```
...
{
      "id": "904c7ac7e1dc5ddd9aed4ceba06ee290",
      "metadata": {
        "operationType": "receive",
        "hash": "0x0f12fde4d498ad01baa181f433ad46ff6ce760af5bfe388418c243f2e2fb168b",
        "minedAt": "2023-12-04T11:02:25Z",
        "sentFrom": "0xd09a341d601505b0c8a0377acc962802e5f3fb65",
        "sentTo": "0x2c27e884cbe02252587ef62c5647ecb9a8936f3e",
        "status": "confirmed",
        "nonce": 76792,
        "application": { // NEW DAPP OBJECT
          "name": "USDC",
          "iconUrl": "https://token-icons.s3.amazonaws.com/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png"
        },
        "chain": "eip155:56" // NEW CHAIN STRING
      },
      "transfers": [
      ...
      ]
    },
...
```

The context of this task: https://walletconnect.slack.com/archives/C03SCF66K2T/p1706184453173909

## How Has This Been Tested?

1. Manual
* Start the server locally by: `cargo run`
* Run the curl query to get the transactions list: `curl -v 'http://localhost:3000/v1/account/0x63755B7B300228254FB7d16321eCD3B87f98ca2a/history?projectId=xxx' | jq .`

2. Integration tests for the fulfilled history are updated to check new objects' presence.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
