### PR TITLE
fix(providers): changing the Base testnet to Sepolia

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -28,7 +28,7 @@ Chain name with associated `chainId` query param to use.
 | Avalanche Fuji Testnet <sup>[1](#footnote1)</sup>        | eip155:43113         |
 | Avalanche C-Chain                                        | eip155:43114         |
 | Polygon Mumbai                                           | eip155:80001         |
-| Base Goerli                                              | eip155:84531         |
+| Base Sepolia                                             | eip155:84532         |
 | Arbitrum Goerli                                          | eip155:421613        |
 | Zora <sup>[1](#footnote1)</sup>                          | eip155:7777777       |
 | Ethereum Sepolia                                         | eip155:11155111      |

--- a/src/env/base.rs
+++ b/src/env/base.rs
@@ -43,11 +43,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
-        // Base Goerli
+        // Base Sepolia
         (
-            "eip155:84531".into(),
+            "eip155:84532".into(),
             (
-                "https://goerli.base.org".into(),
+                "https://sepolia.base.org".into(),
                 Weight::new(Priority::Low).unwrap(),
             ),
         ),

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -107,10 +107,13 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
-        // Base Goerli
+        // Base Sepolia
         (
-            "eip155:84531".into(),
-            ("base-goerli".into(), Weight::new(Priority::Normal).unwrap()),
+            "eip155:84532".into(),
+            (
+                "base-sepolia".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
     ])
 }

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -78,9 +78,9 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
-        // Base testnet
+        // Base Sepolia
         (
-            "eip155:84531".into(),
+            "eip155:84532".into(),
             (
                 "base-testnet".into(),
                 Weight::new(Priority::Normal).unwrap(),

--- a/tests/functional/http/base.rs
+++ b/tests/functional/http/base.rs
@@ -18,12 +18,12 @@ async fn base_provider_eip155_8453_and_84531(ctx: &mut ServerContext) {
     )
     .await;
 
-    // Base Goerli
+    // Base Sepolia
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
         &ProviderKind::Base,
-        "eip155:84531",
-        "0x14a33",
+        "eip155:84532",
+        "0x14a34",
     )
     .await
 }

--- a/tests/functional/http/infura.rs
+++ b/tests/functional/http/infura.rs
@@ -99,12 +99,12 @@ async fn infura_provider(ctx: &mut ServerContext) {
     )
     .await;
 
-    // Base Goerli
+    // Base Sepolia
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
         &ProviderKind::Infura,
-        "eip155:84531",
-        "0x14a33",
+        "eip155:84532",
+        "0x14a34",
     )
     .await
 }

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -41,12 +41,12 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     )
     .await;
 
-    // Base testnet
+    // Base Sepolia
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
         &ProviderKind::Pokt,
-        "eip155:84531",
-        "0x14a33",
+        "eip155:84532",
+        "0x14a34",
     )
     .await;
 


### PR DESCRIPTION
# Description

[The Base moved the test network from Goerli to Sepolia](https://base.mirror.xyz/kkz1-KFdUwl0n23PdyBRtnFewvO48_m-fZNzPMJehM4). Since the end of January 2024, Goerli shouldn't be used as a test network for the Base.
This PR fixing to use the Sepolia `eip155:84532` as the testnet for Base.

## How Has This Been Tested?

Tested by the updated providers test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
