### PR TITLE
feat(conversion): approve transaction endpoint implementation

### DIFF
--- a/integration/convert.test.ts
+++ b/integration/convert.test.ts
@@ -48,4 +48,18 @@ describe('Token conversion (single chain)', () => {
       expect(quote.toAmount).toEqual(expect.stringMatching(/[0-9].*/));
     }
   })
+
+  it('build approve tx', async () => {
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/convert/build-approve?projectId=${projectId}&amount=${amount}&from=${srcAsset}&to=${destAsset}`
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.tx).toBe('object')
+
+    const tx = resp.data.tx;
+    expect(tx.from).toEqual(srcAsset);
+    expect(tx.to).toEqual(destAsset);
+    expect(tx.data).toEqual(expect.stringMatching(/^0x.*/));
+    expect(tx.eip155.gasPrice).toEqual(expect.stringMatching(/[0-9].*/));
+  })
 })

--- a/src/handlers/convert/approve.rs
+++ b/src/handlers/convert/approve.rs
@@ -47,7 +47,7 @@ pub async fn handler(
     query: Query<ConvertApproveQueryParams>,
 ) -> Result<Response, RpcError> {
     handler_internal(state, query)
-        .with_metrics(HANDLER_TASK_METRICS.with_name("tokens_list"))
+        .with_metrics(HANDLER_TASK_METRICS.with_name("convert_approve_tx"))
         .await
 }
 

--- a/src/handlers/convert/approve.rs
+++ b/src/handlers/convert/approve.rs
@@ -1,0 +1,73 @@
+use {
+    super::super::HANDLER_TASK_METRICS,
+    crate::{error::RpcError, state::AppState},
+    axum::{
+        extract::{Query, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    serde::{Deserialize, Serialize},
+    std::sync::Arc,
+    tap::TapFallible,
+    tracing::log::error,
+    wc::future::FutureExt,
+};
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ConvertApproveQueryParams {
+    pub project_id: String,
+    pub amount: usize,
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ConvertApproveResponseBody {
+    pub tx: ConvertApproveTx,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ConvertApproveTx {
+    pub from: String,
+    pub to: String,
+    pub data: String,
+    pub value: String,
+    pub eip155: Option<ConvertApproveTxEip155>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ConvertApproveTxEip155 {
+    pub gas_price: String,
+}
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    query: Query<ConvertApproveQueryParams>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, query)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("tokens_list"))
+        .await
+}
+
+#[tracing::instrument(skip_all)]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    query: Query<ConvertApproveQueryParams>,
+) -> Result<Response, RpcError> {
+    state
+        .validate_project_access_and_quota(&query.project_id)
+        .await?;
+
+    let response = state
+        .providers
+        .conversion_provider
+        .build_approve_tx(query.0)
+        .await
+        .tap_err(|e| {
+            error!("Failed to call build approve tx for conversion with {}", e);
+        })?;
+
+    Ok(Json(response).into_response())
+}

--- a/src/handlers/convert/mod.rs
+++ b/src/handlers/convert/mod.rs
@@ -1,2 +1,3 @@
+pub mod approve;
 pub mod quotes;
 pub mod tokens;

--- a/src/handlers/convert/quotes.rs
+++ b/src/handlers/convert/quotes.rs
@@ -43,7 +43,7 @@ pub async fn handler(
     query: Query<ConvertQuoteQueryParams>,
 ) -> Result<Response, RpcError> {
     handler_internal(state, query)
-        .with_metrics(HANDLER_TASK_METRICS.with_name("tokens_list"))
+        .with_metrics(HANDLER_TASK_METRICS.with_name("convert_quote"))
         .await
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,10 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/convert/quotes",
             get(handlers::convert::quotes::handler),
         )
+        .route(
+            "/v1/convert/build-approve",
+            get(handlers::convert::approve::handler),
+        )
         .route_layer(tracing_and_metrics_layer)
         .route("/health", get(handlers::health::handler))
         .layer(cors);

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -6,6 +6,7 @@ use {
         handlers::{
             balance::{self, BalanceQueryParams, BalanceResponseBody},
             convert::{
+                approve::{ConvertApproveQueryParams, ConvertApproveResponseBody},
                 quotes::{ConvertQuoteQueryParams, ConvertQuoteResponseBody},
                 tokens::{TokensListQueryParams, TokensListResponseBody},
             },
@@ -563,4 +564,9 @@ pub trait ConversionProvider: Send + Sync + Debug {
         &self,
         params: ConvertQuoteQueryParams,
     ) -> RpcResult<ConvertQuoteResponseBody>;
+
+    async fn build_approve_tx(
+        &self,
+        params: ConvertApproveQueryParams,
+    ) -> RpcResult<ConvertApproveResponseBody>;
 }

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -196,11 +196,7 @@ impl ConversionProvider for OneInchProvider {
             ));
         }
 
-        let base = format!(
-            "{}/{}/approve/transaction",
-            &self.base_api_url,
-            chain_id.clone()
-        );
+        let base = format!("{}/{}/approve/transaction", &self.base_api_url, chain_id);
         let mut url = Url::parse(&base).map_err(|_| RpcError::ConversionParseURLError)?;
 
         url.query_pairs_mut()


### PR DESCRIPTION
# Description

This PR implements `/v1/convert/build-approve` endpoint to build the approval transaction for eip2612 incompatible tokens swap (single chain) according to the [API SPEC](https://github.com/WalletConnect/walletconnect-specs/pull/207/files#diff-f64bf5c2b17c9c6d32ae9d85d9a1ce5a4aa07cb680c6f4085de94d3c4915b9d9R334-R364).

The following changes are made:

* `1inch` provider implementation updates for the approval transaction agnostic trait,
* New endpoint handler implementation.

*This is an Alpha release implementation to support only single-chain swaps*

## How Has This Been Tested?

* [New integration test](https://github.com/WalletConnect/blockchain-api/pull/570/files#diff-d2a40c4ae4e4965cd2ea19db3965e98a04e70177954587a2a3edecfcf1263ce0) for the endpoint.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
