### PR TITLE
fix(errors): unifying provider reachability errors to the 503 HTTP Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -170,7 +170,7 @@ impl IntoResponse for RpcError {
             )
                 .into_response(),
             Self::ProviderError => (
-                StatusCode::BAD_GATEWAY,
+                StatusCode::SERVICE_UNAVAILABLE,
                 Json(new_error_response(
                     "unreachable".to_string(),
                     "We failed to reach the provider for your request".to_string(),
@@ -194,7 +194,7 @@ impl IntoResponse for RpcError {
             )
                 .into_response(),
             Self::Throttled => (
-                StatusCode::BAD_GATEWAY,
+                StatusCode::SERVICE_UNAVAILABLE,
                 Json(new_error_response(
                     "throttled".to_string(),
                     "Our provider for this chain this chain is currently throttling our requests. \
@@ -204,7 +204,7 @@ impl IntoResponse for RpcError {
             )
                 .into_response(),
             Self::TransportError(_) => (
-                StatusCode::BAD_GATEWAY,
+                StatusCode::SERVICE_UNAVAILABLE,
                 Json(new_error_response(
                     "transport".to_string(),
                     "We failed to reach the provider for your request".to_string(),

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -135,7 +135,7 @@ async fn handler_internal(
         state
             .metrics
             .add_rate_limited_call(provider.borrow(), project_id);
-        *response.status_mut() = http::StatusCode::BAD_GATEWAY;
+        *response.status_mut() = http::StatusCode::SERVICE_UNAVAILABLE;
     }
 
     state.metrics.add_external_http_latency(

--- a/terraform/monitoring/panels/proxy/errors_provider.libsonnet
+++ b/terraform/monitoring/panels/proxy/errors_provider.libsonnet
@@ -16,7 +16,7 @@ local alertCondition  = grafana.alertCondition;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'round(sum(increase(http_call_counter_total{code=\"502\"}[5m])))',
-      refId       = "bad_gateway",
+      expr        = 'round(sum(increase(http_call_counter_total{code=\"503\"}[5m])))',
+      refId       = "service_unavailable",
     ))
 }

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -38,7 +38,6 @@ async fn check_if_rpc_is_responding_correctly_for_supported_chain(
     let (status, rpc_response) = send_jsonrpc_request(client, addr, chaind_id, request).await;
 
     match status {
-        StatusCode::BAD_GATEWAY => {}
         StatusCode::OK => {
             // Verify there was no error in rpc
             assert!(rpc_response.error.is_none());


### PR DESCRIPTION
# Description

This PR unifies provider reachability errors to the 503 `Service Temporary Unavailable` instead of 502 `Bad Gateway` which is the Load Balancer error. 
This change should distinguish app third-party providers errors from AWS ALB errors, that return 502 status.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
