### PR TITLE
fix(ci): fixing the new integration test expected code from `400` to `401`

### DIFF
--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -329,7 +329,7 @@ describe('blockchain api', () => {
         `${baseUrl}/v1?chainId=${chainId}&projectId=${notAllowedProjectId}&providerId=${providerId}`,
         payload
       )
-      expect(resp.status).toBe(400)
+      expect(resp.status).toBe(401)
     })
   })
 })


### PR DESCRIPTION
# Description

This is a small change to fix the expected status code in the integration test from `400` to `401`. This fixing the [following error](https://github.com/WalletConnect/blockchain-api/actions/runs/7741353150/job/21109965889#step:5:51).

## How Has This Been Tested?

Integration test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
