### PR TITLE
feat: account balance endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.25.0",
  "syn 2.0.42",
  "tempfile",
  "thiserror",
@@ -4084,6 +4084,8 @@ dependencies = [
  "serde_piecewise_default",
  "sha256",
  "sqlx",
+ "strum 0.26.1",
+ "strum_macros 0.26.1",
  "sysinfo",
  "tap",
  "test-context",
@@ -4862,14 +4864,33 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.25.3",
 ]
+
+[[package]]
+name = "strum"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 
 [[package]]
 name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.70",
+ "quote 1.0.33",
+ "rustversion",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck",
  "proc-macro2 1.0.70",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ serde_piecewise_default = "0.2"
 serde-aux = "3.1"
 validator = { version = "0.16", features = ["derive"] }
 num_enum = "0.7"
+strum = "0.26"
+strum_macros = "0.26"
 
 # Storage
 aws-config = "0.56"

--- a/integration/balance.test.ts
+++ b/integration/balance.test.ts
@@ -1,6 +1,6 @@
 import { getTestSetup } from './init';
 
-describe('Address balance', () => {
+describe('Account balance', () => {
   const { baseUrl, projectId, httpClient } = getTestSetup();
 
   const fulfilled_address = '0xf3ea39310011333095CFCcCc7c4Ad74034CABA63'

--- a/integration/balance.test.ts
+++ b/integration/balance.test.ts
@@ -1,0 +1,36 @@
+import { getTestSetup } from './init';
+
+describe('Address balance', () => {
+  const { baseUrl, projectId, httpClient } = getTestSetup();
+
+  const fulfilled_address = '0xf3ea39310011333095CFCcCc7c4Ad74034CABA63'
+  const empty_address = '0x5b6262592954B925B510651462b63ddEbcc22eaD'
+  const currency = 'usd'
+
+  it('fulfilled balance', async () => {
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/account/${fulfilled_address}/balance?projectId=${projectId}&currency=${currency}`
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.balances).toBe('object')
+    expect(resp.data.balances.length).toBeGreaterThan(1)
+
+    for (const item of resp.data.balances) {
+      expect(typeof item.name).toBe('string')
+      expect(typeof item.symbol).toBe('string')
+      expect(item.chainId).toEqual(expect.stringMatching(/^(eip155:)?\d+$/))
+      expect(typeof item.price).toBe('number')
+      expect(typeof item.quantity).toBe('object')
+      expect(typeof item.iconUrl).toBe('string')
+    }
+  })
+
+  it('empty balance', async () => {
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/account/${empty_address}/balance?projectId=${projectId}&currency=${currency}`
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.balances).toBe('object')
+    expect(resp.data.balances).toHaveLength(0)
+  })
+})

--- a/integration/history.test.ts
+++ b/integration/history.test.ts
@@ -4,7 +4,7 @@ describe('Transactions history', () => {
   const { baseUrl, projectId, httpClient } = getTestSetup();
 
   const fulfilled_address = '0x63755B7B300228254FB7d16321eCD3B87f98ca2a'
-  const empty_history_address = '0x739ff389c8eBd9339E69611d46Eec6212179BB67'
+  const empty_history_address = '0x5b6262592954B925B510651462b63ddEbcc22eaD'
 
   it('fulfilled history', async () => {
     let resp: any = await httpClient.get(

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,12 @@ pub enum RpcError {
     #[error("Failed to reach the portfolio provider")]
     PortfolioProviderError,
 
+    #[error("Failed to reach the balance provider")]
+    BalanceProviderError,
+
+    #[error("Failed to parse balance provider url")]
+    BalanceParseURLError,
+
     #[error("Failed to parse onramp provider url")]
     OnRampParseURLError,
 

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -1,0 +1,113 @@
+use {
+    super::HANDLER_TASK_METRICS,
+    crate::{error::RpcError, state::AppState},
+    axum::{
+        extract::{Path, Query, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    ethers::abi::Address,
+    serde::{Deserialize, Serialize},
+    std::{fmt::Display, sync::Arc},
+    tap::TapFallible,
+    tracing::log::error,
+    wc::future::FutureExt,
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum BalanceCurrencies {
+    BTC,
+    ETH,
+    USD,
+    EUR,
+    GBP,
+    AUD,
+    CAD,
+    INR,
+    JPY,
+}
+
+impl Display for BalanceCurrencies {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            BalanceCurrencies::BTC => "btc",
+            BalanceCurrencies::ETH => "eth",
+            BalanceCurrencies::USD => "usd",
+            BalanceCurrencies::EUR => "eur",
+            BalanceCurrencies::GBP => "gbp",
+            BalanceCurrencies::AUD => "aud",
+            BalanceCurrencies::CAD => "cad",
+            BalanceCurrencies::INR => "inr",
+            BalanceCurrencies::JPY => "jpy",
+        })
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BalanceQueryParams {
+    pub project_id: String,
+    pub currency: BalanceCurrencies,
+    pub chain_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BalanceResponseBody {
+    pub balances: Vec<BalanceItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BalanceItem {
+    pub name: String,
+    pub symbol: String,
+    pub chain_id: Option<String>,
+    pub value: Option<f64>,
+    pub price: f64,
+    pub quantity: BalanceQuantity,
+    pub icon_url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BalanceQuantity {
+    pub decimals: String,
+    pub numeric: String,
+}
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    query: Query<BalanceQueryParams>,
+    address: Path<String>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, query, address)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("balance"))
+        .await
+}
+
+#[tracing::instrument(skip_all)]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    query: Query<BalanceQueryParams>,
+    Path(address): Path<String>,
+) -> Result<Response, RpcError> {
+    let project_id = query.project_id.clone();
+    address
+        .parse::<Address>()
+        .map_err(|_| RpcError::InvalidAddress)?;
+
+    state.validate_project_access_and_quota(&project_id).await?;
+
+    let response = state
+        .providers
+        .balance_provider
+        .get_balance(address, query.0, state.http_client.clone())
+        .await
+        .tap_err(|e| {
+            error!("Failed to call balance with {}", e);
+        })?;
+
+    Ok(Json(response).into_response())
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -3,6 +3,7 @@ use {
     wc::metrics::TaskMetrics,
 };
 
+pub mod balance;
 pub mod generators;
 pub mod health;
 pub mod history;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,10 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/account/:address/portfolio",
             get(handlers::portfolio::handler),
         )
+        .route(
+            "/v1/account/:address/balance",
+            get(handlers::balance::handler),
+        )
         // Register account name
         .route(
             "/v1/profile/account",

--- a/src/providers/coinbase.rs
+++ b/src/providers/coinbase.rs
@@ -17,7 +17,7 @@ use {
                 quotes::{OnRampBuyQuotesParams, OnRampBuyQuotesResponse},
             },
         },
-        utils::crypto::string_chain_id_to_caip2_format,
+        utils::crypto::ChainId,
     },
     async_trait::async_trait,
     hyper::Client,
@@ -120,7 +120,7 @@ impl HistoryProvider for CoinbaseProvider {
                     sent_to: address.clone(),
                     status: f.status,
                     application: None,
-                    chain: string_chain_id_to_caip2_format(&f.purchase_network).ok(),
+                    chain: ChainId::to_caip2(&f.purchase_network),
                 },
                 transfers: Some(vec![HistoryTransactionTransfer {
                     fungible_info: Some(HistoryTransactionFungibleInfo {

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -1,8 +1,9 @@
 use {
-    super::{HistoryProvider, PortfolioProvider},
+    super::{BalanceProvider, HistoryProvider, PortfolioProvider},
     crate::{
         error::{RpcError, RpcResult},
         handlers::{
+            balance::{BalanceQueryParams, BalanceResponseBody},
             history::{
                 HistoryQueryParams,
                 HistoryResponseBody,
@@ -20,6 +21,7 @@ use {
             },
             portfolio::{PortfolioPosition, PortfolioQueryParams, PortfolioResponseBody},
         },
+        providers::balance::{BalanceItem, BalanceQuantity},
         utils::crypto,
     },
     async_trait::async_trait,
@@ -28,6 +30,7 @@ use {
     hyper::Client,
     hyper_tls::HttpsConnector,
     serde::{Deserialize, Serialize},
+    tap::TapFallible,
     tracing::log::{error, info},
     url::Url,
 };
@@ -70,19 +73,14 @@ pub struct ZerionPortfolioResponseBody {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ZerionPortfolioAttributes {
-    pub quantity: ZerionPortfolioQuantity,
-    pub fungible_info: ZerionPortfolioFungibleInfo,
+    pub quantity: ZerionQuantityAttribute,
+    pub fungible_info: ZerionFungibleInfoAttribute,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub struct ZerionPortfolioQuantity {
+pub struct ZerionQuantityAttribute {
+    pub decimals: usize,
     pub numeric: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub struct ZerionPortfolioFungibleInfo {
-    pub name: String,
-    pub symbol: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -90,21 +88,21 @@ pub struct ZerionTransactionsReponseBody {
     pub r#type: String,
     pub id: String,
     pub attributes: ZerionTransactionAttributes,
-    pub relationships: ZerionTransactionsRelationships,
+    pub relationships: ZerionRelationshipsItem,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub struct ZerionTransactionsRelationships {
-    pub chain: ZerionTransactionsRelationshipsChain,
+pub struct ZerionRelationshipsItem {
+    pub chain: ZerionRelationshipsItemChain,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub struct ZerionTransactionsRelationshipsChain {
-    pub data: ZerionTransactionsRelationshipsChainData,
+pub struct ZerionRelationshipsItemChain {
+    pub data: ZerionRelationshipsItemChainData,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub struct ZerionTransactionsRelationshipsChainData {
+pub struct ZerionRelationshipsItemChainData {
     pub r#type: String,
     pub id: String,
 }
@@ -125,7 +123,7 @@ pub struct ZerionTransactionAttributes {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ZerionTransactionTransfer {
-    pub fungible_info: Option<ZerionTransactionFungibleInfo>,
+    pub fungible_info: Option<ZerionFungibleInfoAttribute>,
     pub nft_info: Option<ZerionTransactionNFTInfo>,
     pub direction: String,
     pub quantity: ZerionTransactionTransferQuantity,
@@ -134,9 +132,9 @@ pub struct ZerionTransactionTransfer {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-pub struct ZerionTransactionFungibleInfo {
-    pub name: Option<String>,
-    pub symbol: Option<String>,
+pub struct ZerionFungibleInfoAttribute {
+    pub name: String,
+    pub symbol: String,
     pub icon: Option<ZerionTransactionURLItem>,
 }
 
@@ -183,6 +181,20 @@ pub struct ZerionTransactionApplicationMetadata {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ZerionUrlItem {
     pub url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ZerionPosition {
+    pub attributes: ZerionPositionAttributes,
+    pub relationships: ZerionRelationshipsItem,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ZerionPositionAttributes {
+    pub value: Option<f64>,
+    pub price: f64,
+    pub quantity: ZerionQuantityAttribute,
+    pub fungible_info: ZerionFungibleInfoAttribute,
 }
 
 #[async_trait]
@@ -283,8 +295,8 @@ impl HistoryProvider for ZerionProvider {
                         Some(HistoryTransactionTransfer {
                             fungible_info: f.fungible_info.map(|f| {
                                 HistoryTransactionFungibleInfo {
-                                    name: f.name,
-                                    symbol: f.symbol,
+                                    name: Some(f.name),
+                                    symbol: Some(f.symbol),
                                     icon: f.icon.map(|f| HistoryTransactionURLItem { url: f.url }),
                                 }
                             }),
@@ -382,5 +394,80 @@ impl PortfolioProvider for ZerionProvider {
             .collect();
 
         Ok(PortfolioResponseBody { data: portfolio })
+    }
+}
+
+#[async_trait]
+impl BalanceProvider for ZerionProvider {
+    #[tracing::instrument(skip(self, params), fields(provider = "Zerion"))]
+    async fn get_balance(
+        &self,
+        address: String,
+        params: BalanceQueryParams,
+        http_client: reqwest::Client,
+    ) -> RpcResult<BalanceResponseBody> {
+        let base = format!("https://api.zerion.io/v1/wallets/{}/positions/?", &address);
+        let mut url = Url::parse(&base).map_err(|_| RpcError::BalanceParseURLError)?;
+        url.query_pairs_mut()
+            .append_pair("currency", &params.currency.to_string());
+        url.query_pairs_mut()
+            .append_pair("filter[position_types]", "wallet");
+        if let Some(chain_id) = params.chain_id {
+            url.query_pairs_mut()
+                .append_pair("filter[chain_ids]", &chain_id);
+        }
+
+        let response = http_client
+            .get(url)
+            .header("Content-Type", "application/json")
+            .header("authorization", format!("Basic {}", self.api_key))
+            .send()
+            .await?;
+
+        if response.status() != reqwest::StatusCode::OK {
+            error!(
+                "Error on zerion balance response. Status is not OK: {:?}",
+                response.status(),
+            );
+            return Err(RpcError::BalanceProviderError);
+        }
+        let body = response
+            .json::<ZerionResponseBody<Vec<ZerionPosition>>>()
+            .await?;
+
+        let balances_vec = body
+            .data
+            .into_iter()
+            .map(|f| BalanceItem {
+                name: f.attributes.fungible_info.name,
+                symbol: f.attributes.fungible_info.symbol,
+                chain_id: crypto::string_chain_id_to_caip2_format(&f.relationships.chain.data.id)
+                    .tap_err(|_| {
+                        error!(
+                            "Error on parsing chain id to caip2 format: {:?}",
+                            f.relationships.chain.data.id
+                        )
+                    })
+                    .ok(),
+                value: f.attributes.value,
+                price: f.attributes.price,
+                quantity: BalanceQuantity {
+                    decimals: f.attributes.quantity.decimals.to_string(),
+                    numeric: f.attributes.quantity.numeric,
+                },
+                icon_url: f
+                    .attributes
+                    .fungible_info
+                    .icon
+                    .map(|f| f.url)
+                    .unwrap_or_default(),
+            })
+            .collect();
+
+        let response = BalanceResponseBody {
+            balances: balances_vec,
+        };
+
+        Ok(response)
     }
 }

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -1,6 +1,9 @@
 use {
     ethers::types::H160,
-    std::{collections::HashMap, str::FromStr},
+    std::str::FromStr,
+    strum::IntoEnumIterator,
+    strum_macros::{Display, EnumIter, EnumString},
+    tracing::warn,
 };
 
 /// Veryfy message signature signed by the keccak256
@@ -33,26 +36,82 @@ pub fn convert_coin_type_to_evm_chain_id(coin_type: u32) -> u32 {
     0x7FFFFFFF & coin_type
 }
 
-/// Convert from human readable chain id (e.g. polygon) to CAIP-2 format
-/// (e.g. eip155:137)
-pub fn string_chain_id_to_caip2_format(chain_id: &str) -> Result<String, anyhow::Error> {
-    // Aliases for string chain ids
-    let aliases: HashMap<String, Vec<String>> =
-        HashMap::from([("mainnet".into(), vec!["ethereum".into()])]);
+/// Human readable chain ids to CAIP-2 chain ids
+#[derive(Clone, Copy, Debug, EnumString, EnumIter, Display)]
+#[strum(serialize_all = "lowercase")]
+#[repr(u64)]
+pub enum ChainId {
+    Arbitrum = 42161,
+    Aurora = 1313161554,
+    Avalanche = 43114,
+    Base = 8453,
+    #[strum(
+        to_string = "binance-smart-chain",
+        serialize = "binance_smart_chain",
+        serialize = "bsc"
+    )]
+    BinanceSmartChain = 56,
+    Blast = 81032,
+    Celo = 42220,
+    #[strum(serialize = "ethereum", serialize = "mainnet")]
+    Ethereum = 1,
+    Fantom = 250,
+    Goerli = 5,
+    Linea = 59160,
+    Optimism = 10,
+    Polygon = 137,
+    Scroll = 8508132,
+    #[strum(
+        to_string = "xdai",
+        serialize = "gnosis",
+        serialize = "gnosis_chain",
+        serialize = "gnosis-chain",
+        serialize = "gnosischain"
+    )]
+    GnosisChain = 100,
+    #[strum(serialize = "zksync", serialize = "zksyncera")]
+    ZkSyncEra = 328,
+    Zora = 7854577,
+}
 
-    for (alias_name, aliases_vec) in aliases {
-        if aliases_vec.contains(&chain_id.to_lowercase()) {
-            return Ok(format!(
-                "eip155:{}",
-                ethers::types::Chain::from_str(&alias_name)? as u64
-            ));
+impl ChainId {
+    /// Convert from human readable chain name id (e.g. polygon) to CAIP-2
+    /// format chain id (e.g. `eip155:137`)
+    pub fn to_caip2(chain_name: &str) -> Option<String> {
+        match ChainId::from_str(chain_name) {
+            Ok(chain_id) => Some(format!("eip155:{}", chain_id as u64)),
+            Err(_) => {
+                warn!("CAIP-2 Convertion: Chain name is not found: {}", chain_name);
+                None
+            }
         }
     }
 
-    Ok(format!(
-        "eip155:{}",
-        ethers::types::Chain::from_str(chain_id)? as u64
-    ))
+    /// Convert from CAIP-2 format (e.g. `eip155:137`) to human readable chain
+    /// name id (e.g. polygon)
+    pub fn from_caip2(caip2_chain_id: &str) -> Option<String> {
+        let extracted_chain_id = caip2_chain_id
+            .split(':')
+            .collect::<Vec<&str>>()
+            .pop()
+            .unwrap_or_default()
+            .parse::<u64>()
+            .unwrap_or_default();
+
+        match ChainId::iter()
+            .find(|&x| x as u64 == extracted_chain_id)
+            .map(|x| x.to_string())
+        {
+            Some(chain_id) => Some(chain_id),
+            None => {
+                warn!(
+                    "CAIP-2 Convertion: Chain id is not found: {}",
+                    caip2_chain_id
+                );
+                None
+            }
+        }
+    }
 }
 
 /// Compare two values (either H160 or &str) in constant time to prevent timing
@@ -125,22 +184,40 @@ mod tests {
     }
 
     #[test]
-    fn test_string_chain_id_to_caip2_format() {
-        let mut chains: HashMap<&str, u64> = HashMap::new();
-        chains.insert("mainnet", 1);
-        // Test for an `ethereum` alias
-        chains.insert("ethereum", 1);
-        chains.insert("goerli", 5);
-        chains.insert("optimism", 10);
-        chains.insert("bsc", 56);
-        chains.insert("xdai", 100);
-        chains.insert("polygon", 137);
-        chains.insert("base", 8453);
+    fn test_human_format_to_caip2_format() {
+        let mut chains: HashMap<&str, &str> = HashMap::new();
+        chains.insert("ethereum", "eip155:1");
+        chains.insert("mainnet", "eip155:1");
+        chains.insert("goerli", "eip155:5");
+        chains.insert("optimism", "eip155:10");
+        chains.insert("bsc", "eip155:56");
+        chains.insert("gnosis", "eip155:100");
+        chains.insert("xdai", "eip155:100");
+        chains.insert("polygon", "eip155:137");
+        chains.insert("base", "eip155:8453");
 
-        for (chain_id, coin_type) in chains.iter() {
-            let result = string_chain_id_to_caip2_format(chain_id);
-            assert!(result.is_ok(), "chain_id is not found: {}", chain_id);
-            assert_eq!(result.unwrap(), format!("eip155:{}", coin_type));
+        for (chain_name, coin_type) in chains.iter() {
+            let result = ChainId::to_caip2(chain_name);
+            assert!(result.is_some(), "chain_name is not found: {}", chain_name);
+            assert_eq!(&result.unwrap(), coin_type);
+        }
+    }
+
+    #[test]
+    fn test_caip2_format_to_human_format() {
+        let mut chains: HashMap<&str, &str> = HashMap::new();
+        chains.insert("eip155:1", "ethereum");
+        chains.insert("eip155:5", "goerli");
+        chains.insert("eip155:10", "optimism");
+        chains.insert("eip155:56", "binance-smart-chain");
+        chains.insert("eip155:100", "xdai");
+        chains.insert("eip155:137", "polygon");
+        chains.insert("eip155:8453", "base");
+
+        for (chain_id, chain_name) in chains.iter() {
+            let result = ChainId::from_caip2(chain_id);
+            assert!(result.is_some(), "chain_id is not found: {}", chain_id);
+            assert_eq!(&result.unwrap(), chain_name);
         }
     }
 


### PR DESCRIPTION
# Description

This PR adds the new account balance endpoint `/v1/account/{address}/balance` according to the [specification](https://specs.walletconnect.com/2.0/specs/servers/blockchain/blockchain-server-api#balance).

The following changes were made:

* A new `balance` provider trait was added,
* Zerion was added as a first account balance provider,
* Handler for the endpoint was implemented https://github.com/WalletConnect/blockchain-api/pull/563/commits/1dcd06ef90d7667da0d94687c57e717d177f3d1e,
* Fixing CAIP-2 to human readable chain IDs converter by using own enum list instead of Ethers-rs to be compatible with the Zerions chain-ids and Coinbase provider formats that is used for the filtering https://github.com/WalletConnect/blockchain-api/pull/563/commits/750c95f140dd78a1e85235277f65fb6c63cbf6d2,
* Integration tests for the new endpoint were added. https://github.com/WalletConnect/blockchain-api/pull/563/commits/d4d6b6b3e6119de00e3d9af0e8f500b508acbd60.

## How Has This Been Tested?

[New integration tests](https://github.com/WalletConnect/blockchain-api/pull/563/commits/d4d6b6b3e6119de00e3d9af0e8f500b508acbd60) and [updated unit tests](https://github.com/WalletConnect/blockchain-api/pull/563/files#diff-43dc5270da6ae7bd3fbe8ee20c85643dcc3d3fb0feba36ad76570b327ef51667R187-R220) are included in this PR.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
