### PR TITLE
feat(conversion): conversion quotes endpoint implementation

### DIFF
--- a/integration/convert.test.ts
+++ b/integration/convert.test.ts
@@ -1,11 +1,15 @@
 import { getTestSetup } from './init';
 
-describe('Token conversion', () => {
+describe('Token conversion (single chain)', () => {
   const { baseUrl, projectId, httpClient } = getTestSetup();
 
   const namespace = 'eip155'
   const chainId = '1';
   const caip2_chain_id = `${namespace}:${chainId}`;
+
+  const srcAsset = `${namespace}:${chainId}:0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`;
+  const destAsset = `${namespace}:${chainId}:0x111111111117dc0aa78b770fa6a738034120c302`;
+  const amount = 10000000000000000;
 
   it('available tokens list', async () => {
     let resp: any = await httpClient.get(
@@ -28,6 +32,20 @@ describe('Token conversion', () => {
       if (token.eip2612 !== null) {
         expect(typeof token.eip2612).toBe('boolean');
       }
+    }
+  })
+
+  it('get conversion quote', async () => {
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/convert/quotes?projectId=${projectId}&amount=${amount}&from=${srcAsset}&to=${destAsset}`
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.quotes).toBe('object')
+    expect(resp.data.quotes.length).toBeGreaterThan(0)
+
+    for (const quote of resp.data.quotes) {
+      expect(quote.fromAmount).toEqual(`${amount}`);
+      expect(quote.toAmount).toEqual(expect.stringMatching(/[0-9].*/));
     }
   })
 })

--- a/src/handlers/convert/mod.rs
+++ b/src/handlers/convert/mod.rs
@@ -1,1 +1,2 @@
+pub mod quotes;
 pub mod tokens;

--- a/src/handlers/convert/quotes.rs
+++ b/src/handlers/convert/quotes.rs
@@ -1,0 +1,69 @@
+use {
+    super::super::HANDLER_TASK_METRICS,
+    crate::{error::RpcError, state::AppState},
+    axum::{
+        extract::{Query, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    serde::{Deserialize, Serialize},
+    std::sync::Arc,
+    tap::TapFallible,
+    tracing::log::error,
+    wc::future::FutureExt,
+};
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ConvertQuoteQueryParams {
+    pub project_id: String,
+    pub amount: usize,
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ConvertQuoteResponseBody {
+    pub quotes: Vec<QuoteItem>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct QuoteItem {
+    pub id: Option<String>,
+    pub from_amount: String,
+    pub from_account: String,
+    pub to_amount: String,
+    pub to_account: String,
+}
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    query: Query<ConvertQuoteQueryParams>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, query)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("tokens_list"))
+        .await
+}
+
+#[tracing::instrument(skip_all)]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    query: Query<ConvertQuoteQueryParams>,
+) -> Result<Response, RpcError> {
+    state
+        .validate_project_access_and_quota(&query.project_id)
+        .await?;
+
+    let response = state
+        .providers
+        .conversion_provider
+        .get_convert_quote(query.0)
+        .await
+        .tap_err(|e| {
+            error!("Failed to call get conversion quotes with {}", e);
+        })?;
+
+    Ok(Json(response).into_response())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,10 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/convert/tokens",
             get(handlers::convert::tokens::handler),
         )
+        .route(
+            "/v1/convert/quotes",
+            get(handlers::convert::quotes::handler),
+        )
         .route_layer(tracing_and_metrics_layer)
         .route("/health", get(handlers::health::handler))
         .layer(cors);

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -5,7 +5,10 @@ use {
         error::{RpcError, RpcResult},
         handlers::{
             balance::{self, BalanceQueryParams, BalanceResponseBody},
-            convert::tokens::{TokensListQueryParams, TokensListResponseBody},
+            convert::{
+                quotes::{ConvertQuoteQueryParams, ConvertQuoteResponseBody},
+                tokens::{TokensListQueryParams, TokensListResponseBody},
+            },
             history::{HistoryQueryParams, HistoryResponseBody},
             onramp::{
                 options::{OnRampBuyOptionsParams, OnRampBuyOptionsResponse},
@@ -555,4 +558,9 @@ pub trait ConversionProvider: Send + Sync + Debug {
         &self,
         params: TokensListQueryParams,
     ) -> RpcResult<TokensListResponseBody>;
+
+    async fn get_convert_quote(
+        &self,
+        params: ConvertQuoteQueryParams,
+    ) -> RpcResult<ConvertQuoteResponseBody>;
 }


### PR DESCRIPTION
# Description

This PR implements `/v1/convert/quotes` endpoint to get swap quotes between two assets (single chain) according to the [API SPEC](https://github.com/WalletConnect/walletconnect-specs/pull/207/files#diff-f64bf5c2b17c9c6d32ae9d85d9a1ce5a4aa07cb680c6f4085de94d3c4915b9d9R308-R332).

The following changes are made:

* `1inch` provider implementation updates for the quotes provider agnostic trait,
* New endpoint handler implementation,
* `disassemble_caip10` utility was added.

*This is an Alpha release implementation to support only single-chain swaps*

## How Has This Been Tested?

* [New integration test](https://github.com/WalletConnect/blockchain-api/pull/568/files#diff-d2a40c4ae4e4965cd2ea19db3965e98a04e70177954587a2a3edecfcf1263ce0) for the endpoint and [unit tests](https://github.com/WalletConnect/blockchain-api/pull/568/files#diff-43dc5270da6ae7bd3fbe8ee20c85643dcc3d3fb0feba36ad76570b327ef51667R290) for new utils.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
