### PR TITLE
feat(onramp): adding onramp buy options endpoint

### DIFF
--- a/integration/onramp.test.ts
+++ b/integration/onramp.test.ts
@@ -1,0 +1,30 @@
+import { getTestSetup } from './init';
+
+describe('OnRamp', () => {
+  const { baseUrl, projectId, httpClient } = getTestSetup();
+  const onRampPath = `${baseUrl}/v1/onramp`;
+
+  it('buy options', async () => {
+    let resp: any = await httpClient.get(
+      `${onRampPath}/buy/options?projectId=${projectId}&country=US&subdivision=NY`,
+    )
+    expect(resp.status).toBe(200)
+    
+    const firstPayment = resp.data.paymentCurrencies[0]
+    expect(typeof firstPayment.id).toBe('string')
+    const firstPaymentLimits = firstPayment.limits[0]
+    expect(typeof firstPaymentLimits.id).toBe('string')
+    expect(typeof firstPaymentLimits.min).toBe('string')
+    expect(typeof firstPaymentLimits.max).toBe('string')
+
+    const firstPurchase = resp.data.purchaseCurrencies[0]
+    expect(typeof firstPurchase.id).toBe('string')
+    expect(typeof firstPurchase.name).toBe('string')
+    expect(typeof firstPurchase.symbol).toBe('string')
+    const firstPurchaseNetworks = firstPurchase.networks[0]
+    expect(typeof firstPurchaseNetworks.name).toBe('string')
+    expect(typeof firstPurchaseNetworks.displayName).toBe('string')
+    expect(typeof firstPurchaseNetworks.contractAddress).toBe('string')
+    expect(typeof firstPurchaseNetworks.chainId).toBe('string')
+  })
+})

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,6 +55,9 @@ pub enum RpcError {
     #[error("Failed to reach the portfolio provider")]
     PortfolioProviderError,
 
+    #[error("Failed to parse onramp provider url")]
+    OnRampParseURLError,
+
     #[error("Failed to reach the onramp provider")]
     OnRampProviderError,
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod health;
 pub mod history;
 pub mod identity;
 pub mod metrics;
+pub mod onramp;
 pub mod portfolio;
 pub mod profile;
 pub mod proxy;

--- a/src/handlers/onramp/mod.rs
+++ b/src/handlers/onramp/mod.rs
@@ -1,0 +1,1 @@
+pub mod options;

--- a/src/handlers/onramp/options.rs
+++ b/src/handlers/onramp/options.rs
@@ -1,0 +1,96 @@
+use {
+    crate::{error::RpcError, handlers::HANDLER_TASK_METRICS, state::AppState},
+    axum::{
+        extract::{ConnectInfo, Query, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    hyper::HeaderMap,
+    serde::{Deserialize, Serialize},
+    std::{net::SocketAddr, sync::Arc},
+    tap::TapFallible,
+    tracing::log::error,
+    wc::future::FutureExt,
+};
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct OnRampBuyOptionsParams {
+    pub project_id: String,
+    pub country: String,
+    pub subdivision: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OnRampBuyOptionsResponse {
+    #[serde(rename(serialize = "paymentCurrencies"))]
+    pub payment_currencies: Vec<PaymentCurrenciesLimits>,
+    #[serde(rename(serialize = "purchaseCurrencies"))]
+    pub purchase_currencies: Vec<PurchaseCurrencies>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PaymentCurrenciesLimits {
+    pub id: String,
+    pub limits: Vec<PaymentCurrenciesLimit>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PaymentCurrenciesLimit {
+    pub id: String,
+    pub min: String,
+    pub max: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PurchaseCurrencies {
+    pub id: String,
+    pub name: String,
+    pub symbol: String,
+    pub networks: Vec<PurchaseCurrencyNetwork>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PurchaseCurrencyNetwork {
+    pub name: String,
+    #[serde(rename(serialize = "displayName"))]
+    pub display_name: String,
+    #[serde(rename(serialize = "contractAddress"))]
+    pub contract_address: String,
+    #[serde(rename(serialize = "chainId"))]
+    pub chain_id: String,
+}
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    connect_info: ConnectInfo<SocketAddr>,
+    query: Query<OnRampBuyOptionsParams>,
+    headers: HeaderMap,
+) -> Result<Response, RpcError> {
+    handler_internal(state, connect_info, query, headers)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("onrmap_buy_options"))
+        .await
+}
+
+#[tracing::instrument(skip_all)]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    _connect_info: ConnectInfo<SocketAddr>,
+    query: Query<OnRampBuyOptionsParams>,
+    _headers: HeaderMap,
+) -> Result<Response, RpcError> {
+    state
+        .validate_project_access_and_quota(&query.project_id)
+        .await?;
+
+    let buy_options = state
+        .providers
+        .onramp_provider
+        .get_buy_options(query.0)
+        .await
+        .tap_err(|e| {
+            error!("Failed to call coinbase buy options with {}", e);
+        })?;
+
+    Ok(Json(buy_options).into_response())
+}

--- a/src/handlers/onramp/options.rs
+++ b/src/handlers/onramp/options.rs
@@ -10,14 +10,17 @@ use {
     std::{net::SocketAddr, sync::Arc},
     tap::TapFallible,
     tracing::log::error,
+    validator::Validate,
     wc::future::FutureExt,
 };
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct OnRampBuyOptionsParams {
     pub project_id: String,
+    #[validate(length(equal = 2))]
     pub country: String,
+    #[validate(length(equal = 2))]
     pub subdivision: Option<String>,
 }
 
@@ -86,7 +89,7 @@ async fn handler_internal(
     let buy_options = state
         .providers
         .onramp_provider
-        .get_buy_options(query.0)
+        .get_buy_options(query.0, state.http_client.clone())
         .await
         .tap_err(|e| {
             error!("Failed to call coinbase buy options with {}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,6 +248,11 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/generators/onrampurl",
             post(handlers::generators::onrampurl::handler),
         )
+        // OnRamp
+        .route(
+            "/v1/onramp/buy/options",
+            get(handlers::onramp::options::handler),
+        )
         .route_layer(tracing_and_metrics_layer)
         .route("/health", get(handlers::health::handler))
         .layer(cors);

--- a/src/providers/coinbase.rs
+++ b/src/providers/coinbase.rs
@@ -173,7 +173,7 @@ impl OnRampProvider for CoinbaseProvider {
                 "Error on CoinBase buy options response. Status is not OK: {:?}",
                 response.status(),
             );
-            return Err(RpcError::TransactionProviderError);
+            return Err(RpcError::OnRampProviderError);
         }
 
         Ok(response.json::<OnRampBuyOptionsResponse>().await?)

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -5,6 +5,7 @@ use {
         error::{RpcError, RpcResult},
         handlers::{
             history::{HistoryQueryParams, HistoryResponseBody},
+            onramp::options::{OnRampBuyOptionsParams, OnRampBuyOptionsResponse},
             portfolio::{PortfolioQueryParams, PortfolioResponseBody},
             RpcQueryParams,
         },
@@ -82,6 +83,7 @@ pub struct ProviderRepository {
     pub history_provider: Arc<dyn HistoryProvider>,
     pub portfolio_provider: Arc<dyn PortfolioProvider>,
     pub coinbase_pay_provider: Arc<dyn HistoryProvider>,
+    pub onramp_provider: Arc<dyn OnRampProvider>,
 }
 
 impl ProviderRepository {
@@ -125,8 +127,11 @@ impl ProviderRepository {
 
         let history_provider = Arc::new(ZerionProvider::new(zerion_api_key));
         let portfolio_provider = history_provider.clone();
-        let coinbase_pay_provider =
-            Arc::new(CoinbaseProvider::new(coinbase_api_key, coinbase_app_id));
+        let coinbase_pay_provider = Arc::new(CoinbaseProvider::new(
+            coinbase_api_key,
+            coinbase_app_id,
+            "https://pay.coinbase.com/api/v1".into(),
+        ));
 
         Self {
             providers: HashMap::new(),
@@ -137,7 +142,8 @@ impl ProviderRepository {
             prometheus_workspace_header,
             history_provider,
             portfolio_provider,
-            coinbase_pay_provider,
+            coinbase_pay_provider: coinbase_pay_provider.clone(),
+            onramp_provider: coinbase_pay_provider,
         }
     }
 
@@ -483,4 +489,12 @@ pub trait PortfolioProvider: Send + Sync + Debug {
         body: hyper::body::Bytes,
         params: PortfolioQueryParams,
     ) -> RpcResult<PortfolioResponseBody>;
+}
+
+#[async_trait]
+pub trait OnRampProvider: Send + Sync + Debug {
+    async fn get_buy_options(
+        &self,
+        params: OnRampBuyOptionsParams,
+    ) -> RpcResult<OnRampBuyOptionsResponse>;
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -496,5 +496,6 @@ pub trait OnRampProvider: Send + Sync + Debug {
     async fn get_buy_options(
         &self,
         params: OnRampBuyOptionsParams,
+        http_client: reqwest::Client,
     ) -> RpcResult<OnRampBuyOptionsResponse>;
 }


### PR DESCRIPTION
# Description

This PR adds the new endpoint for getting buy options for the onramp payments from the [CB payment options endpoint](https://docs.cloud.coinbase.com/pay-sdk/docs/rest-api-reference#buy-options).

* `/v1/onramp/buy/options` GET parameters:
  * `projectId` - project ID
  * `country` - [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) two-digit country code string representing the purchasing user’s country of residence, e.g., US.
  * `subdivision` (optional) - [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) two-digit country subdivision code representing the purchasing user’s subdivision of residence within their country, e.g. NY. Required if the country=“US” because certain states (e.g., NY) have state specific asset restrictions.

The new endpoint response object contains the following fields:

* `paymentCurrencies` - List of supported fiat currencies that can be exchanged for crypto on CBPay in the given location. Each currency contains a list of available payment methods, with `min` and `max` transaction limits for that currency `id`.
* `purchaseCurrencies` - List of available crypto assets that can be bought on CBPay in the given location.


Context of this requirement: https://walletconnect.slack.com/archives/C03SCF66K2T/p1706780083868789?thread_ts=1706744422.369399&cid=C03SCF66K2T


## How Has This Been Tested?

1. [New integration test](https://github.com/WalletConnect/blockchain-api/pull/499/files#diff-29ee1e76a6651d33c3e1a5117e948675ccda1e60165c885696a9accdc1bf0bb9R336-R355) included with this PR.

2. Manual. 

* Start the server locally: `cargo run`.
* Run the following curl request: `curl -v 'http://localhost:3000/v1/onramp/buy/options?projectId=xxx&country=US' | jq .`

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
