### PR TITLE
feat(analytics): onramp transactions history analytics

### DIFF
--- a/src/analytics/onramp_history_lookup_info.rs
+++ b/src/analytics/onramp_history_lookup_info.rs
@@ -1,0 +1,58 @@
+use {
+    parquet_derive::ParquetRecordWriter,
+    serde::Serialize,
+    std::{sync::Arc, time::Duration},
+};
+
+#[derive(Debug, Clone, Serialize, ParquetRecordWriter)]
+pub struct OnrampHistoryLookupInfo {
+    pub timestamp: chrono::NaiveDateTime,
+    pub latency_secs: f64,
+
+    pub lookup_address: String,
+    pub project_id: String,
+
+    pub origin: Option<String>,
+    pub region: Option<String>,
+    pub country: Option<Arc<str>>,
+    pub continent: Option<Arc<str>>,
+
+    pub transaction_status: String,
+    pub purchase_currency: String,
+    pub purchase_network: String,
+    pub purchase_amount: String,
+}
+
+impl OnrampHistoryLookupInfo {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        latency: Duration,
+        lookup_address: String,
+        project_id: String,
+        origin: Option<String>,
+        region: Option<Vec<String>>,
+        country: Option<Arc<str>>,
+        continent: Option<Arc<str>>,
+
+        transaction_status: String,
+        purchase_currency: String,
+        purchase_network: String,
+        purchase_amount: String,
+    ) -> Self {
+        OnrampHistoryLookupInfo {
+            timestamp: wc::analytics::time::now(),
+            latency_secs: latency.as_secs_f64(),
+            lookup_address,
+            project_id,
+            origin,
+            country,
+            region: region.map(|r| r.join(", ")),
+            continent,
+
+            transaction_status,
+            purchase_currency,
+            purchase_network,
+            purchase_amount,
+        }
+    }
+}

--- a/src/providers/coinbase.rs
+++ b/src/providers/coinbase.rs
@@ -11,6 +11,7 @@ use {
             HistoryTransactionTransfer,
             HistoryTransactionTransferQuantity,
         },
+        utils::crypto::string_chain_id_to_caip2_format,
     },
     async_trait::async_trait,
     axum::{body::Bytes, http::method},
@@ -53,6 +54,7 @@ pub struct CoinbaseTransaction {
     pub transaction_id: String,
     pub tx_hash: String,
     pub created_at: String,
+    pub purchase_network: String,
     pub purchase_amount: CoinbasePurchaseAmount,
 }
 
@@ -128,7 +130,7 @@ impl HistoryProvider for CoinbaseProvider {
                     sent_to: address.clone(),
                     status: f.status,
                     application: None,
-                    chain: None,
+                    chain: string_chain_id_to_caip2_format(&f.purchase_network).ok(),
                 },
                 transfers: Some(vec![HistoryTransactionTransfer {
                     fungible_info: Some(HistoryTransactionFungibleInfo {


### PR DESCRIPTION
# Description

This PR extracts the onramp transactions history analytics.
The following fields are included in the [onramp transaction analytics object](https://github.com/WalletConnect/blockchain-api/pull/498/files#diff-11beafba26762442363d5775947e0edd9c71eb2d24696e09eacf659725a3f07eR8-R24):

Common:

* `timestamp`
* `latency_secs`
* `lookup_address`
* `project_id`

Geo data:

* `origin`
* `region`
* `country`
* `continent`

Transaction:

* `transaction_status`: Status of the transaction:
  * `ONRAMP_TRANSACTION_STATUS_CREATED`
  * `ONRAMP_TRANSACTION_STATUS_IN_PROGRESS`
  * `ONRAMP_TRANSACTION_STATUS_SUCCESS`
  * `ONRAMP_TRANSACTION_STATUS_FAILED`
* `purchase_currency`: Crypto currency being purchased. Example: `USDC` 
* `purchase_network`: Network used to deliver crypto to the user’s wallet in CAIP-2 format. Example: `eip155:1`
* `purchase_amount`: Amount of crypto currency being purchased.

The new analytics S3 export prefix is `blockchain-api/onramp-history-lookups` with the name of `onramp-history_lookups`.

## How Has This Been Tested?

* Analytics is not tested.
* Correctness of the history endpoint response is tested by the integration test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
