### PR TITLE
feat(conversion): available tokens list endpoint implementation

### DIFF
--- a/integration/convert.test.ts
+++ b/integration/convert.test.ts
@@ -1,0 +1,33 @@
+import { getTestSetup } from './init';
+
+describe('Token conversion', () => {
+  const { baseUrl, projectId, httpClient } = getTestSetup();
+
+  const namespace = 'eip155'
+  const chainId = '1';
+  const caip2_chain_id = `${namespace}:${chainId}`;
+
+  it('available tokens list', async () => {
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/convert/tokens?projectId=${projectId}&chainId=${caip2_chain_id}`
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.tokens).toBe('object')
+    expect(resp.data.tokens.length).toBeGreaterThan(1)
+
+    for (const token of resp.data.tokens) {
+      expect(typeof token.name).toBe('string')
+      expect(typeof token.symbol).toBe('string')
+      expect(token.address).toEqual(expect.stringMatching(new RegExp(`^${caip2_chain_id}:.+$`)))
+      expect(typeof token.decimals).toBe('number')
+      if (token.logoUri !== null) {
+        expect(token.logoUri).toEqual(expect.stringMatching(/^(https:\/\/|ipfs:\/\/).+$/));
+      } else {
+        expect(token.logoUri).toBeNull();
+      }
+      if (token.eip2612 !== null) {
+        expect(typeof token.eip2612).toBe('boolean');
+      }
+    }
+  })
+})

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -146,6 +146,7 @@ mod test {
             ),
             ("RPC_PROXY_PROVIDER_COINBASE_API_KEY", "COINBASE_API_KEY"),
             ("RPC_PROXY_PROVIDER_COINBASE_APP_ID", "COINBASE_APP_ID"),
+            ("RPC_PROXY_PROVIDER_ONE_INCH_API_KEY", "ONE_INCH_API_KEY"),
             (
                 "RPC_PROXY_PROVIDER_PROMETHEUS_QUERY_URL",
                 "PROMETHEUS_QUERY_URL",
@@ -215,6 +216,7 @@ mod test {
                 zerion_api_key: Some("ZERION_API_KEY".to_owned()),
                 coinbase_api_key: Some("COINBASE_API_KEY".to_owned()),
                 coinbase_app_id: Some("COINBASE_APP_ID".to_owned()),
+                one_inch_api_key: Some("ONE_INCH_API_KEY".to_owned()),
             },
         });
 

--- a/src/handlers/convert/mod.rs
+++ b/src/handlers/convert/mod.rs
@@ -1,0 +1,1 @@
+pub mod tokens;

--- a/src/handlers/convert/tokens.rs
+++ b/src/handlers/convert/tokens.rs
@@ -1,0 +1,68 @@
+use {
+    super::super::HANDLER_TASK_METRICS,
+    crate::{error::RpcError, state::AppState},
+    axum::{
+        extract::{Query, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    serde::{Deserialize, Serialize},
+    std::sync::Arc,
+    tap::TapFallible,
+    tracing::log::error,
+    wc::future::FutureExt,
+};
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TokensListQueryParams {
+    pub project_id: String,
+    pub chain_id: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TokensListResponseBody {
+    pub tokens: Vec<TokenItem>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenItem {
+    pub name: String,
+    pub symbol: String,
+    pub address: String,
+    pub decimals: u8,
+    pub logo_uri: Option<String>,
+    pub eip2612: Option<bool>,
+}
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    query: Query<TokensListQueryParams>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, query)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("tokens_list"))
+        .await
+}
+
+#[tracing::instrument(skip_all)]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    query: Query<TokensListQueryParams>,
+) -> Result<Response, RpcError> {
+    state
+        .validate_project_access_and_quota(&query.project_id)
+        .await?;
+
+    let response = state
+        .providers
+        .conversion_provider
+        .get_tokens_list(query.0)
+        .await
+        .tap_err(|e| {
+            error!("Failed to call get tokens list for conversion with {}", e);
+        })?;
+
+    Ok(Json(response).into_response())
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -4,6 +4,7 @@ use {
 };
 
 pub mod balance;
+pub mod convert;
 pub mod generators;
 pub mod health;
 pub mod history;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,11 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/onramp/buy/quotes",
             get(handlers::onramp::quotes::handler),
         )
+        // Conversion
+        .route(
+            "/v1/convert/tokens",
+            get(handlers::convert::tokens::handler),
+        )
         .route_layer(tracing_and_metrics_layer)
         .route("/health", get(handlers::health::handler))
         .layer(cors);

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -5,6 +5,7 @@ use {
         error::{RpcError, RpcResult},
         handlers::{
             balance::{self, BalanceQueryParams, BalanceResponseBody},
+            convert::tokens::{TokensListQueryParams, TokensListResponseBody},
             history::{HistoryQueryParams, HistoryResponseBody},
             onramp::{
                 options::{OnRampBuyOptionsParams, OnRampBuyOptionsResponse},
@@ -37,6 +38,7 @@ mod infura;
 mod mantle;
 mod near;
 mod omnia;
+mod one_inch;
 mod pokt;
 mod publicnode;
 mod quicknode;
@@ -53,6 +55,7 @@ pub use {
     mantle::MantleProvider,
     near::NearProvider,
     omnia::OmniatechProvider,
+    one_inch::OneInchProvider,
     pokt::PoktProvider,
     publicnode::PublicnodeProvider,
     quicknode::QuicknodeProvider,
@@ -93,6 +96,7 @@ pub struct ProviderRepository {
     pub coinbase_pay_provider: Arc<dyn HistoryProvider>,
     pub onramp_provider: Arc<dyn OnRampProvider>,
     pub balance_provider: Arc<dyn BalanceProvider>,
+    pub conversion_provider: Arc<dyn ConversionProvider>,
 }
 
 impl ProviderRepository {
@@ -138,6 +142,7 @@ impl ProviderRepository {
         let history_provider = zerion_provider.clone();
         let portfolio_provider = zerion_provider.clone();
         let balance_provider = zerion_provider;
+        let conversion_provider = Arc::new(OneInchProvider::new("test".into()));
 
         let coinbase_pay_provider = Arc::new(CoinbaseProvider::new(
             coinbase_api_key,
@@ -157,6 +162,7 @@ impl ProviderRepository {
             coinbase_pay_provider: coinbase_pay_provider.clone(),
             onramp_provider: coinbase_pay_provider,
             balance_provider,
+            conversion_provider,
         }
     }
 
@@ -533,4 +539,12 @@ pub trait BalanceProvider: Send + Sync + Debug {
         params: BalanceQueryParams,
         http_client: reqwest::Client,
     ) -> RpcResult<BalanceResponseBody>;
+}
+
+#[async_trait]
+pub trait ConversionProvider: Send + Sync + Debug {
+    async fn get_tokens_list(
+        &self,
+        params: TokensListQueryParams,
+    ) -> RpcResult<TokensListResponseBody>;
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -79,6 +79,7 @@ pub struct ProvidersConfig {
     pub zerion_api_key: Option<String>,
     pub coinbase_api_key: Option<String>,
     pub coinbase_app_id: Option<String>,
+    pub one_inch_api_key: Option<String>,
 }
 
 pub struct ProviderRepository {
@@ -138,11 +139,18 @@ impl ProviderRepository {
             .clone()
             .unwrap_or("COINBASE_APP_ID_UNDEFINED".into());
 
+        // Don't crash the application if the ONE_INCH_API_KEY is not set
+        // TODO: find a better way to handle this
+        let one_inch_api_key = config
+            .one_inch_api_key
+            .clone()
+            .unwrap_or("ONE_INCH_API_KEY".into());
+
         let zerion_provider = Arc::new(ZerionProvider::new(zerion_api_key));
         let history_provider = zerion_provider.clone();
         let portfolio_provider = zerion_provider.clone();
         let balance_provider = zerion_provider;
-        let conversion_provider = Arc::new(OneInchProvider::new("test".into()));
+        let conversion_provider = Arc::new(OneInchProvider::new(one_inch_api_key));
 
         let coinbase_pay_provider = Arc::new(CoinbaseProvider::new(
             coinbase_api_key,

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -1,0 +1,111 @@
+use {
+    crate::{
+        error::{RpcError, RpcResult},
+        handlers::convert::tokens::{TokenItem, TokensListQueryParams, TokensListResponseBody},
+        providers::ConversionProvider,
+        utils::crypto,
+    },
+    async_trait::async_trait,
+    serde::Deserialize,
+    std::collections::HashMap,
+    tracing::log::error,
+    url::Url,
+};
+
+#[derive(Debug)]
+pub struct OneInchProvider {
+    pub api_key: String,
+    pub base_api_url: String,
+    pub http_client: reqwest::Client,
+}
+
+impl OneInchProvider {
+    pub fn new(api_key: String) -> Self {
+        let base_api_url = "https://api.1inch.dev/swap/v6.0".to_string();
+        let http_client = reqwest::Client::new();
+        Self {
+            api_key,
+            base_api_url,
+            http_client,
+        }
+    }
+
+    async fn send_request(
+        &self,
+        url: Url,
+        http_client: &reqwest::Client,
+    ) -> Result<reqwest::Response, reqwest::Error> {
+        http_client
+            .get(url)
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .send()
+            .await
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OneInchTokensResponse {
+    tokens: HashMap<String, OneInchTokenItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OneInchTokenItem {
+    symbol: String,
+    name: String,
+    address: String,
+    decimals: u8,
+    #[serde(alias = "logoURI")]
+    logo_uri: Option<String>,
+    eip2612: Option<bool>,
+}
+
+#[async_trait]
+impl ConversionProvider for OneInchProvider {
+    #[tracing::instrument(skip(self, params), fields(provider = "1inch"))]
+    async fn get_tokens_list(
+        &self,
+        params: TokensListQueryParams,
+    ) -> RpcResult<TokensListResponseBody> {
+        let evm_chain_id = crypto::disassemble_caip2(&params.chain_id)?.1;
+        let base = format!("{}/{}/tokens", &self.base_api_url, evm_chain_id.clone());
+        let url = Url::parse(&base).map_err(|_| RpcError::ConversionParseURLError)?;
+
+        let response = self.send_request(url, &self.http_client.clone()).await?;
+
+        if !response.status().is_success() {
+            error!(
+                "Error on getting tokens list for conversion from 1inch provider. Status is not \
+                 OK: {:?}",
+                response.status(),
+            );
+            return Err(RpcError::ConversionProviderError);
+        }
+        let body = response.json::<OneInchTokensResponse>().await?;
+
+        let response: TokensListResponseBody = TokensListResponseBody {
+            tokens: body
+                .tokens
+                .into_values()
+                .map(|token| TokenItem {
+                    name: token.name,
+                    symbol: token.symbol,
+                    address: crypto::format_to_caip10(
+                        crypto::CaipNamespaces::Eip155,
+                        &evm_chain_id,
+                        &token.address,
+                    ),
+                    decimals: token.decimals,
+                    logo_uri: token.logo_uri,
+                    eip2612: if token.eip2612.is_some() {
+                        Some(token.eip2612.unwrap_or_default())
+                    } else {
+                        Some(false)
+                    },
+                })
+                .collect(),
+        };
+
+        Ok(response)
+    }
+}

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -98,7 +98,7 @@ impl ConversionProvider for OneInchProvider {
                     decimals: token.decimals,
                     logo_uri: token.logo_uri,
                     eip2612: if token.eip2612.is_some() {
-                        Some(token.eip2612.unwrap_or_default())
+                        token.eip2612
                     } else {
                         Some(false)
                     },

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -120,7 +120,7 @@ impl ChainId {
     }
 }
 
-#[derive(Clone, Copy, Debug, EnumString, EnumIter, Display)]
+#[derive(Clone, Copy, Debug, EnumString, EnumIter, Display, Eq, PartialEq)]
 #[strum(serialize_all = "lowercase")]
 pub enum CaipNamespaces {
     Eip155,
@@ -254,5 +254,21 @@ mod tests {
         let string_two = "some another string";
         assert!(!constant_time_eq(string_one, string_two));
         assert!(constant_time_eq(string_one, string_one));
+    }
+
+    #[test]
+    fn test_format_to_caip10() {
+        assert_eq!(
+            format_to_caip10(CaipNamespaces::Eip155, "1", "0xtest"),
+            "eip155:1:0xtest"
+        );
+    }
+
+    #[test]
+    fn test_disassemble_caip2() {
+        let caip2 = "eip155:1";
+        let result = disassemble_caip2(caip2).unwrap();
+        assert_eq!(result.0, CaipNamespaces::Eip155);
+        assert_eq!(result.1, "1".to_string());
     }
 }

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -85,6 +85,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_PROVIDER_ZERION_API_KEY", value = var.zerion_api_key },
         { name = "RPC_PROXY_PROVIDER_COINBASE_API_KEY", value = var.coinbase_api_key },
         { name = "RPC_PROXY_PROVIDER_COINBASE_APP_ID", value = var.coinbase_app_id },
+        { name = "RPC_PROXY_PROVIDER_ONE_INCH_API_KEY", value = var.one_inch_api_key },
         { name = "RPC_PROXY_PROVIDER_PROMETHEUS_QUERY_URL", value = "http://127.0.0.1:${local.prometheus_proxy_port}/workspaces/${var.prometheus_workspace_id}" },
         { name = "RPC_PROXY_PROVIDER_PROMETHEUS_WORKSPACE_HEADER", value = "aps-workspaces.${module.this.region}.amazonaws.com" },
 

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -185,6 +185,12 @@ variable "coinbase_app_id" {
   sensitive   = true
 }
 
+variable "one_inch_api_key" {
+  description = "The API key for 1inch"
+  type        = string
+  sensitive   = true
+}
+
 variable "testing_project_id" {
   description = "Project ID used in a testing suite"
   type        = string

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -66,6 +66,7 @@ module "ecs" {
   zerion_api_key      = var.zerion_api_key
   coinbase_api_key    = var.coinbase_api_key
   coinbase_app_id     = var.coinbase_app_id
+  one_inch_api_key    = var.one_inch_api_key
 
   # Project Registry
   registry_api_endpoint   = var.registry_api_endpoint

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -115,6 +115,12 @@ variable "coinbase_app_id" {
   sensitive   = true
 }
 
+variable "one_inch_api_key" {
+  description = "The API key for 1inch"
+  type        = string
+  sensitive   = true
+}
+
 variable "testing_project_id" {
   description = "Project ID used in a testing suite"
   type        = string


### PR DESCRIPTION
# Description

This PR implements `/v1/convert/tokens` endpoint for the list of available tokens for the swap according to the [SPEC](https://github.com/WalletConnect/walletconnect-specs/pull/207/files#diff-f64bf5c2b17c9c6d32ae9d85d9a1ce5a4aa07cb680c6f4085de94d3c4915b9d9R284-R306).

The following changes are made:

* A new `ConversionProvider` trait was added,
* 1inch provider implementation for the `ConversionProvider` trait,
* New endpoint handler implementation,
* `format_to_caip10` and `disassemble_caip2` utils were added.

*This is an Alpha release implementation to support only single-chain swaps*

## How Has This Been Tested?

* [New integration test](https://github.com/WalletConnect/blockchain-api/pull/567/commits/3be8a9b6f6b1e1b82e10fac12bf543f82f21dba3) for the endpoint and [unit tests](https://github.com/WalletConnect/blockchain-api/pull/567/commits/3be8a9b6f6b1e1b82e10fac12bf543f82f21dba3) for new utils.

### Merging policy 🚧

* [x] 1inch API key should be added to the TFC.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
