### PR TITLE
fix(providers): adding more `Near protocol` support

### DIFF
--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -15,6 +15,7 @@ pub use {
     base::*,
     binance::*,
     infura::*,
+    near::*,
     omnia::*,
     pokt::*,
     publicnode::*,
@@ -27,6 +28,7 @@ mod aurora;
 mod base;
 mod binance;
 mod infura;
+mod near;
 mod omnia;
 mod pokt;
 mod publicnode;

--- a/src/env/near.rs
+++ b/src/env/near.rs
@@ -1,0 +1,47 @@
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
+
+#[derive(Debug)]
+pub struct NearConfig {
+    pub supported_chains: HashMap<String, (String, Weight)>,
+}
+
+impl Default for NearConfig {
+    fn default() -> Self {
+        Self {
+            supported_chains: default_supported_chains(),
+        }
+    }
+}
+
+impl ProviderConfig for NearConfig {
+    fn supported_chains(self) -> HashMap<String, (String, Weight)> {
+        self.supported_chains
+    }
+
+    fn supported_ws_chains(self) -> HashMap<String, (String, Weight)> {
+        HashMap::new()
+    }
+
+    fn provider_kind(&self) -> crate::providers::ProviderKind {
+        crate::providers::ProviderKind::Near
+    }
+}
+
+fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
+    HashMap::from([
+        // Near protocol
+        (
+            "near".into(),
+            (
+                "https://rpc.mainnet.near.org".into(),
+                Weight::new(Priority::High).unwrap(),
+            ),
+        ),
+    ])
+}

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -143,5 +143,13 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Near protocol
+        (
+            "near".into(),
+            (
+                "near-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
     ])
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use {
         BaseConfig,
         BinanceConfig,
         InfuraConfig,
+        NearConfig,
         OmniatechConfig,
         PoktConfig,
         PublicnodeConfig,
@@ -37,6 +38,7 @@ use {
         BinanceProvider,
         InfuraProvider,
         InfuraWsProvider,
+        NearProvider,
         OmniatechProvider,
         PoktProvider,
         ProviderRepository,
@@ -368,6 +370,7 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
         config.infura_project_id.clone(),
     ));
     providers.add_provider::<ZoraProvider, ZoraConfig>(ZoraConfig::default());
+    providers.add_provider::<NearProvider, NearConfig>(NearConfig::default());
 
     providers.add_ws_provider::<InfuraWsProvider, InfuraConfig>(InfuraConfig::new(
         config.infura_project_id.clone(),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -33,6 +33,7 @@ mod base;
 mod binance;
 mod coinbase;
 mod infura;
+mod near;
 mod omnia;
 mod pokt;
 mod publicnode;
@@ -47,6 +48,7 @@ pub use {
     base::BaseProvider,
     binance::BinanceProvider,
     infura::{InfuraProvider, InfuraWsProvider},
+    near::NearProvider,
     omnia::OmniatechProvider,
     pokt::PoktProvider,
     publicnode::PublicnodeProvider,
@@ -318,6 +320,7 @@ pub enum ProviderKind {
     Zerion,
     Coinbase,
     Quicknode,
+    Near,
 }
 
 impl Display for ProviderKind {
@@ -335,6 +338,7 @@ impl Display for ProviderKind {
             ProviderKind::Zerion => "Zerion",
             ProviderKind::Coinbase => "Coinbase",
             ProviderKind::Quicknode => "Quicknode",
+            ProviderKind::Near => "Near",
         })
     }
 }
@@ -355,6 +359,7 @@ impl ProviderKind {
             "Zerion" => Some(Self::Zerion),
             "Coinbase" => Some(Self::Coinbase),
             "Quicknode" => Some(Self::Quicknode),
+            "Near" => Some(Self::Near),
             _ => None,
         }
     }

--- a/src/providers/near.rs
+++ b/src/providers/near.rs
@@ -1,0 +1,96 @@
+use {
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::NearConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::{client::HttpConnector, http, Client, Method},
+    hyper_tls::HttpsConnector,
+    std::collections::HashMap,
+    tracing::info,
+};
+
+#[derive(Debug)]
+pub struct NearProvider {
+    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub supported_chains: HashMap<String, String>,
+}
+
+impl Provider for NearProvider {
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
+
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Near
+    }
+}
+
+#[async_trait]
+impl RateLimited for NearProvider {
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
+}
+
+#[async_trait]
+impl RpcProvider for NearProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()))]
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
+
+        let hyper_request = hyper::http::Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header("Content-Type", "application/json")
+            .body(hyper::body::Body::from(body))?;
+
+        let response = self.client.request(hyper_request).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
+
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && status.is_success() {
+                info!(
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                     Near public RPC: {response:?}"
+                );
+            }
+        }
+
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
+}
+
+impl RpcProviderFactory<NearConfig> for NearProvider {
+    #[tracing::instrument]
+    fn new(provider_config: &NearConfig) -> Self {
+        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
+
+        NearProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
+}

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod aurora;
 pub(crate) mod base;
 pub(crate) mod binance;
 pub(crate) mod infura;
+pub(crate) mod near;
 pub(crate) mod pokt;
 pub(crate) mod publicnode;
 pub(crate) mod quicknode;
@@ -44,6 +45,45 @@ async fn check_if_rpc_is_responding_correctly_for_supported_chain(
 
             // Check chainId
             assert_eq!(rpc_response.result::<String>().unwrap(), expected_id)
+        }
+        _ => panic!("Unexpected status code: {}", status),
+    };
+}
+
+async fn check_if_rpc_is_responding_correctly_for_near_protocol(
+    ctx: &ServerContext,
+    provider_id: &ProviderKind,
+) {
+    let addr = format!(
+        "{}/v1/?projectId={}&providerId={}&chainId=",
+        ctx.server.public_addr, ctx.server.project_id, provider_id
+    );
+
+    let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+    let request = jsonrpc::Request {
+        method: "EXPERIMENTAL_genesis_config",
+        params: &[],
+        id: serde_json::Value::Number(1.into()),
+        jsonrpc: JSONRPC_VERSION,
+    };
+
+    let (status, rpc_response) = send_jsonrpc_request(client, addr, "near", request).await;
+
+    #[derive(serde::Deserialize)]
+    struct GenesisConfig {
+        chain_id: String,
+    }
+
+    match status {
+        StatusCode::OK => {
+            // Verify there was no error in rpc
+            assert!(rpc_response.error.is_none());
+
+            // Check chainId
+            assert_eq!(
+                rpc_response.result::<GenesisConfig>().unwrap().chain_id,
+                "mainnet"
+            )
         }
         _ => panic!("Unexpected status code: {}", status),
     };

--- a/tests/functional/http/near.rs
+++ b/tests/functional/http/near.rs
@@ -1,0 +1,13 @@
+use {
+    super::check_if_rpc_is_responding_correctly_for_near_protocol,
+    crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind,
+    test_context::test_context,
+};
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn near_provider(ctx: &mut ServerContext) {
+    check_if_rpc_is_responding_correctly_for_near_protocol(ctx, &ProviderKind::Near).await;
+}

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -1,5 +1,8 @@
 use {
-    super::check_if_rpc_is_responding_correctly_for_supported_chain,
+    super::{
+        check_if_rpc_is_responding_correctly_for_near_protocol,
+        check_if_rpc_is_responding_correctly_for_supported_chain,
+    },
     crate::{context::ServerContext, utils::send_jsonrpc_request, JSONRPC_VERSION},
     hyper::{Client, StatusCode},
     hyper_tls::HttpsConnector,
@@ -171,4 +174,11 @@ async fn pokt_provider_solana_mainnet(ctx: &mut ServerContext) {
 
     // Check chainId
     assert_eq!(rpc_response.result::<String>().unwrap(), "ok")
+}
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn pokt_provider_near(ctx: &mut ServerContext) {
+    check_if_rpc_is_responding_correctly_for_near_protocol(ctx, &ProviderKind::Pokt).await;
 }


### PR DESCRIPTION
# Description

[We have `Near` support in our Supported chains](https://github.com/WalletConnect/blockchain-api/blob/9a4c0b5efd7f8f975307a9e0e6f493adaf434766/SUPPORTED_CHAINS.md?plain=1#L26), but the only provider for it is Omnia which mostly always in a rate-limited state, so we don't have any `Near` successful requests for a long time.

This PR adds the following changes: 

* Adds the Near protocol public RPC to our providers list,
* Adds Near support for the Pokt/Grove provider.
* Adds tests for the Near protocol RPC.

## How Has This Been Tested?

* Functional integration tests are included in this PR for new Near public RPC provider and Pokt.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
