### PR TITLE
fix: correct Solana chain ID

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -35,7 +35,7 @@ Chain name with associated `chainId` query param to use.
 | Aurora                         | eip155:1313161554    |
 | Aurora Testnet                 | eip155:1313161555    |
 | Near Mainnet                   | near:mainnet         |
-| Solana Mainnet                 | solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz |
+| Solana Mainnet                 | solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp |
 
 ## WebSocket RPC
 

--- a/src/env/omnia.rs
+++ b/src/env/omnia.rs
@@ -67,6 +67,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         ),
         // Solana Mainnet
         (
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".into(),
+            ("sol".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
+        (
+            // Incorrect (not CAIP-2), uses block explorer blockhash instead of getGenesisHash RPC
             "solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz".into(),
             ("sol".into(), Weight::new(Priority::Normal).unwrap()),
         ),

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -40,6 +40,14 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
     HashMap::from([
         // Solana Mainnet
         (
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".into(),
+            (
+                "solana-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
+        (
+            // Incorrect (not CAIP-2), uses block explorer blockhash instead of getGenesisHash RPC
             "solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz".into(),
             (
                 "solana-mainnet".into(),

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -52,13 +52,7 @@ async fn handler_internal(
         .validate_project_access_and_quota(&query_params.project_id)
         .await?;
 
-    // TODO: Remove the `solana-mainnet` chain_id alias for
-    // `solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz` when ready
-    let chain_id = if query_params.chain_id.to_lowercase() == "solana-mainnet" {
-        "solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz".to_string()
-    } else {
-        query_params.chain_id.to_lowercase()
-    };
+    let chain_id = query_params.chain_id.clone();
 
     // Exact provider proxy request for testing suite
     // This request is allowed only for the RPC_PROXY_TESTING_PROJECT_ID

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -188,7 +188,7 @@ async fn pokt_provider_solana_mainnet(ctx: &mut ServerContext) {
 #[test_context(ServerContext)]
 #[tokio::test]
 #[ignore]
-async fn pokt_provider_solana_mainnet_incorrect(ctx: &mut ServerContext) {
+async fn pokt_provider_solana_mainnet_non_standard(ctx: &mut ServerContext) {
     let addr = format!(
         "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -170,6 +170,41 @@ async fn pokt_provider_solana_mainnet(ctx: &mut ServerContext) {
     let (status, rpc_response) = send_jsonrpc_request(
         client,
         addr,
+        "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        request,
+    )
+    .await;
+
+    // Verify that HTTP communication was successful
+    assert_eq!(status, StatusCode::OK);
+
+    // Verify there was no error in rpc
+    assert!(rpc_response.error.is_none());
+
+    // Check chainId
+    assert_eq!(rpc_response.result::<String>().unwrap(), "ok")
+}
+
+#[test_context(ServerContext)]
+#[tokio::test]
+#[ignore]
+async fn pokt_provider_solana_mainnet_incorrect(ctx: &mut ServerContext) {
+    let addr = format!(
+        "{}/v1?projectId={}&chainId=",
+        ctx.server.public_addr, ctx.server.project_id
+    );
+
+    let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+    let request = jsonrpc::Request {
+        method: "getHealth",
+        params: &[],
+        id: serde_json::Value::Number(1.into()),
+        jsonrpc: JSONRPC_VERSION,
+    };
+
+    let (status, rpc_response) = send_jsonrpc_request(
+        client,
+        addr,
         "solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz",
         request,
     )


### PR DESCRIPTION
# Description

Updates the Solana chain ID to be correct. [Slack conversation](https://walletconnect.slack.com/archives/C04SYT4LU2W/p1709656775702379?thread_ts=1709319338.504139&cid=C04SYT4LU2W)

Also removes `solana-mainnet` alias as there is no indication of traffic using this chain ID for last 30 days.

Removes `to_lowercase()` on chain ID as [chain IDs are case-sensitive](https://chainagnostic.org/CAIPs/caip-2#syntax).

## How Has This Been Tested?

New test

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
