### PR TITLE
fix: supported chains endpoint

### DIFF
--- a/integration/supported-chains.test.ts
+++ b/integration/supported-chains.test.ts
@@ -1,0 +1,11 @@
+import { getTestSetup } from './init';
+
+describe('Supported chains', () => {
+  const { baseUrl, httpClient } = getTestSetup();
+
+  it('Returns Ethereum Mainnet', async () => {
+    const resp = await httpClient.get(`${baseUrl}/v1/supported-chains`)
+    expect(resp.status).toBe(200)
+    expect(resp.data).toContain('eip155:1')
+  })
+})

--- a/integration/supported-chains.test.ts
+++ b/integration/supported-chains.test.ts
@@ -6,6 +6,9 @@ describe('Supported chains', () => {
   it('Returns Ethereum Mainnet', async () => {
     const resp = await httpClient.get(`${baseUrl}/v1/supported-chains`)
     expect(resp.status).toBe(200)
-    expect(resp.data).toContain('eip155:1')
+    expect(resp.data.http).toContain('eip155:1')
+    expect(resp.data.http).toContain('eip155:8453')
+    expect(resp.data.ws).toContain('eip155:1')
+    expect(resp.data.ws).not.toContain('eip155:8453')
   })
 })

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -14,8 +14,8 @@ pub mod onramp;
 pub mod portfolio;
 pub mod profile;
 pub mod proxy;
-pub mod ws_proxy;
 pub mod supported_chains;
+pub mod ws_proxy;
 
 static HANDLER_TASK_METRICS: TaskMetrics = TaskMetrics::new("handler_task");
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -15,6 +15,7 @@ pub mod portfolio;
 pub mod profile;
 pub mod proxy;
 pub mod ws_proxy;
+pub mod supported_chains;
 
 static HANDLER_TASK_METRICS: TaskMetrics = TaskMetrics::new("handler_task");
 

--- a/src/handlers/supported_chains.rs
+++ b/src/handlers/supported_chains.rs
@@ -1,12 +1,12 @@
 use {
     super::HANDLER_TASK_METRICS,
-    crate::{error::RpcError, state::AppState},
+    crate::{error::RpcError, providers::SupportedChains, state::AppState},
     axum::{extract::State, Json},
-    std::{collections::HashSet, sync::Arc},
+    std::sync::Arc,
     wc::future::FutureExt,
 };
 
-pub async fn handler(state: State<Arc<AppState>>) -> Result<Json<HashSet<String>>, RpcError> {
+pub async fn handler(state: State<Arc<AppState>>) -> Result<Json<SupportedChains>, RpcError> {
     handler_internal(state)
         .with_metrics(HANDLER_TASK_METRICS.with_name("supported_chains"))
         .await
@@ -15,6 +15,6 @@ pub async fn handler(state: State<Arc<AppState>>) -> Result<Json<HashSet<String>
 #[tracing::instrument(skip_all, level = "debug")]
 async fn handler_internal(
     State(state): State<Arc<AppState>>,
-) -> Result<Json<HashSet<String>>, RpcError> {
+) -> Result<Json<SupportedChains>, RpcError> {
     Ok(Json(state.providers.supported_chains.clone()))
 }

--- a/src/handlers/supported_chains.rs
+++ b/src/handlers/supported_chains.rs
@@ -1,0 +1,20 @@
+use {
+    super::HANDLER_TASK_METRICS,
+    crate::{error::RpcError, state::AppState},
+    axum::{extract::State, Json},
+    std::{collections::HashSet, sync::Arc},
+    wc::future::FutureExt,
+};
+
+pub async fn handler(state: State<Arc<AppState>>) -> Result<Json<HashSet<String>>, RpcError> {
+    handler_internal(state)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("supported_chains"))
+        .await
+}
+
+#[tracing::instrument(skip_all, level = "debug")]
+async fn handler_internal(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<HashSet<String>>, RpcError> {
+    Ok(Json(state.providers.supported_chains.clone()))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
     let app = Router::new()
         .route("/v1", post(handlers::proxy::handler))
         .route("/v1/", post(handlers::proxy::handler))
+        .route("/v1/supported-chains", get(handlers::supported_chains::handler))
         .route("/ws", get(handlers::ws_proxy::handler))
         .route("/v1/identity/:address", get(handlers::identity::handler))
         .route(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -21,7 +21,7 @@ use {
     hyper::http::HeaderValue,
     rand::{distributions::WeightedIndex, prelude::Distribution, rngs::OsRng},
     std::{
-        collections::HashMap,
+        collections::{HashMap, HashSet},
         fmt::{Debug, Display},
         hash::Hash,
         sync::Arc,
@@ -83,6 +83,8 @@ pub struct ProvidersConfig {
 }
 
 pub struct ProviderRepository {
+    pub supported_chains: HashSet<String>,
+
     providers: HashMap<ProviderKind, Arc<dyn RpcProvider>>,
     ws_providers: HashMap<ProviderKind, Arc<dyn RpcWsProvider>>,
 
@@ -159,6 +161,7 @@ impl ProviderRepository {
         ));
 
         Self {
+            supported_chains: HashSet::new(),
             providers: HashMap::new(),
             ws_providers: HashMap::new(),
             weight_resolver: HashMap::new(),
@@ -259,6 +262,7 @@ impl ProviderRepository {
         supported_ws_chains
             .into_iter()
             .for_each(|(chain_id, (_, weight))| {
+                self.supported_chains.insert(chain_id.clone());
                 self.ws_weight_resolver
                     .entry(chain_id)
                     .or_default()


### PR DESCRIPTION
# Description

Adds a basic endpoint to return a list of supported CAIP-2 chain IDs.

Resolves #566 

## How Has This Been Tested?

New integration test

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
