### PR TITLE
feat(providers): adding Mantle to supported chains

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -32,6 +32,8 @@ Chain name with associated `chainId` query param to use.
 - Zora (`eip155:7777777`)
 - Zora Goerli (`eip155:999`)
 - Klaytn Mainnet (`eip155:8217`)
+- Mantle (`eip155:5000`)
+- Mantle Testnet (`eip155:5001`)
 
 ## WebSocket RPC
 

--- a/src/env/mantle.rs
+++ b/src/env/mantle.rs
@@ -1,0 +1,55 @@
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
+
+#[derive(Debug)]
+pub struct MantleConfig {
+    pub supported_chains: HashMap<String, (String, Weight)>,
+}
+
+impl Default for MantleConfig {
+    fn default() -> Self {
+        Self {
+            supported_chains: default_supported_chains(),
+        }
+    }
+}
+
+impl ProviderConfig for MantleConfig {
+    fn supported_chains(self) -> HashMap<String, (String, Weight)> {
+        self.supported_chains
+    }
+
+    fn supported_ws_chains(self) -> HashMap<String, (String, Weight)> {
+        HashMap::new()
+    }
+
+    fn provider_kind(&self) -> crate::providers::ProviderKind {
+        crate::providers::ProviderKind::Mantle
+    }
+}
+
+fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
+    HashMap::from([
+        // Mantle mainnet
+        (
+            "eip155:5000".into(),
+            (
+                "https://rpc.mantle.xyz".into(),
+                Weight::new(Priority::High).unwrap(),
+            ),
+        ),
+        // Mantle testnet
+        (
+            "eip155:5001".into(),
+            (
+                "https://rpc.testnet.mantle.xyz".into(),
+                Weight::new(Priority::High).unwrap(),
+            ),
+        ),
+    ])
+}

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -15,6 +15,7 @@ pub use {
     base::*,
     binance::*,
     infura::*,
+    mantle::*,
     near::*,
     omnia::*,
     pokt::*,
@@ -28,6 +29,7 @@ mod aurora;
 mod base;
 mod binance;
 mod infura;
+mod mantle;
 mod near;
 mod omnia;
 mod pokt;

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -100,5 +100,10 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::High).unwrap(),
             ),
         ),
+        // Mantle mainnet
+        (
+            "eip155:5000".into(),
+            ("mantle-rpc".into(), Weight::new(Priority::High).unwrap()),
+        ),
     ])
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use {
         BaseConfig,
         BinanceConfig,
         InfuraConfig,
+        MantleConfig,
         NearConfig,
         OmniatechConfig,
         PoktConfig,
@@ -38,6 +39,7 @@ use {
         BinanceProvider,
         InfuraProvider,
         InfuraWsProvider,
+        MantleProvider,
         NearProvider,
         OmniatechProvider,
         PoktProvider,
@@ -371,6 +373,7 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
     ));
     providers.add_provider::<ZoraProvider, ZoraConfig>(ZoraConfig::default());
     providers.add_provider::<NearProvider, NearConfig>(NearConfig::default());
+    providers.add_provider::<MantleProvider, MantleConfig>(MantleConfig::default());
 
     providers.add_ws_provider::<InfuraWsProvider, InfuraConfig>(InfuraConfig::new(
         config.infura_project_id.clone(),

--- a/src/providers/mantle.rs
+++ b/src/providers/mantle.rs
@@ -1,0 +1,96 @@
+use {
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
+    crate::{
+        env::MantleConfig,
+        error::{RpcError, RpcResult},
+    },
+    async_trait::async_trait,
+    axum::{
+        http::HeaderValue,
+        response::{IntoResponse, Response},
+    },
+    hyper::{client::HttpConnector, http, Client, Method},
+    hyper_tls::HttpsConnector,
+    std::collections::HashMap,
+    tracing::info,
+};
+
+#[derive(Debug)]
+pub struct MantleProvider {
+    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub supported_chains: HashMap<String, String>,
+}
+
+impl Provider for MantleProvider {
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.supported_chains.contains_key(chain_id)
+    }
+
+    fn supported_caip_chains(&self) -> Vec<String> {
+        self.supported_chains.keys().cloned().collect()
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Mantle
+    }
+}
+
+#[async_trait]
+impl RateLimited for MantleProvider {
+    async fn is_rate_limited(&self, response: &mut Response) -> bool {
+        response.status() == http::StatusCode::TOO_MANY_REQUESTS
+    }
+}
+
+#[async_trait]
+impl RpcProvider for MantleProvider {
+    #[tracing::instrument(skip(self, body), fields(provider = %self.provider_kind()))]
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
+        let uri = self
+            .supported_chains
+            .get(chain_id)
+            .ok_or(RpcError::ChainNotFound)?;
+
+        let hyper_request = hyper::http::Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header("Content-Type", "application/json")
+            .body(hyper::body::Body::from(body))?;
+
+        let response = self.client.request(hyper_request).await?;
+        let status = response.status();
+        let body = hyper::body::to_bytes(response.into_body()).await?;
+
+        if let Ok(response) = serde_json::from_slice::<jsonrpc::Response>(&body) {
+            if response.error.is_some() && status.is_success() {
+                info!(
+                    "Strange: provider returned JSON RPC error, but status {status} is success: \
+                     Mantle public RPC: {response:?}"
+                );
+            }
+        }
+
+        let mut response = (status, body).into_response();
+        response
+            .headers_mut()
+            .insert("Content-Type", HeaderValue::from_static("application/json"));
+        Ok(response)
+    }
+}
+
+impl RpcProviderFactory<MantleConfig> for MantleProvider {
+    #[tracing::instrument]
+    fn new(provider_config: &MantleConfig) -> Self {
+        let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+        let supported_chains: HashMap<String, String> = provider_config
+            .supported_chains
+            .iter()
+            .map(|(k, v)| (k.clone(), v.0.clone()))
+            .collect();
+
+        MantleProvider {
+            client: forward_proxy_client,
+            supported_chains,
+        }
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -33,6 +33,7 @@ mod base;
 mod binance;
 mod coinbase;
 mod infura;
+mod mantle;
 mod near;
 mod omnia;
 mod pokt;
@@ -48,6 +49,7 @@ pub use {
     base::BaseProvider,
     binance::BinanceProvider,
     infura::{InfuraProvider, InfuraWsProvider},
+    mantle::MantleProvider,
     near::NearProvider,
     omnia::OmniatechProvider,
     pokt::PoktProvider,
@@ -321,6 +323,7 @@ pub enum ProviderKind {
     Coinbase,
     Quicknode,
     Near,
+    Mantle,
 }
 
 impl Display for ProviderKind {
@@ -339,6 +342,7 @@ impl Display for ProviderKind {
             ProviderKind::Coinbase => "Coinbase",
             ProviderKind::Quicknode => "Quicknode",
             ProviderKind::Near => "Near",
+            ProviderKind::Mantle => "Mantle",
         })
     }
 }
@@ -360,6 +364,7 @@ impl ProviderKind {
             "Coinbase" => Some(Self::Coinbase),
             "Quicknode" => Some(Self::Quicknode),
             "Near" => Some(Self::Near),
+            "Mantle" => Some(Self::Mantle),
             _ => None,
         }
     }

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -68,6 +68,7 @@ dashboard.new(
     panels.usage.provider(ds, vars, 'Quicknode')     { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Zora')          { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'zkSync')        { gridPos: pos._4 },
+    panels.usage.provider(ds, vars, 'Mantle')        { gridPos: pos._4 },
 
   row.new('Provider Weights'),
     panels.weights.provider(ds, vars, 'Aurora')      { gridPos: pos._4 },
@@ -80,6 +81,7 @@ dashboard.new(
     panels.weights.provider(ds, vars, 'Quicknode')   { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Zora')        { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'zkSync')      { gridPos: pos._4 },
+    panels.weights.provider(ds, vars, 'Mantle')      { gridPos: pos._4 },
 
   row.new('Status Codes'),
     panels.status.provider(ds, vars, 'Aurora')       { gridPos: pos._4 },
@@ -92,6 +94,7 @@ dashboard.new(
     panels.status.provider(ds, vars, 'Quicknode')    { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Zora')         { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'zkSync')       { gridPos: pos._4 },
+    panels.status.provider(ds, vars, 'Mantle')       { gridPos: pos._4 },
 
   row.new('Proxy Metrics'),
     panels.proxy.calls(ds, vars)                     { gridPos: pos._2 },

--- a/tests/functional/http/mantle.rs
+++ b/tests/functional/http/mantle.rs
@@ -1,0 +1,28 @@
+use {
+    super::check_if_rpc_is_responding_correctly_for_supported_chain,
+    crate::context::ServerContext,
+    rpc_proxy::providers::ProviderKind,
+    test_context::test_context,
+};
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn mantle_provider(ctx: &mut ServerContext) {
+    // Mantle mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Mantle,
+        "eip155:5000",
+        "0x1388",
+    )
+    .await;
+    // Mantle testnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Mantle,
+        "eip155:5001",
+        "0x1389",
+    )
+    .await;
+}

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod aurora;
 pub(crate) mod base;
 pub(crate) mod binance;
 pub(crate) mod infura;
+pub(crate) mod mantle;
 pub(crate) mod near;
 pub(crate) mod pokt;
 pub(crate) mod publicnode;

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -98,4 +98,13 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
         "0x13881",
     )
     .await;
+
+    // Mantle mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Publicnode,
+        "eip155:5000",
+        "0x1388",
+    )
+    .await;
 }


### PR DESCRIPTION
# Description

This PR adds [Mantle](https://mantle.xyz) chain `eip155:5000` and testnet `eip155:5001` to supported chains.
The following changes are made:

* Mantle public RPC endpoints for the mainnet and testnet were added as a `Mantle` provider.
* Mantle mainnet added to the chains list for the `Publicnode` provider.
* Tests for the Mantle provider were added.
* Tests for the Publicnode provider were updated.
* Grafana panels for the Mantle chain were added.
* Supported chains list was updated.

Resolves #537 

## How Has This Been Tested?

Provider functional tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
