### PR TITLE
feat(providers): adding Base chain support for Pokt and Publicnode providers

### DIFF
--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -62,6 +62,22 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Base mainnet
+        (
+            "eip155:8453".into(),
+            (
+                "base-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        // Base testnet
+        (
+            "eip155:84531".into(),
+            (
+                "base-testnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
         // Binance Smart Chain
         (
             "eip155:56".into(),

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -48,6 +48,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::High).unwrap(),
             ),
         ),
+        // Base mainnet
+        (
+            "eip155:8453".into(),
+            ("base".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Binance Smart Chain mainnet
         (
             "eip155:56".into(),

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod base;
 pub(crate) mod binance;
 pub(crate) mod infura;
 pub(crate) mod pokt;
+pub(crate) mod publicnode;
 pub(crate) mod quicknode;
 pub(crate) mod zksync;
 pub(crate) mod zora;

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -29,6 +29,24 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     )
     .await;
 
+    // Base mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:8453",
+        "0x2105",
+    )
+    .await;
+
+    // Base testnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:84531",
+        "0x14a33",
+    )
+    .await;
+
     // Binance mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -1,0 +1,92 @@
+use {
+    super::check_if_rpc_is_responding_correctly_for_supported_chain,
+    crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind,
+    test_context::test_context,
+};
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn publicnode_provider(ctx: &mut ServerContext) {
+    // Ethereum mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Publicnode,
+        "eip155:1",
+        "0x1",
+    )
+    .await;
+
+    // Ethereum goerli
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Publicnode,
+        "eip155:5",
+        "0x5",
+    )
+    .await;
+
+    // Base mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Publicnode,
+        "eip155:8453",
+        "0x2105",
+    )
+    .await;
+
+    // BSC mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Publicnode,
+        "eip155:56",
+        "0x38",
+    )
+    .await;
+
+    // BSC testnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Publicnode,
+        "eip155:97",
+        "0x61",
+    )
+    .await;
+
+    // Avalanche c chain
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Publicnode,
+        "eip155:43114",
+        "0xa86a",
+    )
+    .await;
+
+    // Avalanche fuji testnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Publicnode,
+        "eip155:43113",
+        "0xa869",
+    )
+    .await;
+
+    // Polygon mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Publicnode,
+        "eip155:137",
+        "0x89",
+    )
+    .await;
+
+    // Polygon mumbai
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Publicnode,
+        "eip155:80001",
+        "0x13881",
+    )
+    .await;
+}


### PR DESCRIPTION
# Description

This PR adds Base (eip155:8453) chain support in Pokt/Grove and Publicnode providers. At the moment we are using only one provider for the Base, but we can spread the load across a few providers that support the Base chain.

The following changes are made:

* Base support for the Pokt/Grove provider,
* Base support for the Publicnode provider,
* Updating integration tests for the Pokt provider,
* Adding missed integration tests for the Publicnode provider.

## How Has This Been Tested?

* Updated integration tests in this PR.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
