### PR TITLE
feat(metrics): exporting CPU and Memory usage metrics to Prometheus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,7 +2402,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -2923,6 +2923,15 @@ name = "nonempty"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -4022,6 +4031,7 @@ dependencies = [
  "serde_piecewise_default",
  "sha256",
  "sqlx",
+ "sysinfo",
  "tap",
  "test-context",
  "thiserror",
@@ -4879,6 +4889,21 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sysinfo"
+version = "0.30.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb4f3438c8f6389c864e61221cbc97e9bca98b4daf39a5beb7bea660f528bb2"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
+]
 
 [[package]]
 name = "system-configuration"
@@ -5774,12 +5799,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,9 @@ bytes = "1.4.0"
 regex = "1.10"
 sha256 = "1.2.2"
 
+# System CPU and Memory metrics
+sysinfo = "0.30"
+
 [dev-dependencies]
 jsonrpc = "0.14.0"
 test-context = "0.1"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -5,6 +5,7 @@ use {
     },
     hyper::http,
     std::time::{Duration, SystemTime},
+    sysinfo::{System, MINIMUM_CPU_UPDATE_INTERVAL},
     wc::metrics::{
         otel::{
             self,
@@ -43,6 +44,11 @@ pub struct Metrics {
     pub history_lookup_counter: Counter<u64>,
     pub history_lookup_success_counter: Counter<u64>,
     pub history_lookup_latency_tracker: Histogram<f64>,
+
+    // System metrics
+    pub cpu_usage: Histogram<f64>,
+    pub memory_total: Histogram<f64>,
+    pub memory_used: Histogram<f64>,
 }
 
 impl Metrics {
@@ -185,6 +191,21 @@ impl Metrics {
             .with_description("The latency to serve transactions history lookups")
             .init();
 
+        let cpu_usage = meter
+            .f64_histogram("cpu_usage")
+            .with_description("The cpu(s) usage")
+            .init();
+
+        let memory_total = meter
+            .f64_histogram("memory_total")
+            .with_description("Total system memory")
+            .init();
+
+        let memory_used = meter
+            .f64_histogram("memory_used")
+            .with_description("Used system memory")
+            .init();
+
         Metrics {
             rpc_call_counter,
             http_call_counter,
@@ -213,6 +234,9 @@ impl Metrics {
             history_lookup_counter,
             history_lookup_success_counter,
             history_lookup_latency_tracker,
+            cpu_usage,
+            memory_total,
+            memory_used,
         }
     }
 }
@@ -417,5 +441,38 @@ impl Metrics {
             latency.as_secs_f64(),
             &[otel::KeyValue::new("provider", provider.to_string())],
         );
+    }
+
+    fn add_cpu_usage(&self, usage: f64, cpu_id: f64) {
+        self.cpu_usage
+            .record(&otel::Context::new(), usage, &[otel::KeyValue::new(
+                "cpu", cpu_id,
+            )]);
+    }
+
+    fn add_memory_total(&self, memory: f64) {
+        self.memory_total.record(&otel::Context::new(), memory, &[]);
+    }
+
+    fn add_memory_used(&self, memory: f64) {
+        self.memory_used.record(&otel::Context::new(), memory, &[]);
+    }
+
+    /// Gathering system CPU(s) and Memory usage metrics
+    pub async fn gather_system_metrics(&self) {
+        let mut system = System::new_all();
+
+        system.refresh_all();
+        // Wait a bit because CPU usage is based on diff.
+        // https://docs.rs/sysinfo/0.30.5/sysinfo/struct.Cpu.html#method.cpu_usage
+        tokio::time::sleep(MINIMUM_CPU_UPDATE_INTERVAL).await;
+        system.refresh_cpu();
+
+        for (i, processor) in system.cpus().iter().enumerate() {
+            self.add_cpu_usage(processor.cpu_usage() as f64, i as f64);
+        }
+
+        self.add_memory_total(system.total_memory() as f64);
+        self.add_memory_used(system.used_memory() as f64);
     }
 }


### PR DESCRIPTION
# Description

This PR introduces gathering and exporting of CPU and Memory usage metrics to the Prometheus.

System CPU(s) usage and Memory usage metrics are gathered by the app tokio task once per minute and record the data into the Prometheus exported metrics.

The reason for making this change is that we want to disable AWS CloudWatch ContainerInsights for the ECS.
The full context: https://walletconnect.slack.com/archives/C068RRL89HC/p1704549567804539

### Follow-ups after this PR is merged:

* Changing Grafana panels to use new metrics for CPU and Memory.
* Disabling `ContainerInsights` in the terraform ECS config.

## How Has This Been Tested?

Not fully tested, just run it locally.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
