### PR TITLE
feat(docs): adding a footnote for not guaranteed (availability) RPC chains

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -4,38 +4,40 @@ Chain name with associated `chainId` query param to use.
 
 ## HTTP RPC
 
-| Network                        | Chain ID             |
-|--------------------------------|----------------------|
-| Ethereum                       | eip155:1             |
-| Ethereum Goerli                | eip155:5             |
-| Optimism                       | eip155:10            |
-| Binance Smart Chain            | eip155:56            |
-| Binance Smart Chain Testnet    | eip155:56            |
-| Gnosis Chain                   | eip155:100           |
-| Polygon                        | eip155:137           |
-| zkSync Era Testnet             | eip155:280           |
-| zkSync Era                     | eip155:324           |
-| Optimism Goerli                | eip155:420           |
-| Zora Goerli                    | eip155:999           |
-| Polygon Zkevm                  | eip155:1101          |
-| Mantle                         | eip155:5000          |
-| Mantle Testnet                 | eip155:5001          |
-| Klaytn Mainnet                 | eip155:8217          |
-| Base                           | eip155:8453          |
-| Ethereum Holesky               | eip155:17000         |
-| Arbitrum                       | eip155:42161         |
-| Celo                           | eip155:42220         |
-| Avalanche Fuji Testnet         | eip155:43113         |
-| Avalanche C-Chain              | eip155:43114         |
-| Polygon Mumbai                 | eip155:80001         |
-| Base Goerli                    | eip155:84531         |
-| Arbitrum Goerli                | eip155:421613        |
-| Zora                           | eip155:7777777       |
-| Ethereum Sepolia               | eip155:11155111      |
-| Aurora                         | eip155:1313161554    |
-| Aurora Testnet                 | eip155:1313161555    |
-| Near Mainnet                   | near:mainnet         |
-| Solana Mainnet                 | solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp |
+| Network                                                  | Chain ID             |
+|----------------------------------------------------------|----------------------|
+| Ethereum                                                 | eip155:1             |
+| Ethereum Goerli                                          | eip155:5             |
+| Optimism                                                 | eip155:10            |
+| Binance Smart Chain                                      | eip155:56            |
+| Binance Smart Chain Testnet <sup>[1](#footnote1)</sup>   | eip155:97            |
+| Gnosis Chain                                             | eip155:100           |
+| Polygon                                                  | eip155:137           |
+| zkSync Era Testnet <sup>[1](#footnote1)</sup>            | eip155:280           |
+| zkSync Era                                               | eip155:324           |
+| Optimism Goerli                                          | eip155:420           |
+| Zora Goerli <sup>[1](#footnote1)</sup>                   | eip155:999           |
+| Polygon Zkevm                                            | eip155:1101          |
+| Mantle <sup>[1](#footnote1)</sup>                        | eip155:5000          |
+| Mantle Testnet <sup>[1](#footnote1)</sup>                | eip155:5001          |
+| Klaytn Mainnet                                           | eip155:8217          |
+| Base                                                     | eip155:8453          |
+| Ethereum Holesky                                         | eip155:17000         |
+| Arbitrum                                                 | eip155:42161         |
+| Celo                                                     | eip155:42220         |
+| Avalanche Fuji Testnet <sup>[1](#footnote1)</sup>        | eip155:43113         |
+| Avalanche C-Chain                                        | eip155:43114         |
+| Polygon Mumbai                                           | eip155:80001         |
+| Base Goerli                                              | eip155:84531         |
+| Arbitrum Goerli                                          | eip155:421613        |
+| Zora <sup>[1](#footnote1)</sup>                          | eip155:7777777       |
+| Ethereum Sepolia                                         | eip155:11155111      |
+| Aurora <sup>[1](#footnote1)</sup>                        | eip155:1313161554    |
+| Aurora Testnet <sup>[1](#footnote1)</sup>                | eip155:1313161555    |
+| Near Mainnet                                             | near:mainnet         |
+| Solana Mainnet                                           | solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp |
+
+<a id="footnote1"><sup>1</sup></a> The availability of this chain in our RPC is not guaranteed.
 
 ## WebSocket RPC
 


### PR DESCRIPTION
# Description

This PR adds a footnote to RPC chains where we use only public providers and can't guarantee any SLA (availability).

We should link to this list in our SLA to exclude out-of-SLA chains.

## How Has This Been Tested?

It doesn't need a test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
