### PR TITLE
feat(ens): check for supported attributes and value format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4013,6 +4013,7 @@ dependencies = [
  "pnet_datalink",
  "prometheus-http-query",
  "rand",
+ "regex",
  "rmp-serde",
  "serde",
  "serde-aux",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ prometheus-http-query = "0.6.6"
 ethers = { version = "2.0.11", git = "https://github.com/gakonst/ethers-rs" } # using Git version because crates.io version fails clippy
 
 bytes = "1.4.0"
+regex = "1.10"
 sha256 = "1.2.2"
 
 [dev-dependencies]

--- a/integration/names.test.ts
+++ b/integration/names.test.ts
@@ -45,6 +45,30 @@ describe('Account profile names', () => {
     )
     expect(resp.status).toBe(401)
   })
+
+  it('register with wrong attributes', async () => {
+    // Create a message to sign with wrong attributes
+    const wrongAttributesMessageObject = {
+      name,
+      attributes: { someAttribute: 'some attribute name' },
+      timestamp: Math.round(Date.now() / 1000)
+    };
+    const message = JSON.stringify(wrongAttributesMessageObject);
+    const signature = await wallet.signMessage(message);
+
+    const payload = {
+      message,
+      signature,
+      coin_type,
+      address,
+    };
+    let resp: any = await httpClient.post(
+      `${baseUrl}/v1/profile/account/${name}`,
+      payload
+    )
+    expect(resp.status).toBe(400)
+  })
+
   it('register new name', async () => {
     // Sign the message
     const signature = await wallet.signMessage(message);

--- a/src/handlers/profile/mod.rs
+++ b/src/handlers/profile/mod.rs
@@ -1,19 +1,29 @@
 use {
-    ethers::types::H160,
+    once_cell::sync::Lazy,
+    regex::Regex,
     serde::{Deserialize, Serialize},
-    std::{
-        collections::HashMap,
-        str::FromStr,
-        time::{SystemTime, UNIX_EPOCH},
-    },
-    tap::TapFallible,
+    std::collections::HashMap,
 };
 
 pub mod lookup;
 pub mod register;
 pub mod reverse;
+pub mod utils;
 
 pub const UNIXTIMESTAMP_SYNC_THRESHOLD: u64 = 10;
+
+/// Attributes value max length
+const ATTRIBUTES_VALUE_MAX_LENGTH: usize = 255;
+
+/// List of supported attributes with the regex check pattern
+static SUPPORTED_ATTRIBUTES: Lazy<HashMap<String, Regex>> = Lazy::new(|| {
+    let mut map: HashMap<String, Regex> = HashMap::new();
+    map.insert(
+        "bio".into(),
+        Regex::new(r"^[a-zA-Z0-9@:/._\-?&=+ ]+$").expect("Invalid regex for bio"),
+    );
+    map
+});
 
 /// Payload to register domain name that should be serialized to JSON
 /// and passed to the RegisterRequest.message
@@ -44,104 +54,4 @@ pub struct RegisterRequest {
     pub coin_type: u32,
     /// Address
     pub address: String,
-}
-
-#[tracing::instrument]
-pub fn verify_message_signature(
-    message: &str,
-    signature: &str,
-    owner: &H160,
-) -> Result<bool, Box<dyn std::error::Error>> {
-    let prefixed_message = format!("\x19Ethereum Signed Message:\n{}{}", message.len(), message);
-    let message_hash = ethers::core::utils::keccak256(prefixed_message.clone());
-    let message_hash = ethers::types::H256::from_slice(&message_hash);
-
-    let sign = ethers::types::Signature::from_str(signature)?;
-    match sign.verify(message_hash, *owner) {
-        Ok(_) => Ok(true),
-        Err(_) => Ok(false),
-    }
-}
-
-/// Check if the given unixtimestamp is within the threshold interval relative
-/// to the current time
-#[tracing::instrument(level = "debug")]
-pub fn is_timestamp_within_interval(unix_timestamp: u64, threshold_interval: u64) -> bool {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .tap_err(|_| tracing::error!("SystemTime before UNIX EPOCH!"))
-        .unwrap_or_default()
-        .as_secs();
-
-    unix_timestamp >= (now - threshold_interval) && unix_timestamp <= (now + threshold_interval)
-}
-
-#[cfg(test)]
-mod tests {
-    use {super::*, ethers::types::H160, std::str::FromStr};
-
-    #[test]
-    fn test_verify_message_signature_valid() {
-        let message = "test message signature";
-        let signature = "0x660739ee06920c5f55fbaf0da4f435faaa9c55e2c9da303c50c4b3865191d67e5002a0b10eb0f89bae66823f7f07415ea9d5bbb607ee61ac98b7f2a0a44fcb5c1b";
-        let owner = H160::from_str("0xAff392551773CCb2574fAE23195CC3aFDBe98d18").unwrap();
-
-        let result = verify_message_signature(message, signature, &owner);
-        assert!(result.is_ok());
-        assert!(result.unwrap());
-    }
-
-    #[test]
-    fn test_verify_message_signature_json() {
-        let message = r#"{\"test\":\"some my text\"}"#;
-        let signature = "0x2fe0b640b4036c9c97911e6f22c72a2c934f1d67db02948055c0e0c84dbf4f2b33c2f8c4b000642735dbf5d1c96ba48ccd2a998324c9e4cb7bb776f0c95ee2fc1b";
-        let owner = H160::from_str("0xAff392551773CCb2574fAE23195CC3aFDBe98d18").unwrap();
-
-        let result = verify_message_signature(message, signature, &owner);
-        assert!(result.is_ok());
-        println!("result: {:?}", result);
-        assert!(result.unwrap());
-    }
-
-    #[test]
-    fn test_verify_message_signature_invalid() {
-        let message = "wrong message signature";
-        let signature = "0x660739ee06920c5f55fbaf0da4f435faaa9c55e2c9da303c50c4b3865191d67e5002a0b10eb0f89bae66823f7f07415ea9d5bbb607ee61ac98b7f2a0a44fcb5c1b"; // The signature of the message
-        let owner = H160::from_str("0xAff392551773CCb2574fAE23195CC3aFDBe98d18").unwrap(); // The Ethereum address of the signer
-
-        let result = verify_message_signature(message, signature, &owner);
-        assert!(result.is_ok());
-        assert!(!result.unwrap());
-    }
-
-    #[test]
-    fn test_verify_is_timestamp_within_interval_valid() {
-        let threshold_interval = 10;
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .tap_err(|_| tracing::error!("SystemTime before UNIX EPOCH!"))
-            .unwrap_or_default()
-            .as_secs();
-        assert!(is_timestamp_within_interval(now, threshold_interval));
-    }
-
-    #[test]
-    fn test_verify_is_timestamp_within_interval_invalid() {
-        let threshold_interval = 10;
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .tap_err(|_| tracing::error!("SystemTime before UNIX EPOCH!"))
-            .unwrap_or_default()
-            .as_secs();
-        // Upper bound reached
-        assert!(!is_timestamp_within_interval(
-            now + threshold_interval + 1,
-            threshold_interval
-        ));
-        // Lower bound reached
-        assert!(!is_timestamp_within_interval(
-            now - threshold_interval - 1,
-            threshold_interval
-        ));
-    }
 }

--- a/src/handlers/profile/register.rs
+++ b/src/handlers/profile/register.rs
@@ -1,7 +1,7 @@
 use {
     super::{
         super::HANDLER_TASK_METRICS,
-        is_timestamp_within_interval,
+        utils::{check_attributes, is_timestamp_within_interval},
         RegisterPayload,
         RegisterRequest,
         UNIXTIMESTAMP_SYNC_THRESHOLD,
@@ -117,6 +117,22 @@ pub async fn handler_internal(
             return Ok((StatusCode::BAD_REQUEST, "Invalid H160 address format").into_response());
         }
     };
+
+    // Check for supported attributes
+    if let Some(attributes) = payload.attributes.clone() {
+        if !check_attributes(
+            &attributes,
+            &super::SUPPORTED_ATTRIBUTES,
+            super::ATTRIBUTES_VALUE_MAX_LENGTH,
+        ) {
+            return Ok((
+                StatusCode::BAD_REQUEST,
+                "Unsupported attribute in
+        payload",
+            )
+                .into_response());
+        }
+    }
 
     // Check the signature
     let sinature_check =

--- a/src/handlers/profile/utils.rs
+++ b/src/handlers/profile/utils.rs
@@ -1,0 +1,164 @@
+use {
+    ethers::types::H160,
+    regex::Regex,
+    std::{
+        collections::HashMap,
+        str::FromStr,
+        time::{SystemTime, UNIX_EPOCH},
+    },
+    tap::TapFallible,
+};
+
+#[tracing::instrument]
+pub fn verify_message_signature(
+    message: &str,
+    signature: &str,
+    owner: &H160,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let prefixed_message = format!("\x19Ethereum Signed Message:\n{}{}", message.len(), message);
+    let message_hash = ethers::core::utils::keccak256(prefixed_message.clone());
+    let message_hash = ethers::types::H256::from_slice(&message_hash);
+
+    let sign = ethers::types::Signature::from_str(signature)?;
+    match sign.verify(message_hash, *owner) {
+        Ok(_) => Ok(true),
+        Err(_) => Ok(false),
+    }
+}
+
+/// Check if the given unixtimestamp is within the threshold interval relative
+/// to the current time
+#[tracing::instrument(level = "debug")]
+pub fn is_timestamp_within_interval(unix_timestamp: u64, threshold_interval: u64) -> bool {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .tap_err(|_| tracing::error!("SystemTime before UNIX EPOCH!"))
+        .unwrap_or_default()
+        .as_secs();
+
+    unix_timestamp >= (now - threshold_interval) && unix_timestamp <= (now + threshold_interval)
+}
+
+/// Check if the given attributes map contains only supported attributes
+/// in the given format and length
+pub fn check_attributes(
+    attributes_map: &HashMap<String, String>,
+    keys_allowed: &HashMap<String, Regex>,
+    max_length: usize,
+) -> bool {
+    attributes_map.iter().all(|(key, value)| {
+        if !keys_allowed.contains_key(key) {
+            return false;
+        }
+        if value.is_empty() || value.len() > max_length {
+            return false;
+        }
+        keys_allowed[key].is_match(value)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::handlers::profile::{ATTRIBUTES_VALUE_MAX_LENGTH, SUPPORTED_ATTRIBUTES},
+        ethers::types::H160,
+        std::str::FromStr,
+    };
+
+    #[test]
+    fn test_verify_message_signature_valid() {
+        let message = "test message signature";
+        let signature = "0x660739ee06920c5f55fbaf0da4f435faaa9c55e2c9da303c50c4b3865191d67e5002a0b10eb0f89bae66823f7f07415ea9d5bbb607ee61ac98b7f2a0a44fcb5c1b";
+        let owner = H160::from_str("0xAff392551773CCb2574fAE23195CC3aFDBe98d18").unwrap();
+
+        let result = verify_message_signature(message, signature, &owner);
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_verify_message_signature_json() {
+        let message = r#"{\"test\":\"some my text\"}"#;
+        let signature = "0x2fe0b640b4036c9c97911e6f22c72a2c934f1d67db02948055c0e0c84dbf4f2b33c2f8c4b000642735dbf5d1c96ba48ccd2a998324c9e4cb7bb776f0c95ee2fc1b";
+        let owner = H160::from_str("0xAff392551773CCb2574fAE23195CC3aFDBe98d18").unwrap();
+
+        let result = verify_message_signature(message, signature, &owner);
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_verify_message_signature_invalid() {
+        let message = "wrong message signature";
+        let signature = "0x660739ee06920c5f55fbaf0da4f435faaa9c55e2c9da303c50c4b3865191d67e5002a0b10eb0f89bae66823f7f07415ea9d5bbb607ee61ac98b7f2a0a44fcb5c1b"; // The signature of the message
+        let owner = H160::from_str("0xAff392551773CCb2574fAE23195CC3aFDBe98d18").unwrap(); // The Ethereum address of the signer
+
+        let result = verify_message_signature(message, signature, &owner);
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_verify_is_timestamp_within_interval_valid() {
+        let threshold_interval = 10;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .tap_err(|_| tracing::error!("SystemTime before UNIX EPOCH!"))
+            .unwrap_or_default()
+            .as_secs();
+        assert!(is_timestamp_within_interval(now, threshold_interval));
+    }
+
+    #[test]
+    fn test_verify_is_timestamp_within_interval_invalid() {
+        let threshold_interval = 10;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .tap_err(|_| tracing::error!("SystemTime before UNIX EPOCH!"))
+            .unwrap_or_default()
+            .as_secs();
+        // Upper bound reached
+        assert!(!is_timestamp_within_interval(
+            now + threshold_interval + 1,
+            threshold_interval
+        ));
+        // Lower bound reached
+        assert!(!is_timestamp_within_interval(
+            now - threshold_interval - 1,
+            threshold_interval
+        ));
+    }
+
+    #[test]
+    fn test_check_attributes() {
+        let valid_map: HashMap<String, String> = HashMap::from([("bio".into(), "Test bio".into())]);
+        let invalid_key_map: HashMap<String, String> = HashMap::from([
+            ("some_key".into(), "some text".into()),
+            ("bio".into(), "Some bio".into()),
+        ]);
+        let invalid_character_map: HashMap<String, String> =
+            HashMap::from([("bio".into(), "Bio *>".into())]);
+
+        // Valid
+        assert!(check_attributes(
+            &valid_map,
+            &SUPPORTED_ATTRIBUTES,
+            ATTRIBUTES_VALUE_MAX_LENGTH,
+        ));
+        // Invalid attributes key
+        assert!(!check_attributes(
+            &invalid_key_map,
+            &SUPPORTED_ATTRIBUTES,
+            ATTRIBUTES_VALUE_MAX_LENGTH,
+        ));
+        // Invalid value length
+        assert!(!check_attributes(&valid_map, &SUPPORTED_ATTRIBUTES, 4,));
+        // Invalid characters
+        assert!(!check_attributes(
+            &invalid_character_map,
+            &SUPPORTED_ATTRIBUTES,
+            ATTRIBUTES_VALUE_MAX_LENGTH,
+        ));
+    }
+}


### PR DESCRIPTION
# Description

This PR adds a check for the supported name attributes to prevent registration with the attributes that are not supported or in the wrong format. The following changes are made:
* [check_attributes](https://github.com/WalletConnect/blockchain-api/commit/ab4f9b9ac9b5b579dbf3ed578c24a324fecd83d4#diff-f8a4ed25bf7d7d3b6998382ac049bed43c3275bfb07ac13bc8f4c47be087fa76R44) function is added to check keys in the attributes map to contain [only supported attributes and check the attribute value format by regexp](https://github.com/WalletConnect/blockchain-api/commit/ab4f9b9ac9b5b579dbf3ed578c24a324fecd83d4#diff-e382530ad7aeb0bbd6f4f0ac9bbddf4cc3944e24c387114ecc2dd640cf9e071fR19) for the certain attribute type.
* minor refactoring: [moved all utilities functions to the utils.rs](https://github.com/WalletConnect/blockchain-api/commit/ab4f9b9ac9b5b579dbf3ed578c24a324fecd83d4#diff-e382530ad7aeb0bbd6f4f0ac9bbddf4cc3944e24c387114ecc2dd640cf9e071fL48-L147)

## How Has This Been Tested?

* [Unit test](https://github.com/WalletConnect/blockchain-api/commit/ab4f9b9ac9b5b579dbf3ed578c24a324fecd83d4#diff-f8a4ed25bf7d7d3b6998382ac049bed43c3275bfb07ac13bc8f4c47be087fa76R134) for the new function,
* [Integration test](https://github.com/WalletConnect/blockchain-api/commit/ab4f9b9ac9b5b579dbf3ed578c24a324fecd83d4#diff-29ee1e76a6651d33c3e1a5117e948675ccda1e60165c885696a9accdc1bf0bb9R197).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
