### PR TITLE
feat(ens): unifying errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -74,7 +74,7 @@ pub enum RpcError {
     AxumTungstenite(#[from] axum_tungstenite::Error),
 
     #[error("Invalid address")]
-    IdentityInvalidAddress,
+    InvalidAddress,
 
     #[error("Failed to parse provider cursor")]
     HistoryParseCursorError,
@@ -96,6 +96,43 @@ pub enum RpcError {
 
     #[error("invalid parameter: {0}")]
     InvalidParameter(String),
+
+    // Profile names errors
+    #[error("Name is already registered: {0}")]
+    NameAlreadyRegistered(String),
+
+    #[error("Name is not registered: {0}")]
+    NameNotRegistered(String),
+
+    #[error("Name is not found: {0}")]
+    NameNotFound(String),
+
+    #[error("No name is found for address")]
+    NameByAddressNotFound,
+
+    #[error("Invalid name format: {0}")]
+    InvalidNameFormat(String),
+
+    #[error("Invalid name length: {0}")]
+    InvalidNameLength(String),
+
+    #[error("Name is not in the allowed zones: {0}")]
+    InvalidNameZone(String),
+
+    #[error("Unsupported coin type: {0}")]
+    UnsupportedCoinType(u32),
+
+    #[error("Unsupported name attribute")]
+    UnsupportedNameAttribute,
+
+    #[error("Signature UNIXTIME timestamp is too old: {0}")]
+    ExpiredTimestamp(u64),
+
+    #[error("Error during the signature validation: {0}")]
+    SignatureValidationError(String),
+
+    #[error("Name owner validation error")]
+    NameOwnerValidationError,
 }
 
 impl IntoResponse for RpcError {
@@ -168,7 +205,7 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response(),
-            Self::IdentityInvalidAddress => (
+            Self::InvalidAddress => (
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "address".to_string(),
@@ -192,6 +229,106 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response(),
+
+            // Profile names errors
+            Self::InvalidNameFormat(e) => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "name".to_string(),
+                    format!("Invalid name format: {}", e),
+                )),
+            )
+                .into_response(),
+            Self::InvalidNameLength(e) => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "name".to_string(),
+                    format!("Invalid name length: {}", e),
+                )),
+            )
+                .into_response(),
+            Self::InvalidNameZone(e) => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "name".to_string(),
+                    format!("Name is not in the allowed zones: {}", e),
+                )),
+            )
+                .into_response(),
+            Self::UnsupportedCoinType(e) => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "coin_type".to_string(),
+                    format!("Unsupported coin type: {}", e),
+                )),
+            )
+                .into_response(),
+            Self::UnsupportedNameAttribute => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "attributes".to_string(),
+                    "Unsupported name attribute in payload".to_string(),
+                )),
+            )
+                .into_response(),
+            Self::NameAlreadyRegistered(e) => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "name".to_string(),
+                    format!("Name is already registered: {}", e),
+                )),
+            )
+                .into_response(),
+            Self::NameNotRegistered(e) => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "name".to_string(),
+                    format!("Name is not registered: {}", e),
+                )),
+            )
+                .into_response(),
+            Self::NameNotFound(e) => (
+                StatusCode::NOT_FOUND,
+                Json(new_error_response(
+                    "name".to_string(),
+                    format!("Name is not found in the database: {}", e),
+                )),
+            )
+                .into_response(),
+            Self::NameByAddressNotFound => (
+                StatusCode::NOT_FOUND,
+                Json(new_error_response(
+                    "address".to_string(),
+                    "No name for address is found".into(),
+                )),
+            )
+                .into_response(),
+            Self::ExpiredTimestamp(e) => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "timestamp".to_string(),
+                    format!("Signature UNIXTIME timestamp is too old: {}", e),
+                )),
+            )
+                .into_response(),
+            Self::SignatureValidationError(e) => (
+                StatusCode::UNAUTHORIZED,
+                Json(new_error_response(
+                    "signature".to_string(),
+                    format!("Signature validation error: {}", e),
+                )),
+            )
+                .into_response(),
+            Self::NameOwnerValidationError => (
+                StatusCode::UNAUTHORIZED,
+                Json(new_error_response(
+                    "address".to_string(),
+                    "Name owner validation error".into(),
+                )),
+            )
+                .into_response(),
+
+            // Any other errors considering as 500
             e => {
                 error!("Internal server error: {}", e);
                 (

--- a/src/error.rs
+++ b/src/error.rs
@@ -327,6 +327,14 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response(),
+            Self::SerdeJson(e) => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(new_error_response(
+                    "".to_string(),
+                    format!("Deserialization error: {}", e),
+                )),
+            )
+                .into_response(),
 
             // Any other errors considering as 500
             e => {

--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -145,7 +145,7 @@ async fn handler_internal(
     let project_id = query.project_id.clone();
 
     // Checking for the H160 address correctness
-    H160::from_str(&address).map_err(|_| RpcError::IdentityInvalidAddress)?;
+    H160::from_str(&address).map_err(|_| RpcError::InvalidAddress)?;
 
     let latency_tracker_start = std::time::SystemTime::now();
     let history_provider: ProviderKind;

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -65,7 +65,7 @@ async fn handler_internal(
 
     let address = address
         .parse::<Address>()
-        .map_err(|_| RpcError::IdentityInvalidAddress)?;
+        .map_err(|_| RpcError::InvalidAddress)?;
 
     let identity_result = lookup_identity(
         address,

--- a/src/handlers/portfolio.rs
+++ b/src/handlers/portfolio.rs
@@ -65,7 +65,7 @@ async fn handler_internal(
     let _address_hash = address.clone();
     address
         .parse::<Address>()
-        .map_err(|_| RpcError::IdentityInvalidAddress)?;
+        .map_err(|_| RpcError::InvalidAddress)?;
 
     state.validate_project_access_and_quota(&project_id).await?;
 

--- a/src/handlers/profile/lookup.rs
+++ b/src/handlers/profile/lookup.rs
@@ -33,27 +33,23 @@ async fn handler_internal(
 ) -> Result<Response, RpcError> {
     // Check if the name is in the correct format
     if !is_name_format_correct(&name) {
-        return Ok((StatusCode::BAD_REQUEST, "Invalid name format").into_response());
+        return Err(RpcError::InvalidNameFormat(name));
     }
 
     // Check if the name length is correct
     if !is_name_length_correct(&name) {
-        return Ok((StatusCode::BAD_REQUEST, "Invalid name length").into_response());
+        return Err(RpcError::InvalidNameLength(name));
     }
 
     // Check is name in the allowed zones
     if !is_name_in_allowed_zones(&name, &ALLOWED_ZONES) {
-        return Ok((StatusCode::BAD_REQUEST, "Name is not in the allowed zones").into_response());
+        return Err(RpcError::InvalidNameZone(name));
     }
 
-    match get_name_and_addresses_by_name(name, &state.postgres).await {
+    match get_name_and_addresses_by_name(name.clone(), &state.postgres).await {
         Ok(response) => Ok(Json(response).into_response()),
         Err(e) => match e {
-            SqlxError::RowNotFound => {
-                // Respond with a "Not Found" status code if name was found
-                let not_found_response = (StatusCode::NOT_FOUND, "Name is not registered");
-                Ok(not_found_response.into_response())
-            }
+            SqlxError::RowNotFound => return Err(RpcError::NameNotFound(name)),
             _ => {
                 // Handle other types of errors
                 error!("Failed to lookup name: {}", e);

--- a/src/handlers/profile/register.rs
+++ b/src/handlers/profile/register.rs
@@ -32,7 +32,7 @@ use {
     num_enum::TryFromPrimitive,
     sqlx::Error as SqlxError,
     std::{collections::HashMap, str::FromStr, sync::Arc},
-    tracing::log::{error, info},
+    tracing::log::error,
     wc::future::FutureExt,
 };
 
@@ -53,38 +53,27 @@ pub async fn handler_internal(
     let raw_payload = &register_request.message;
     let payload = match serde_json::from_str::<RegisterPayload>(raw_payload) {
         Ok(payload) => payload,
-        Err(e) => {
-            info!("Failed to deserialize register payload: {}", e);
-            return Ok((StatusCode::BAD_REQUEST, "").into_response());
-        }
+        Err(e) => return Err(RpcError::SerdeJson(e)),
     };
 
     // Check if the name is in the correct format
     if !is_name_format_correct(&payload.name) {
-        info!("Invalid name format: {}", payload.name);
-        return Ok((StatusCode::BAD_REQUEST, "Invalid name format").into_response());
+        return Err(RpcError::InvalidNameFormat(payload.name));
     }
 
     // Check if the name length is correct
     if !is_name_length_correct(&payload.name) {
-        info!("Invalid name length: {}", payload.name);
-        return Ok((StatusCode::BAD_REQUEST, "Invalid name length").into_response());
+        return Err(RpcError::InvalidNameLength(payload.name));
     }
 
     // Check is name in the allowed zones
     if !is_name_in_allowed_zones(&payload.name, &ALLOWED_ZONES) {
-        info!("Name is not in the allowed zones");
-        return Ok((StatusCode::BAD_REQUEST, "Name is not in the allowed zones").into_response());
+        return Err(RpcError::InvalidNameZone(payload.name));
     }
 
     // Check for the supported ENSIP-11 coin type
     if Eip155SupportedChains::try_from_primitive(register_request.coin_type).is_err() {
-        info!("Unsupported coin type {}", register_request.coin_type);
-        return Ok((
-            StatusCode::BAD_REQUEST,
-            "Unsupported coin type for name registration",
-        )
-            .into_response());
+        return Err(RpcError::UnsupportedCoinType(register_request.coin_type));
     }
 
     // Check is name already registered
@@ -92,28 +81,17 @@ pub async fn handler_internal(
         .await
         .is_ok()
     {
-        info!(
-            "Registration request for already registered name {}",
-            payload.name.clone()
-        );
-        return Ok((StatusCode::BAD_REQUEST, "Name is already registered").into_response());
+        return Err(RpcError::NameAlreadyRegistered(payload.name.clone()));
     };
 
     // Check the timestamp is within the sync threshold interval
     if !is_timestamp_within_interval(payload.timestamp, UNIXTIMESTAMP_SYNC_THRESHOLD) {
-        return Ok((
-            StatusCode::BAD_REQUEST,
-            "Timestamp is too old or in the future",
-        )
-            .into_response());
+        return Err(RpcError::ExpiredTimestamp(payload.timestamp));
     }
 
     let owner = match ethers::types::H160::from_str(&register_request.address) {
         Ok(owner) => owner,
-        Err(e) => {
-            info!("Failed to parse H160 address: {}", e);
-            return Ok((StatusCode::BAD_REQUEST, "Invalid H160 address format").into_response());
-        }
+        Err(_) => return Err(RpcError::InvalidAddress),
     };
 
     // Check for supported attributes
@@ -123,12 +101,7 @@ pub async fn handler_internal(
             &super::SUPPORTED_ATTRIBUTES,
             super::ATTRIBUTES_VALUE_MAX_LENGTH,
         ) {
-            return Ok((
-                StatusCode::BAD_REQUEST,
-                "Unsupported attribute in
-        payload",
-            )
-                .into_response());
+            return Err(RpcError::UnsupportedNameAttribute);
         }
     }
 
@@ -136,17 +109,16 @@ pub async fn handler_internal(
     let sinature_check =
         match verify_message_signature(raw_payload, &register_request.signature, &owner) {
             Ok(sinature_check) => sinature_check,
-            Err(e) => {
-                info!("Invalid signature: {}", e);
-                return Ok((
-                    StatusCode::UNAUTHORIZED,
-                    "Invalid signature or message format",
-                )
-                    .into_response());
+            Err(_) => {
+                return Err(RpcError::SignatureValidationError(
+                    "Invalid signature".into(),
+                ))
             }
         };
     if !sinature_check {
-        return Ok((StatusCode::UNAUTHORIZED, "Signature verification error").into_response());
+        return Err(RpcError::SignatureValidationError(
+            "Signature verification error".into(),
+        ));
     }
 
     // Register (insert) a new domain with address
@@ -169,16 +141,14 @@ pub async fn handler_internal(
     }
 
     // Return the registered name and addresses
-    match get_name_and_addresses_by_name(payload.name, &state.postgres.clone()).await {
+    match get_name_and_addresses_by_name(payload.name.clone(), &state.postgres.clone()).await {
         Ok(response) => Ok(Json(response).into_response()),
         Err(e) => match e {
-            SqlxError::RowNotFound => {
-                error!("New registered name is not found in the database: {}", e);
-                Ok((StatusCode::INTERNAL_SERVER_ERROR, "Name is not registered").into_response())
-            }
+            SqlxError::RowNotFound => Err(RpcError::NameNotFound(payload.name.clone())),
             _ => {
-                error!("Error on lookup new registered name: {}", e);
-                Ok((StatusCode::INTERNAL_SERVER_ERROR, "Name is not registered").into_response())
+                // Handle other types of errors
+                error!("Failed to lookup name: {}", e);
+                return Ok((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
             }
         },
     }

--- a/src/handlers/profile/reverse.rs
+++ b/src/handlers/profile/reverse.rs
@@ -39,9 +39,7 @@ async fn handler_internal(
     };
 
     if names.is_empty() {
-        // Respond with a "Not Found" status code if no name was found for the address
-        let not_found_response = (StatusCode::NOT_FOUND, "No rigistered names for the address");
-        return Ok(not_found_response.into_response());
+        return Err(RpcError::NameByAddressNotFound);
     }
 
     let mut result = Vec::new();


### PR DESCRIPTION
# Description

This PR unifies errors in profile names handlers to use the `RpcError`.
This will deduplicate errors and unify them to handle in the frontend.

## How Has This Been Tested?

* Current integration tests are passed.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
