### PR TITLE
fix(zerion): allowing to pass HTTP 202 code

### DIFF
--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -224,7 +224,7 @@ impl HistoryProvider for ZerionProvider {
             .send()
             .await?;
 
-        if response.status() != reqwest::StatusCode::OK {
+        if !response.status().is_success() {
             error!(
                 "Error on zerion transactions response. Status is not OK: {:?}",
                 response.status(),
@@ -414,7 +414,7 @@ impl BalanceProvider for ZerionProvider {
             .send()
             .await?;
 
-        if response.status() != reqwest::StatusCode::OK {
+        if !response.status().is_success() {
             error!(
                 "Error on zerion balance response. Status is not OK: {:?}",
                 response.status(),


### PR DESCRIPTION
# Description

This PR making changes to the handling of the Zerion provider responses to allow pass HTTP 202 code.
Zerion API documentation suggests handling 202 so we should pass it and handle it with the proper message in the frontend:
```
If the address was not added before it is possible that this endpoint will return 202 status. It means that positions for the wallet are not prepared yet, but will be available soon.
```

## How Has This Been Tested?

Current integration tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
