### PR TITLE
feat(monitoring): changing to use Prometheus data for the CPU usage

### DIFF
--- a/terraform/monitoring/panels/ecs/cpu.libsonnet
+++ b/terraform/monitoring/panels/ecs/cpu.libsonnet
@@ -1,44 +1,44 @@
 local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
 local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
 
-local panels    = grafana.panels;
-local targets   = grafana.targets;
-local overrides = defaults.overrides;
+local panels          = grafana.panels;
+local targets         = grafana.targets;
+local alert           = grafana.alert;
+local alertCondition  = grafana.alertCondition;
+local overrides       = defaults.overrides;
 
 {
   new(ds, vars)::
     panels.timeseries(
       title       = 'CPU Utilization',
-      datasource  = ds.cloudwatch,
+      datasource  = ds.prometheus,
     )
     .configure(overrides.cpu(defaults.configuration.timeseries_resource))
-    .setAlert(defaults.alerts.cpu(
+    .setAlert(alert.new(
       namespace     = 'RPC Proxy',
-      env           = vars.environment,
-      title         = 'ECS',
+      name          = "RPC %s - High CPU usage" % vars.environment,
+      message       = "RPC %s - High CPU usage" % vars.environment,
+      period        = '5m',
+      frequency     = '1m',
+      noDataState   = 'alerting',
       notifications = vars.notifications,
-    ))
-
-    .addTarget(targets.cloudwatch(
-      alias       = 'CPU (Max)',
-      datasource  = ds.cloudwatch,
-      dimensions  = {
-        ServiceName: vars.ecs_service_name
+      alertRuleTags = {
+        'og_priority': 'P3',
       },
-      metricName  = 'CPUUtilization',
-      namespace   = 'AWS/ECS',
-      statistic   = 'Maximum',
-      refId       = 'CPU_Max',
+      conditions  = [
+        alertCondition.new(
+          evaluatorParams = [ 70 ],
+          evaluatorType   = 'gt',
+          operatorType    = 'or',
+          queryRefId      = 'CPU_Avg',
+          queryTimeStart  = '5m',
+          reducerType     = 'avg',
+        ),
+      ]
     ))
-    .addTarget(targets.cloudwatch(
-      alias       = 'CPU (Avg)',
-      datasource  = ds.cloudwatch,
-      dimensions  = {
-        ServiceName: vars.ecs_service_name
-      },
-      metricName  = 'CPUUtilization',
-      namespace   = 'AWS/ECS',
-      statistic   = 'Average',
+    .addTarget(targets.prometheus(
+      datasource  = ds.prometheus,
+      expr        = 'sum(rate(cpu_usage_sum[$__rate_interval])) / sum(rate(cpu_usage_count[$__rate_interval]))',
       refId       = 'CPU_Avg',
     ))
 }


### PR DESCRIPTION
# Description

This PR is changing to use Prometheus data for the CPU usage in Grafana instead of the AWS CloudWatch Container Insights data which should be disabled soon.

The following changes are made:

* Data source and query are changed
* Alert for the CPU usage greater than `70` is changed.

This is a followup for #514 

## How Has This Been Tested?

It is tested manually by putting the query into the Grafana UI.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
