### PR TITLE
fix(providers): `Near` chain ID to be CAIP-2 compatible

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -24,7 +24,7 @@ Chain name with associated `chainId` query param to use.
 - Avalanche Fuji Testnet (`eip155:43113`)
 - zkSync Era (`eip155:324`)
 - zkSync Era Testnet (`eip155:280`)
-- Near (`near`)
+- Near Mainnet(`near:mainnet`)
 - Gnosis Chain (`eip155:100`)
 - Solana Mainnet (`solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz`)
 - Base (`eip155:8453`)

--- a/src/env/near.rs
+++ b/src/env/near.rs
@@ -37,7 +37,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
     HashMap::from([
         // Near protocol
         (
-            "near".into(),
+            "near:mainnet".into(),
             (
                 "https://rpc.mainnet.near.org".into(),
                 Weight::new(Priority::High).unwrap(),

--- a/src/env/omnia.rs
+++ b/src/env/omnia.rs
@@ -52,7 +52,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         ),
         // Near
         (
-            "near".into(),
+            "near:mainnet".into(),
             ("near".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         // Aurora

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -154,7 +154,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         ),
         // Near protocol
         (
-            "near".into(),
+            "near:mainnet".into(),
             (
                 "near-mainnet".into(),
                 Weight::new(Priority::Normal).unwrap(),

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -67,7 +67,7 @@ async fn check_if_rpc_is_responding_correctly_for_near_protocol(
         jsonrpc: JSONRPC_VERSION,
     };
 
-    let (status, rpc_response) = send_jsonrpc_request(client, addr, "near", request).await;
+    let (status, rpc_response) = send_jsonrpc_request(client, addr, "near:mainnet", request).await;
 
     #[derive(serde::Deserialize)]
     struct GenesisConfig {


### PR DESCRIPTION
# Description

This PR changes the chain Id for the `Near` to be CAIP-2 compatible and becomes `near:mainnet` instead of `near`.
According to the Grafana chain Ids requests, at the moment we don't have any Near traffic yet (we've added it recently), so we can switch it without migration.

## How Has This Been Tested?

Integration tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
