### PR TITLE
fix(monitoring): removing 503 from non-providers errors

### DIFF
--- a/terraform/monitoring/panels/ecs/availability.libsonnet
+++ b/terraform/monitoring/panels/ecs/availability.libsonnet
@@ -48,7 +48,7 @@ local error_alert(vars) = alert.new(
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = '(1-(sum(rate(http_call_counter_total{code=~"5.+"}[5m])) or vector(0))/(sum(rate(http_call_counter_total{}[5m]))))*100',
+      expr        = '(1-(sum(rate(http_call_counter_total{code=~"5[0-24-9][0-9]"}[5m])) or vector(0))/(sum(rate(http_call_counter_total{}[5m]))))*100',
       refId       = "availability",
       exemplar    = false,
     ))

--- a/terraform/monitoring/panels/proxy/errors_non_provider.libsonnet
+++ b/terraform/monitoring/panels/proxy/errors_non_provider.libsonnet
@@ -16,7 +16,7 @@ local alertCondition  = grafana.alertCondition;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'round(sum(increase(http_call_counter_total{code=~"50[0-1]|503|50[5-9]|5[1-9][0-9]"}[5m])))',
+      expr        = 'round(sum(increase(http_call_counter_total{code=~"50[0-1]|50[5-9]|5[1-9][0-9]"}[5m])))',
       refId       = "non_provider_errors",
       exemplar    = true,
     )) 


### PR DESCRIPTION
# Description

This PR removes `HTTP 503 Temporary Unavailable` error from the availability chart/alert and from the non-provider errors chart.
The reason for this change is that we are returning 503 error to clients when we are rate-limited by the provider.

## How Has This Been Tested?

Put the updated Prometheus queries to the Grafana, the updated chart should appear.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
