### PR TITLE
feat(history): using the shared `reqwest` http client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +147,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
  "term",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -789,6 +818,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -3863,6 +3913,7 @@ version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
+ "async-compression",
  "base64 0.21.5",
  "bytes",
  "encoding_rs",
@@ -3891,6 +3942,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4024,6 +4076,7 @@ dependencies = [
  "prometheus-http-query",
  "rand",
  "regex",
+ "reqwest",
  "rmp-serde",
  "serde",
  "serde-aux",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tower-http = { version = "0.4.0", features = ["cors", "trace", "request-id", "ut
 jsonrpc = "0.14.0"
 async-tungstenite = { version = "0.20.0", features = ["tokio", "tokio-runtime", "tokio-native-tls"] }
 url = "2.5"
+reqwest = { version= "0.11", features = ["deflate", "brotli", "gzip"] }
 
 # Serialization
 rmp-serde = "1.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -133,6 +133,9 @@ pub enum RpcError {
 
     #[error("Name owner validation error")]
     NameOwnerValidationError,
+
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
 }
 
 impl IntoResponse for RpcError {

--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -8,7 +8,6 @@ use {
         utils::network,
     },
     axum::{
-        body::Bytes,
         extract::{ConnectInfo, MatchedPath, Path, Query, State},
         response::{IntoResponse, Response},
         Json,
@@ -125,9 +124,8 @@ pub async fn handler(
     path: MatchedPath,
     headers: HeaderMap,
     address: Path<String>,
-    body: Bytes,
 ) -> Result<Response, RpcError> {
-    handler_internal(state, connect_info, query, path, headers, address, body)
+    handler_internal(state, connect_info, query, path, headers, address)
         .with_metrics(HANDLER_TASK_METRICS.with_name("transactions"))
         .await
 }
@@ -140,7 +138,6 @@ async fn handler_internal(
     _path: MatchedPath,
     headers: HeaderMap,
     Path(address): Path<String>,
-    body: Bytes,
 ) -> Result<Response, RpcError> {
     let project_id = query.project_id.clone();
 
@@ -157,7 +154,7 @@ async fn handler_internal(
             state
                 .providers
                 .coinbase_pay_provider
-                .get_transactions(address.clone(), body.clone(), query.clone().0)
+                .get_transactions(address.clone(), query.clone().0, state.http_client.clone())
                 .await
                 .tap_err(|e| {
                     error!("Failed to call coinbase transactions history with {}", e);
@@ -171,7 +168,7 @@ async fn handler_internal(
         state
             .providers
             .history_provider
-            .get_transactions(address.clone(), body.clone(), query.0.clone())
+            .get_transactions(address.clone(), query.0.clone(), state.http_client.clone())
             .await
             .tap_err(|e| {
                 error!("Failed to call transactions history with {}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,8 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         .await?;
     sqlx::migrate!("./migrations").run(&postgres).await?;
 
+    let http_client = reqwest::Client::new();
+
     let state = state::new_state(
         config.clone(),
         postgres.clone(),
@@ -146,6 +148,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         registry,
         identity_cache,
         analytics,
+        http_client,
     );
 
     let port = state.config.server.port;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -470,8 +470,8 @@ pub trait HistoryProvider: Send + Sync + Debug {
     async fn get_transactions(
         &self,
         address: String,
-        body: hyper::body::Bytes,
         params: HistoryQueryParams,
+        http_client: reqwest::Client,
     ) -> RpcResult<HistoryResponseBody>;
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -28,6 +28,8 @@ pub struct AppState {
     pub compile_info: CompileInfo,
     /// Service instance uptime measurement
     pub uptime: std::time::Instant,
+    /// Shared http client
+    pub http_client: reqwest::Client,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -39,6 +41,7 @@ pub fn new_state(
     registry: Registry,
     identity_cache: Option<Arc<dyn KeyValueStorage<IdentityResponse>>>,
     analytics: RPCAnalytics,
+    http_client: reqwest::Client,
 ) -> AppState {
     AppState {
         config,
@@ -50,6 +53,7 @@ pub fn new_state(
         analytics,
         compile_info: CompileInfo {},
         uptime: std::time::Instant::now(),
+        http_client,
     }
 }
 


### PR DESCRIPTION
# Description

This PR changes to use the shared `reqwest` client for the history endpoints instead of constructing the `hyper` client each time in the handler.

This change should provide the following benefits:

* (code) Making JSON requests using the `reqwest` is much easier than the hyper itself (it handles serialization and deserialization), the code is much clearer.
* (performance) When using the shared `reqwest` HTTP client we will use the internal connection pooling and reuse it ([suggested in the reqwest docs](https://docs.rs/reqwest/latest/reqwest/struct.Client.html#) to create it once and reuse it).

## How Has This Been Tested?

Tested locally:

1. Start the server locally with the `cargo run`.
2. Run the integration tests by `RPC_URL=http://localhost:3000  yarn integration`.
3. Tests successfully passed.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
