### PR TITLE
fix(server): increasing keep-alive timeouts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,8 @@ use {
 };
 
 const SERVICE_TASK_TIMEOUT: Duration = Duration::from_secs(15);
-const KEEPALIVE_IDLE_DURATION: Duration = Duration::from_secs(5);
-const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
+const KEEPALIVE_IDLE_DURATION: Duration = Duration::from_secs(65);
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(65);
 const KEEPALIVE_RETRIES: u32 = 1;
 
 mod analytics;


### PR DESCRIPTION
# Description

We have a rare 502 errors coming from the AWS Load Balancer. 
There are no 5xx server errors or any crashes on the app side. Investigation of the LB access logs and traffic dump showed that the 502 error was caused due to the TCP issue. Further investigation shows that the issue can be in the very low keep-alive timeout in our axum server. 
There are a few [#1](https://www.tessian.com/blog/how-to-fix-http-502-errors/), [#2](https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/) same issues found and possible solution is to increase the keep-alive to the AWS ALB default value of 60 seconds.

This PR increases keep-alive values to 65 seconds to fix the 502 Load Balancer errors.

Context: https://walletconnect.slack.com/archives/C03SCF66K2T/p1707949790838309

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
