### PR TITLE
feat(rpc): adding Klaytn mainnet to supported chains

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -30,6 +30,7 @@ Chain name with associated `chainId` query param to use.
 - Base Goerli (`eip155:84531`)
 - Zora (`eip155:7777777`)
 - Zora Goerli (`eip155:999`)
+- Klaytn Mainnet (`eip155:8217`)
 
 ## WebSocket RPC
 

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -135,5 +135,13 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Klaytn
+        (
+            "eip155:8217".into(),
+            (
+                "klaytn-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
     ])
 }

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -126,7 +126,16 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
         "eip155:42220",
         "0xa4ec",
     )
-    .await
+    .await;
+
+    // Klaytn mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:8217",
+        "0x2019",
+    )
+    .await;
 }
 
 #[test_context(ServerContext)]


### PR DESCRIPTION
# Description

This PR adds the Klaytn Mainnet `eip155:8217` chain to the Pokt/Grove provider and to our supported chains for the RPC.
The full context: https://walletconnect.slack.com/archives/C03SMNKLPU0/p1707814841315879

This is a replacement for the #352 

## How Has This Been Tested?

- Integration test for the Pokt provider is passed.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
