### PR TITLE
feat: adding Holesky to the supported chains

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -6,6 +6,7 @@ Chain name with associated `chainId` query param to use.
 
 - Ethereum (`eip155:1`)
 - Ethereum Goerli (`eip155:5`)
+- Ethereum Holesky (`eip155:17000`)
 - Ethereum Sepolia (`eip155:11155111`)
 - Optimism (`eip155:10`)
 - Optimism Goerli (`eip155:420`)

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -83,14 +83,23 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:56".into(),
             ("bsc-mainnet".into(), Weight::new(Priority::Max).unwrap()),
         ),
-        // Ethereum
+        // Ethereum mainnet
         (
             "eip155:1".into(),
             ("eth-mainnet".into(), Weight::new(Priority::Max).unwrap()),
         ),
+        // Ethereum goerli
         (
             "eip155:5".into(),
             ("eth-goerli".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
+        // Ethereum holesky
+        (
+            "eip155:17000".into(),
+            (
+                "holesky-fullnode-testnet".into(),
+                Weight::new(Priority::High).unwrap(),
+            ),
         ),
         // Optimism
         (

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -48,6 +48,14 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::High).unwrap(),
             ),
         ),
+        // Ethereum Holesky
+        (
+            "eip155:17000".into(),
+            (
+                "ethereum-holesky-rpc".into(),
+                Weight::new(Priority::High).unwrap(),
+            ),
+        ),
         // Base mainnet
         (
             "eip155:8453".into(),

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -56,7 +56,7 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     )
     .await;
 
-    // Ethereum
+    // Ethereum mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
         &ProviderKind::Pokt,
@@ -65,12 +65,21 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     )
     .await;
 
-    // Goerli
+    // Ethereum goerli
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
         &ProviderKind::Pokt,
         "eip155:5",
         "0x5",
+    )
+    .await;
+
+    // Ethereum holesky
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Pokt,
+        "eip155:17000",
+        "0x4268",
     )
     .await;
 

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -27,6 +27,15 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
     )
     .await;
 
+    // Ethereum holesky
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Publicnode,
+        "eip155:17000",
+        "0x4268",
+    )
+    .await;
+
     // Base mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,


### PR DESCRIPTION
# Description

Since Goerli's sunset is now planned for this year, we have requests for support Holesky in our RPC.
This PR adds support to the Holesky testnet `eip155:17000` in our RPC by using our Pokt and Publicnode providers.

Resolves #533

## How Has This Been Tested?

Tests for providers are updated.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
