### PR TITLE
fix(monitoring): fixing typo in excluding 503 from availability

### DIFF
--- a/terraform/monitoring/panels/ecs/availability.libsonnet
+++ b/terraform/monitoring/panels/ecs/availability.libsonnet
@@ -48,7 +48,7 @@ local error_alert(vars) = alert.new(
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = '(1-(sum(rate(http_call_counter_total{code=~"5[0-24-9][0-9]"}[5m])) or vector(0))/(sum(rate(http_call_counter_total{}[5m]))))*100',
+      expr        = '(1-(sum(rate(http_call_counter_total{code=~"5[0-9][0-24-9]"}[5m])) or vector(0))/(sum(rate(http_call_counter_total{}[5m]))))*100',
       refId       = "availability",
       exemplar    = false,
     ))


### PR DESCRIPTION
# Description

This PR fixed the typo in excluding HTTP 503 error from the availability (from #546 ). 
Instead of excluding 503, we were excluded 530.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
