### PR TITLE
feat(monitoring): disabling container insights

### DIFF
--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -43,9 +43,10 @@ resource "aws_ecs_cluster" "app_cluster" {
   }
 
   # Exposes metrics such as the number of running tasks in CloudWatch
+  # Should be disabled because we use Prometheus for CPU and Memory monitoring
   setting {
     name  = "containerInsights"
-    value = "enabled"
+    value = "disabled"
   }
 }
 


### PR DESCRIPTION
# Description

This PR disables AWS CloudWatch Container Insights for the ECS after the CPU #528  and Memory #529 metrics are migrated to the Prometheus and we don't need the Container Insights anymore.

The following changes are made:

* ~~Bump `ci_workflows` tag to `0.2.6`,~~
* Changing ECS `containerInsights` to `disable`.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Merging dependency policy 🚧

* [x] https://github.com/WalletConnect/ci_workflows/pull/5
* [x] #528
* [x] #529
* [x] Check is it hurt the autoscaling (by checking it on staging).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
