### PR TITLE
fix(monitoring): increasing CPU alarm threshold

### DIFF
--- a/terraform/monitoring/panels/ecs/cpu.libsonnet
+++ b/terraform/monitoring/panels/ecs/cpu.libsonnet
@@ -18,7 +18,7 @@ local overrides       = defaults.overrides;
       namespace     = 'RPC Proxy',
       name          = "RPC %s - High CPU usage" % vars.environment,
       message       = "RPC %s - High CPU usage" % vars.environment,
-      period        = '15m',
+      period        = '25m',
       frequency     = '3m',
       noDataState   = 'alerting',
       notifications = vars.notifications,
@@ -31,7 +31,7 @@ local overrides       = defaults.overrides;
           evaluatorType   = 'gt',
           operatorType    = 'or',
           queryRefId      = 'CPU_Avg',
-          queryTimeStart  = '15m',
+          queryTimeStart  = '25m',
           reducerType     = 'max',
         ),
       ]

--- a/terraform/monitoring/panels/ecs/cpu.libsonnet
+++ b/terraform/monitoring/panels/ecs/cpu.libsonnet
@@ -18,8 +18,8 @@ local overrides       = defaults.overrides;
       namespace     = 'RPC Proxy',
       name          = "RPC %s - High CPU usage" % vars.environment,
       message       = "RPC %s - High CPU usage" % vars.environment,
-      period        = '25m',
-      frequency     = '3m',
+      period        = '15m',
+      frequency     = '5m',
       noDataState   = 'alerting',
       notifications = vars.notifications,
       alertRuleTags = {
@@ -31,7 +31,7 @@ local overrides       = defaults.overrides;
           evaluatorType   = 'gt',
           operatorType    = 'or',
           queryRefId      = 'CPU_Avg',
-          queryTimeStart  = '25m',
+          queryTimeStart  = '5m',
           reducerType     = 'max',
         ),
       ]


### PR DESCRIPTION
# Description

This PR increases the CPU utilization alarm threshold to 25 minutes same as we have in the Relay to allow autoscaling provisioning and alarm if it's not scaled along with the high CPU usage.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
