### PR TITLE
fix(rpc): respond with `temporarily unavailable` when no working providers found

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,9 @@ pub enum RpcError {
     #[error("Specified chain is not supported by any of the providers: {0}")]
     UnsupportedChain(String),
 
+    #[error("Requested chain provider is temporarily unavailable: {0}")]
+    ChainTemporarilyUnavailable(String),
+
     #[error("Specified provider is not supported: {0}")]
     UnsupportedProvider(String),
 
@@ -104,6 +107,14 @@ impl IntoResponse for RpcError {
                 Json(new_error_response(
                     "chainId".to_string(),
                     format!("We don't support the chainId you provided: {chain_id}. See the list of supported chains here: https://docs.walletconnect.com/cloud/blockchain-api#supported-chains"),
+                )),
+            )
+                .into_response(),
+            Self::ChainTemporarilyUnavailable(chain_id) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(new_error_response(
+                    "chainId".to_string(),
+                    format!("Requested {chain_id} chain provider is temporarily unavailable"),
                 )),
             )
                 .into_response(),

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -85,10 +85,7 @@ async fn handler_internal(
 
             provider
         }
-        None => state
-            .providers
-            .get_provider_for_chain_id(&chain_id)
-            .ok_or_else(|| RpcError::UnsupportedChain(chain_id.clone()))?,
+        None => state.providers.get_provider_for_chain_id(&chain_id)?,
     };
 
     Span::current().record("provider", &provider.provider_kind().to_string());


### PR DESCRIPTION
# Description

At the moment when all provider weights for the chain are 0 because of rate limiting we are responding with the `Unsupported chain` to users which is confusing. 

This PR makes changes to respond with the `HTTP 503 Temporarily Unavailable` code and `Requested {chain_id} chain provider is temporarily unavailable` error message.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
