### PR TITLE
feat(ens): updating name attributes handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4007,6 +4007,7 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "jsonrpc",
+ "num_enum",
  "once_cell",
  "parquet",
  "parquet_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1.0"
 serde_piecewise_default = "0.2"
 serde-aux = "3.1"
 validator = { version = "0.16", features = ["derive"] }
+num_enum = "0.7"
 
 # Storage
 aws-config = "0.56"

--- a/integration/names.test.ts
+++ b/integration/names.test.ts
@@ -18,20 +18,19 @@ describe('Account profile names', () => {
   const name = `${randomString}.connect.test`;
 
   // Create a message to sign
-  const messageObject = {
+  const registerMessageObject = {
       name,
-      coin_type,
       attributes,
       timestamp: Math.round(Date.now() / 1000)
   };
-  const message = JSON.stringify(messageObject);
+  const registerMessage = JSON.stringify(registerMessageObject);
 
   it('register with wrong signature', async () => {
     // Sign the message
     const signature = await wallet.signMessage('some other message');
 
     const payload = {
-      message,
+      message: registerMessage,
       signature,
       coin_type,
       address,
@@ -68,10 +67,10 @@ describe('Account profile names', () => {
 
   it('register new name', async () => {
     // Sign the message
-    const signature = await wallet.signMessage(message);
+    const signature = await wallet.signMessage(registerMessage);
 
     const payload = {
-      message,
+      message: registerMessage,
       signature,
       coin_type,
       address,
@@ -82,12 +81,13 @@ describe('Account profile names', () => {
     )
     expect(resp.status).toBe(200)
   })
+
   it('try register already registered name', async () => {
     // Sign the message
-    const signature = await wallet.signMessage(message);
+    const signature = await wallet.signMessage(registerMessage);
 
     const payload = {
-      message,
+      message: registerMessage,
       signature,
       coin_type,
       address,
@@ -98,17 +98,20 @@ describe('Account profile names', () => {
     )
     expect(resp.status).toBe(400)
   })
+
   it('name forward lookup', async () => {
     let resp: any = await httpClient.get(
       `${baseUrl}/v1/profile/account/${name}`
     )
     expect(resp.status).toBe(200)
     expect(resp.data.name).toBe(name)
+    expect(resp.data.attributes['bio']).toBe(attributes['bio'])
     expect(typeof resp.data.addresses).toBe('object')
     // ENSIP-11 using the 60 for the Ethereum mainnet
     const first = resp.data.addresses["60"]
     expect(first.address).toBe(address)
   })
+
   it('name reverse lookup', async () => {
     let resp: any = await httpClient.get(
       `${baseUrl}/v1/profile/reverse/${address}`
@@ -121,5 +124,35 @@ describe('Account profile names', () => {
     // ENSIP-11 using the 60 for the Ethereum mainnet
     const first_address = first_name.addresses["60"]
     expect(first_address.address).toBe(address)
+  })
+
+  it('update name attributes', async () => {
+    // Prepare updated attributes payload
+    const updatedAttributes = {
+      bio: 'integration test domain updated attribute',
+    };
+    const updateAttributesMessageObject = {
+      attributes: updatedAttributes,
+      timestamp: Math.round(Date.now() / 1000)
+    };
+    const updateMessage = JSON.stringify(updateAttributesMessageObject);
+
+    // Sign the message
+    const signature = await wallet.signMessage(updateMessage);
+
+    const payload = {
+      message: updateMessage,
+      signature,
+      coin_type,
+      address,
+    };
+    let resp: any = await httpClient.post(
+      `${baseUrl}/v1/profile/account/${name}/attributes`,
+      payload
+    );
+    
+    expect(resp.status).toBe(200)
+    expect(resp.data.name).toBe(name)
+    expect(resp.data.attributes['bio']).toBe(updatedAttributes['bio'])
   })
 })

--- a/integration/names.test.ts
+++ b/integration/names.test.ts
@@ -128,8 +128,10 @@ describe('Account profile names', () => {
 
   it('update name attributes', async () => {
     // Prepare updated attributes payload
+    const randomBioString = Array.from({ length: 24 }, 
+      () => (Math.random().toString(36)[2] || '0')).join('')
     const updatedAttributes = {
-      bio: 'integration test domain updated attribute',
+      bio: randomBioString,
     };
     const updateAttributesMessageObject = {
       attributes: updatedAttributes,
@@ -152,7 +154,6 @@ describe('Account profile names', () => {
     );
     
     expect(resp.status).toBe(200)
-    expect(resp.data.name).toBe(name)
-    expect(resp.data.attributes['bio']).toBe(updatedAttributes['bio'])
+    expect(resp.data['bio']).toBe(updatedAttributes['bio'])
   })
 })

--- a/src/database/error.rs
+++ b/src/database/error.rs
@@ -6,4 +6,6 @@ pub enum DatabaseError {
     BadArgument(String),
     #[error("Address required: {0}")]
     AddressRequired(String),
+    #[error("{0:?}")]
+    SerdeJson(#[from] serde_json::Error),
 }

--- a/src/database/helpers.rs
+++ b/src/database/helpers.rs
@@ -68,7 +68,7 @@ pub async fn delete_name(
 }
 
 #[instrument(skip(postgres))]
-pub async fn update_name(
+pub async fn update_name_attributes(
     name: String,
     attributes: HashMap<String, String>,
     postgres: &PgPool,

--- a/src/handlers/profile/attributes.rs
+++ b/src/handlers/profile/attributes.rs
@@ -46,7 +46,11 @@ pub async fn handler_internal(
         Ok(payload) => payload,
         Err(e) => {
             info!("Failed to deserialize update attributes payload: {}", e);
-            return Ok((StatusCode::BAD_REQUEST, "").into_response());
+            return Ok((
+                StatusCode::BAD_REQUEST,
+                format!("Failed to deserialize update attributes payload: {}", e),
+            )
+                .into_response());
         }
     };
 
@@ -110,7 +114,7 @@ pub async fn handler_internal(
     // Check for the name address ownership and address from the signed payload
     let name_owner = match name_addresses
         .addresses
-        .get(&Eip155SupportedChains::Mainnet.into())
+        .get(&Eip155SupportedChains::EthereumMainnet.into())
     {
         Some(address_entry) => match ethers::types::H160::from_str(&address_entry.address) {
             Ok(owner) => owner,
@@ -153,7 +157,11 @@ pub async fn handler_internal(
     match update_name_attributes(name.clone(), payload.attributes, &state.postgres).await {
         Err(e) => {
             error!("Failed to update attributes: {}", e);
-            Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response())
+            Ok((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to update attributes: {}", e),
+            )
+                .into_response())
         }
         Ok(attributes) => Ok(Json(attributes).into_response()),
     }

--- a/src/handlers/profile/attributes.rs
+++ b/src/handlers/profile/attributes.rs
@@ -1,0 +1,170 @@
+use {
+    super::{
+        super::HANDLER_TASK_METRICS,
+        utils::{check_attributes, is_timestamp_within_interval},
+        RegisterRequest,
+        UpdateAttributesPayload,
+        UNIXTIMESTAMP_SYNC_THRESHOLD,
+    },
+    crate::{
+        database::helpers::{get_name_and_addresses_by_name, update_name_attributes},
+        error::RpcError,
+        state::AppState,
+        utils::crypto::{constant_time_eq, verify_message_signature},
+    },
+    axum::{
+        extract::{Path, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    hyper::StatusCode,
+    sqlx::Error as SqlxError,
+    std::{str::FromStr, sync::Arc},
+    tracing::log::{error, info},
+    wc::future::FutureExt,
+};
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    name: Path<String>,
+    Json(request_payload): Json<RegisterRequest>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, name, request_payload)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("profile_attributes_update"))
+        .await
+}
+
+#[tracing::instrument(skip(state))]
+pub async fn handler_internal(
+    state: State<Arc<AppState>>,
+    Path(name): Path<String>,
+    request_payload: RegisterRequest,
+) -> Result<Response, RpcError> {
+    let raw_payload = &request_payload.message;
+    let payload = match serde_json::from_str::<UpdateAttributesPayload>(raw_payload) {
+        Ok(payload) => payload,
+        Err(e) => {
+            info!("Failed to deserialize register payload: {}", e);
+            return Ok((StatusCode::BAD_REQUEST, "").into_response());
+        }
+    };
+
+    // Check for the supported ENSIP-11 coin type
+    if request_payload.coin_type != 60 {
+        info!("Unsupported coin type {}", request_payload.coin_type);
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            "Only Ethereum Mainnet (60) coin type is supported for name registration",
+        )
+            .into_response());
+    }
+
+    // Check is name registered
+    let name_addresses =
+        match get_name_and_addresses_by_name(name.clone(), &state.postgres.clone()).await {
+            Ok(result) => result,
+            Err(_) => {
+                info!(
+                    "Update attributes request for not registered name {}",
+                    name.clone()
+                );
+                return Ok((StatusCode::BAD_REQUEST, "Name is not registered").into_response());
+            }
+        };
+
+    // Check the timestamp is within the sync threshold interval
+    if !is_timestamp_within_interval(payload.timestamp, UNIXTIMESTAMP_SYNC_THRESHOLD) {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            "Timestamp is too old or in the future",
+        )
+            .into_response());
+    }
+
+    let payload_owner = match ethers::types::H160::from_str(&request_payload.address) {
+        Ok(owner) => owner,
+        Err(e) => {
+            info!("Failed to parse H160 address: {}", e);
+            return Ok((StatusCode::BAD_REQUEST, "Invalid H160 address format").into_response());
+        }
+    };
+
+    // Check the signature
+    let sinature_check =
+        match verify_message_signature(raw_payload, &request_payload.signature, &payload_owner) {
+            Ok(sinature_check) => sinature_check,
+            Err(e) => {
+                info!("Invalid signature: {}", e);
+                return Ok((
+                    StatusCode::UNAUTHORIZED,
+                    "Invalid signature or message format",
+                )
+                    .into_response());
+            }
+        };
+    if !sinature_check {
+        return Ok((StatusCode::UNAUTHORIZED, "Signature verification error").into_response());
+    }
+
+    // Check for the name address ownership and address from the signed payload
+    let name_owner = match name_addresses.addresses.get(&60) {
+        Some(address_entry) => match ethers::types::H160::from_str(&address_entry.address) {
+            Ok(owner) => owner,
+            Err(e) => {
+                info!("Failed to parse H160 address: {}", e);
+                return Ok((StatusCode::BAD_REQUEST, "Invalid H160 address format").into_response());
+            }
+        },
+        None => {
+            info!("Address entry not found for key 60");
+            return Ok((
+                StatusCode::BAD_REQUEST,
+                "Address entry not found for key 60",
+            )
+                .into_response());
+        }
+    };
+    if !constant_time_eq(payload_owner, name_owner) {
+        return Ok((
+            StatusCode::UNAUTHORIZED,
+            "Address is not the owner of the name",
+        )
+            .into_response());
+    }
+
+    // Check for supported attributes
+    if !check_attributes(
+        &payload.attributes,
+        &super::SUPPORTED_ATTRIBUTES,
+        super::ATTRIBUTES_VALUE_MAX_LENGTH,
+    ) {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            "Unsupported attribute in
+    payload",
+        )
+            .into_response());
+    }
+
+    let update_attributes_result =
+        update_name_attributes(name.clone(), payload.attributes, &state.postgres).await;
+    if let Err(e) = update_attributes_result {
+        error!("Failed to update attributes: {}", e);
+        return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
+    }
+
+    // Return the registered name, addresses and attributes
+    match get_name_and_addresses_by_name(name, &state.postgres.clone()).await {
+        Ok(response) => Ok(Json(response).into_response()),
+        Err(e) => match e {
+            SqlxError::RowNotFound => {
+                error!("New registered name is not found in the database: {}", e);
+                Ok((StatusCode::INTERNAL_SERVER_ERROR, "Name is not registered").into_response())
+            }
+            _ => {
+                error!("Error on lookup new registered name: {}", e);
+                Ok((StatusCode::INTERNAL_SERVER_ERROR, "Name is not registered").into_response())
+            }
+        },
+    }
+}

--- a/src/handlers/profile/mod.rs
+++ b/src/handlers/profile/mod.rs
@@ -5,6 +5,7 @@ use {
     std::collections::HashMap,
 };
 
+pub mod attributes;
 pub mod lookup;
 pub mod register;
 pub mod reverse;
@@ -33,6 +34,16 @@ pub struct RegisterPayload {
     pub name: String,
     /// Attributes
     pub attributes: Option<HashMap<String, String>>,
+    /// Unixtime
+    pub timestamp: u64,
+}
+
+/// Payload to update name attributes that should be serialized to JSON and
+/// signed
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateAttributesPayload {
+    /// Attributes
+    pub attributes: HashMap<String, String>,
     /// Unixtime
     pub timestamp: u64,
 }

--- a/src/handlers/profile/mod.rs
+++ b/src/handlers/profile/mod.rs
@@ -16,7 +16,7 @@ pub mod utils;
 #[repr(u32)]
 #[derive(Debug, Clone, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
 enum Eip155SupportedChains {
-    Mainnet = 60,
+    EthereumMainnet = 60,
 }
 
 pub const UNIXTIMESTAMP_SYNC_THRESHOLD: u64 = 10;

--- a/src/handlers/profile/mod.rs
+++ b/src/handlers/profile/mod.rs
@@ -1,4 +1,5 @@
 use {
+    num_enum::{IntoPrimitive, TryFromPrimitive},
     once_cell::sync::Lazy,
     regex::Regex,
     serde::{Deserialize, Serialize},
@@ -10,6 +11,13 @@ pub mod lookup;
 pub mod register;
 pub mod reverse;
 pub mod utils;
+
+/// List of supported Ethereum chains in ENSIP-11 format
+#[repr(u32)]
+#[derive(Debug, Clone, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+enum Eip155SupportedChains {
+    Mainnet = 60,
+}
 
 pub const UNIXTIMESTAMP_SYNC_THRESHOLD: u64 = 10;
 

--- a/src/handlers/profile/register.rs
+++ b/src/handlers/profile/register.rs
@@ -2,6 +2,7 @@ use {
     super::{
         super::HANDLER_TASK_METRICS,
         utils::{check_attributes, is_timestamp_within_interval},
+        Eip155SupportedChains,
         RegisterPayload,
         RegisterRequest,
         UNIXTIMESTAMP_SYNC_THRESHOLD,
@@ -21,6 +22,7 @@ use {
         Json,
     },
     hyper::StatusCode,
+    num_enum::TryFromPrimitive,
     sqlx::Error as SqlxError,
     std::{collections::HashMap, str::FromStr, sync::Arc},
     tracing::log::{error, info},
@@ -51,11 +53,11 @@ pub async fn handler_internal(
     };
 
     // Check for the supported ENSIP-11 coin type
-    if register_request.coin_type != 60 {
+    if Eip155SupportedChains::try_from_primitive(register_request.coin_type).is_err() {
         info!("Unsupported coin type {}", register_request.coin_type);
         return Ok((
             StatusCode::BAD_REQUEST,
-            "Only Ethereum Mainnet (60) coin type is supported for name registration",
+            "Unsupported coin type for name registration",
         )
             .into_response());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,11 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/profile/account",
             post(handlers::profile::register::handler),
         )
+         // Update account name attributes
+         .route(
+            "/v1/profile/account/:name/attributes",
+            post(handlers::profile::attributes::handler),
+        )
         // Forward address lookup
         .route(
             "/v1/profile/account/:name",

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -55,14 +55,18 @@ pub fn string_chain_id_to_caip2_format(chain_id: &str) -> Result<String, anyhow:
     ))
 }
 
-/// Compare two strings in constant time to prevent timing attacks
-pub fn constant_time_eq(a: &str, b: &str) -> bool {
-    if a.len() != b.len() {
+/// Compare two values (either H160 or &str) in constant time to prevent timing
+/// attacks
+pub fn constant_time_eq(a: impl AsRef<[u8]>, b: impl AsRef<[u8]>) -> bool {
+    let a_bytes = a.as_ref();
+    let b_bytes = b.as_ref();
+
+    if a_bytes.len() != b_bytes.len() {
         return false;
     }
 
     let mut result = 0;
-    for (byte_a, byte_b) in a.bytes().zip(b.bytes()) {
+    for (byte_a, byte_b) in a_bytes.iter().zip(b_bytes.iter()) {
         result |= byte_a ^ byte_b;
     }
 

--- a/tests/functional/database.rs
+++ b/tests/functional/database.rs
@@ -11,7 +11,7 @@ use {
             get_names_by_address_and_namespace,
             insert_address,
             insert_name,
-            update_name,
+            update_name_attributes,
         },
         types,
     },
@@ -241,7 +241,8 @@ async fn insert_and_update_name_attributes() {
     // Updating the name with new attributes
     let updated_attributes: HashMap<String, String> =
         HashMap::from_iter([("GitHub".to_string(), "SomeProfile".to_string())]);
-    let updated_result = update_name(name.clone(), updated_attributes.clone(), &pg_pool).await;
+    let updated_result =
+        update_name_attributes(name.clone(), updated_attributes.clone(), &pg_pool).await;
     assert!(updated_result.is_ok(), "Updating name should succeed");
 
     let got_update_name = get_name(name.clone(), &pg_pool).await.unwrap();


### PR DESCRIPTION
# Description

This PR adds an endpoint handler to update name attributes according to the [SPEC](https://github.com/WalletConnect/walletconnect-specs/pull/203).
The following changes are made:

* `POST /v1/profile/account/:name/attributes` endpoint is added to handle the name attributes updating,
  * Updated attributes map returns as a result. 
* [Integration test](https://github.com/WalletConnect/blockchain-api/pull/509/files#diff-28b661942cfc4edae43683709afac7c88cdd3d5bdcc47e602ee9ea4c876dbaf1R129-R157) for the new endpoint to check attributes after updating.

## How Has This Been Tested?

The integration test was added to this PR.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
