### PR TITLE
feat(onramp): adding onramp buy quotes endpoint

### DIFF
--- a/integration/onramp.test.ts
+++ b/integration/onramp.test.ts
@@ -3,10 +3,12 @@ import { getTestSetup } from './init';
 describe('OnRamp', () => {
   const { baseUrl, projectId, httpClient } = getTestSetup();
   const onRampPath = `${baseUrl}/v1/onramp`;
+  const country = 'US';
+  const subdivision = 'NY';
 
   it('buy options', async () => {
     let resp: any = await httpClient.get(
-      `${onRampPath}/buy/options?projectId=${projectId}&country=US&subdivision=NY`,
+      `${onRampPath}/buy/options?projectId=${projectId}&country=${country}&subdivision=${subdivision}`,
     )
     expect(resp.status).toBe(200)
     
@@ -26,5 +28,31 @@ describe('OnRamp', () => {
     expect(typeof firstPurchaseNetworks.displayName).toBe('string')
     expect(typeof firstPurchaseNetworks.contractAddress).toBe('string')
     expect(typeof firstPurchaseNetworks.chainId).toBe('string')
+  })
+
+  it('buy quotes', async () => {
+    let resp: any = await httpClient.get(
+      `${onRampPath}/buy/quotes` +
+      `?projectId=${projectId}` +
+      `&country=${country}` +
+      `&subdivision=${subdivision}` +
+      `&purchaseCurrency=BCH` +
+      `&paymentAmount=100.00` +
+      `&paymentCurrency=USD` +
+      `&paymentMethod=CARD`,
+    );
+    expect(resp.status).toBe(200)
+
+    const checkValueAndCurrency = (obj: any) => {
+      expect(typeof obj.value).toBe('string')
+      expect(typeof obj.currency).toBe('string')
+    }
+    
+    expect(typeof resp.data.quoteId).toBe('string')
+    checkValueAndCurrency(resp.data.paymentTotal)
+    checkValueAndCurrency(resp.data.paymentSubTotal)
+    checkValueAndCurrency(resp.data.purchaseAmount)
+    checkValueAndCurrency(resp.data.coinbaseFee)
+    checkValueAndCurrency(resp.data.networkFee)
   })
 })

--- a/src/handlers/onramp/mod.rs
+++ b/src/handlers/onramp/mod.rs
@@ -1,1 +1,2 @@
 pub mod options;
+pub mod quotes;

--- a/src/handlers/onramp/quotes.rs
+++ b/src/handlers/onramp/quotes.rs
@@ -1,0 +1,95 @@
+use {
+    crate::{error::RpcError, handlers::HANDLER_TASK_METRICS, state::AppState},
+    axum::{
+        extract::{ConnectInfo, Query, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    hyper::HeaderMap,
+    serde::{Deserialize, Serialize},
+    std::{net::SocketAddr, sync::Arc},
+    tap::TapFallible,
+    tracing::log::error,
+    validator::Validate,
+    wc::future::FutureExt,
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Validate)]
+pub struct OnRampBuyQuotesParams {
+    #[serde(rename(deserialize = "projectId"))]
+    pub project_id: String,
+    #[validate(length(max = 4))]
+    #[serde(rename(deserialize = "purchaseCurrency"))]
+    pub purchase_currency: String,
+    #[serde(rename(deserialize = "purchaseNetwork"))]
+    pub purchase_network: Option<String>,
+    #[serde(rename(deserialize = "paymentAmount"))]
+    pub payment_amount: String,
+    #[validate(length(max = 4))]
+    #[serde(rename(deserialize = "paymentCurrency"))]
+    pub payment_currency: String,
+    #[serde(rename(deserialize = "paymentMethod"))]
+    pub payment_method: String,
+    #[validate(length(equal = 2))]
+    #[serde(rename(deserialize = "country"))]
+    pub country: String,
+    #[validate(length(equal = 2))]
+    #[serde(rename(deserialize = "subdivision"))]
+    pub subdivision: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OnRampBuyQuotesResponse {
+    #[serde(rename(serialize = "paymentTotal"))]
+    pub payment_total: PayOptionValue,
+    #[serde(rename(serialize = "paymentSubTotal"))]
+    pub payment_subtotal: PayOptionValue,
+    #[serde(rename(serialize = "purchaseAmount"))]
+    pub purchase_amount: PayOptionValue,
+    #[serde(rename(serialize = "coinbaseFee"))]
+    pub coinbase_fee: PayOptionValue,
+    #[serde(rename(serialize = "networkFee"))]
+    pub network_fee: PayOptionValue,
+    #[serde(rename(serialize = "quoteId"))]
+    pub quote_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PayOptionValue {
+    pub value: String,
+    pub currency: String,
+}
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    connect_info: ConnectInfo<SocketAddr>,
+    query: Query<OnRampBuyQuotesParams>,
+    headers: HeaderMap,
+) -> Result<Response, RpcError> {
+    handler_internal(state, connect_info, query, headers)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("onrmap_buy_quotes"))
+        .await
+}
+
+#[tracing::instrument(skip_all)]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    _connect_info: ConnectInfo<SocketAddr>,
+    query: Query<OnRampBuyQuotesParams>,
+    _headers: HeaderMap,
+) -> Result<Response, RpcError> {
+    state
+        .validate_project_access_and_quota(&query.project_id)
+        .await?;
+
+    let buy_quotes = state
+        .providers
+        .onramp_provider
+        .get_buy_quotes(query.0, state.http_client.clone())
+        .await
+        .tap_err(|e| {
+            error!("Failed to call coinbase buy quotes with {}", e);
+        })?;
+
+    Ok(Json(buy_quotes).into_response())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,6 +253,10 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/onramp/buy/options",
             get(handlers::onramp::options::handler),
         )
+        .route(
+            "/v1/onramp/buy/quotes",
+            get(handlers::onramp::quotes::handler),
+        )
         .route_layer(tracing_and_metrics_layer)
         .route("/health", get(handlers::health::handler))
         .layer(cors);

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -5,7 +5,10 @@ use {
         error::{RpcError, RpcResult},
         handlers::{
             history::{HistoryQueryParams, HistoryResponseBody},
-            onramp::options::{OnRampBuyOptionsParams, OnRampBuyOptionsResponse},
+            onramp::{
+                options::{OnRampBuyOptionsParams, OnRampBuyOptionsResponse},
+                quotes::{OnRampBuyQuotesParams, OnRampBuyQuotesResponse},
+            },
             portfolio::{PortfolioQueryParams, PortfolioResponseBody},
             RpcQueryParams,
         },
@@ -498,4 +501,10 @@ pub trait OnRampProvider: Send + Sync + Debug {
         params: OnRampBuyOptionsParams,
         http_client: reqwest::Client,
     ) -> RpcResult<OnRampBuyOptionsResponse>;
+
+    async fn get_buy_quotes(
+        &self,
+        params: OnRampBuyQuotesParams,
+        http_client: reqwest::Client,
+    ) -> RpcResult<OnRampBuyQuotesResponse>;
 }


### PR DESCRIPTION
# Description

This PR adds the new endpoint for getting buy quotes for the onramp payments from the [CB payment options endpoint](https://docs.cloud.coinbase.com/pay-sdk/docs/rest-api-reference#buy-quote).

* `/v1/onramp/buy/quotes` GET parameters:
  * `projectId` - project ID
  * `country` - [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) two-digit country code string representing the purchasing user’s country of residence, e.g., US.
  * `subdivision` (optional) - [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) two-digit country subdivision code representing the purchasing user’s subdivision of residence within their country, e.g. NY. Required if the country=“US” because certain states (e.g., NY) have state specific asset restrictions.
  * `purchaseCurrency` - ID of the crypto asset the user wants to purchase. Retrieved from the options API.
  * `purchaseNetwork` (optional) - Name of the network that the purchase currency should be purchased on. Retrieved from the options API. If omitted, the default network for the crypto currency is used.
  * `paymentAmount ` - Fiat amount the user wants to spend to purchase the crypto currency, inclusive of fees with two decimals of precision, e.g., 100.00.
  * `paymentCurrency ` - Fiat currency of the payment amount, e.g., USD.
  * `paymentMethod ` - ID of payment method used to complete the purchase. Retrieved from the options API.

The new endpoint response object contains the following fields:

* `paymentTotal ` - Object with amount and currency of the total fiat payment required to complete the purchase, inclusive of any fees. The currency will match the payment_currency in the request if it is supported, otherwise it falls back to USD.
* `paymentSubtotal ` - Object with amount and currency of the fiat cost of the crypto asset to be purchased, exclusive of any fees. The currency will match the payment_total currency.
* `purchaseAmount ` - Object with amount and currency of the crypto that to be purchased. The currency will match the purchase_currency in the request. The number of decimals will be based on the crypto asset.
* `coinbaseFee ` - Object with amount and currency of the fee changed by the Coinbase exchange to complete the transaction. The currency will match the payment_total currency.
* `networkFee ` - Object with amount and currency of the network fee required to send the purchased crypto to the user’s wallet. The currency will match the payment_total currency.
* `quoteId ` - Reference to the quote that should be passed into the initialization parameters when launching the Coinbase Pay widget via the SDK or URL generator.


## How Has This Been Tested?

1. [New integration test](https://github.com/WalletConnect/blockchain-api/pull/525/commits/af3e230558f6739e5492ba17ed90f2a5cd50ae4a) included in this PR.

2. Manual. 

  * Start the server locally: `cargo run`.
  * Run the following curl request: `http://localhost:3000/v1/onramp/buy/quotes?purchaseCurrency=BCH&paymentAmount=100.00&paymentCurrency=USD&paymentMethod=CARD&country=US&projectId=XXX' | jq .`

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
