### PR TITLE
feat(conversion): convert transaction builder endpoint implementation

### DIFF
--- a/src/handlers/convert/mod.rs
+++ b/src/handlers/convert/mod.rs
@@ -1,3 +1,4 @@
 pub mod approve;
 pub mod quotes;
 pub mod tokens;
+pub mod transaction;

--- a/src/handlers/convert/transaction.rs
+++ b/src/handlers/convert/transaction.rs
@@ -1,0 +1,85 @@
+use {
+    super::super::HANDLER_TASK_METRICS,
+    crate::{error::RpcError, state::AppState},
+    axum::{
+        extract::State,
+        response::{IntoResponse, Response},
+        Json,
+    },
+    serde::{Deserialize, Serialize},
+    std::sync::Arc,
+    tap::TapFallible,
+    tracing::log::error,
+    wc::future::FutureExt,
+};
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ConvertTransactionQueryParams {
+    pub project_id: String,
+    pub amount: usize,
+    pub from: String,
+    pub to: String,
+    pub user_address: String,
+    pub eip155: Option<ConvertTransactionQueryEip155>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ConvertTransactionQueryEip155 {
+    pub slippage: usize,
+    pub permit: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ConvertTransactionResponseBody {
+    pub tx: ConvertTx,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ConvertTx {
+    pub from: String,
+    pub to: String,
+    pub data: String,
+    pub amount: String,
+    pub eip155: Option<ConvertTxEip155>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ConvertTxEip155 {
+    pub gas: String,
+    pub gas_price: String,
+}
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    Json(request_payload): Json<ConvertTransactionQueryParams>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, request_payload)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("convert_build_transaction"))
+        .await
+}
+
+#[tracing::instrument(skip_all)]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    request_payload: ConvertTransactionQueryParams,
+) -> Result<Response, RpcError> {
+    state
+        .validate_project_access_and_quota(&request_payload.project_id)
+        .await?;
+
+    let response = state
+        .providers
+        .conversion_provider
+        .build_convert_tx(request_payload)
+        .await
+        .tap_err(|e| {
+            error!("Failed to call build conversion transaction with {}", e);
+        })?;
+
+    Ok(Json(response).into_response())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,6 +278,10 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/convert/build-approve",
             get(handlers::convert::approve::handler),
         )
+        .route(
+            "/v1/convert/build-transaction",
+            post(handlers::convert::transaction::handler),
+        )
         .route_layer(tracing_and_metrics_layer)
         .route("/health", get(handlers::health::handler))
         .layer(cors);

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -9,6 +9,7 @@ use {
                 approve::{ConvertApproveQueryParams, ConvertApproveResponseBody},
                 quotes::{ConvertQuoteQueryParams, ConvertQuoteResponseBody},
                 tokens::{TokensListQueryParams, TokensListResponseBody},
+                transaction::{ConvertTransactionQueryParams, ConvertTransactionResponseBody},
             },
             history::{HistoryQueryParams, HistoryResponseBody},
             onramp::{
@@ -569,4 +570,9 @@ pub trait ConversionProvider: Send + Sync + Debug {
         &self,
         params: ConvertApproveQueryParams,
     ) -> RpcResult<ConvertApproveResponseBody>;
+
+    async fn build_convert_tx(
+        &self,
+        params: ConvertTransactionQueryParams,
+    ) -> RpcResult<ConvertTransactionResponseBody>;
 }

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -167,7 +167,7 @@ impl ConversionProvider for OneInchProvider {
         // 1inch provider does not support cross-chain swaps
         if dst_chain_id != chain_id {
             return Err(RpcError::InvalidParameter(
-                "from and to chain ids are different in a single chain swap".into(),
+                "`from` and `to` chain IDs must have the same value".into(),
             ));
         }
 
@@ -215,7 +215,7 @@ impl ConversionProvider for OneInchProvider {
         // 1inch provider does not support cross-chain swaps
         if dst_chain_id != chain_id {
             return Err(RpcError::InvalidParameter(
-                "from and to chain ids are different in a single chain swap".into(),
+                "`from` and `to` chain IDs must have the same value".into(),
             ));
         }
 
@@ -262,12 +262,11 @@ impl ConversionProvider for OneInchProvider {
         let (_, dst_chain_id, dst_address) = crypto::disassemble_caip10(&params.to)?;
         let (_, user_chain_id, user_address) = crypto::disassemble_caip10(&params.user_address)?;
 
-        // Check if from and to chain ids are different
+        // Check if from, to and user chain ids are different
         // 1inch provider does not support cross-chain swaps
         if (dst_chain_id != chain_id) || (user_chain_id != chain_id) {
             return Err(RpcError::InvalidParameter(
-                "`from`, `to` and `userAddress` chain ids are different in a single chain swap"
-                    .into(),
+                "`from`, `to` and `userAddress` chain IDs must have the same value".into(),
             ));
         }
 


### PR DESCRIPTION
# Description

This PR implements `/v1/convert/build-transaction` endpoint to build the conversion transaction for tokens swap (single chain) according to the [API SPEC](https://github.com/WalletConnect/walletconnect-specs/pull/207/files#diff-f64bf5c2b17c9c6d32ae9d85d9a1ce5a4aa07cb680c6f4085de94d3c4915b9d9R366-R399).

The following changes are made:

* `1inch` provider implementation updates for the transaction builder,
* New endpoint handler implementation,
* Integration test was implemented for the new endpoint.

*This is an Alpha release implementation to support only single-chain swaps*

## How Has This Been Tested?

* [New integration test](https://github.com/WalletConnect/blockchain-api/pull/572/files#diff-d2a40c4ae4e4965cd2ea19db3965e98a04e70177954587a2a3edecfcf1263ce0R67-R96) for the endpoint.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
