### PR TITLE
fix(providers): updating providers supported chains (removing Goerli)

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -15,8 +15,6 @@ Chain name with associated `chainId` query param to use.
 | Polygon                                                  | eip155:137           |
 | zkSync Era Testnet <sup>[1](#footnote1)</sup>            | eip155:280           |
 | zkSync Era                                               | eip155:324           |
-| Optimism Goerli                                          | eip155:420           |
-| Zora Goerli <sup>[1](#footnote1)</sup>                   | eip155:999           |
 | Polygon Zkevm                                            | eip155:1101          |
 | Mantle <sup>[1](#footnote1)</sup>                        | eip155:5000          |
 | Mantle Testnet <sup>[1](#footnote1)</sup>                | eip155:5001          |
@@ -29,9 +27,11 @@ Chain name with associated `chainId` query param to use.
 | Avalanche C-Chain                                        | eip155:43114         |
 | Polygon Mumbai                                           | eip155:80001         |
 | Base Sepolia                                             | eip155:84532         |
-| Arbitrum Goerli                                          | eip155:421613        |
+| Arbitrum Sepolia                                         | eip155:421614        |
 | Zora <sup>[1](#footnote1)</sup>                          | eip155:7777777       |
 | Ethereum Sepolia                                         | eip155:11155111      |
+| Optimism Sepolia                                         | eip155:11155420      |
+| Zora Sepolia <sup>[1](#footnote1)</sup>                  | eip155:999999999     |
 | Aurora <sup>[1](#footnote1)</sup>                        | eip155:1313161554    |
 | Aurora Testnet <sup>[1](#footnote1)</sup>                | eip155:1313161555    |
 | Near Mainnet                                             | near:mainnet         |
@@ -48,8 +48,8 @@ WebSocket RPC **is not recommended for production use**, and may be removed in t
 | Ethereum           | eip155:1        |
 | Ethereum Goerli    | eip155:5        |
 | Optimism           | eip155:10       |
-| Optimism Goerli    | eip155:420      |
 | Arbitrum           | eip155:42161    |
-| Arbitrum Goerli    | eip155:421613   |
+| Arbitrum Sepolia   | eip155:421614   |
 | Zora               | eip155:7777777  |
 | Ethereum Sepolia   | eip155:11155111 |
+| Optimism Sepolia   | eip155:11155420 |

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -63,9 +63,9 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             ),
         ),
         (
-            "eip155:420".into(),
+            "eip155:11155420".into(),
             (
-                "optimism-goerli".into(),
+                "optimism-sepolia".into(),
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
@@ -78,9 +78,9 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             ),
         ),
         (
-            "eip155:421613".into(),
+            "eip155:421614".into(),
             (
-                "arbitrum-goerli".into(),
+                "arbitrum-sepolia".into(),
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
@@ -104,14 +104,6 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:42220".into(),
             (
                 "celo-mainnet".into(),
-                Weight::new(Priority::Normal).unwrap(),
-            ),
-        ),
-        // Base Sepolia
-        (
-            "eip155:84532".into(),
-            (
-                "base-sepolia".into(),
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
@@ -144,9 +136,9 @@ fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
             ),
         ),
         (
-            "eip155:420".into(),
+            "eip155:11155420".into(),
             (
-                "optimism-goerli".into(),
+                "optimism-sepolia".into(),
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
@@ -159,9 +151,9 @@ fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
             ),
         ),
         (
-            "eip155:421613".into(),
+            "eip155:421614".into(),
             (
-                "arbitrum-goerli".into(),
+                "arbitrum-sepolia".into(),
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -40,14 +40,6 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:1".into(),
             ("ethereum".into(), Weight::new(Priority::High).unwrap()),
         ),
-        // Ethereum goerli
-        (
-            "eip155:5".into(),
-            (
-                "ethereum-goerli".into(),
-                Weight::new(Priority::High).unwrap(),
-            ),
-        ),
         // Ethereum Holesky
         (
             "eip155:17000".into(),

--- a/src/env/zora.rs
+++ b/src/env/zora.rs
@@ -45,11 +45,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
-        // Zora Goerli
+        // Zora Sepolia
         (
-            "eip155:999".into(),
+            "eip155:999999999".into(),
             (
-                "https://testnet.rpc.zora.energy".into(),
+                "https://sepolia.rpc.zora.energy".into(),
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),

--- a/tests/functional/http/infura.rs
+++ b/tests/functional/http/infura.rs
@@ -63,12 +63,12 @@ async fn infura_provider(ctx: &mut ServerContext) {
     )
     .await;
 
-    // Optimism goerli
+    // Optimism Sepolia
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
         &ProviderKind::Infura,
-        "eip155:420",
-        "0x1A4",
+        "eip155:11155420",
+        "0xaa37dc",
     )
     .await;
 
@@ -85,8 +85,8 @@ async fn infura_provider(ctx: &mut ServerContext) {
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
         &ProviderKind::Infura,
-        "eip155:421613",
-        "0x66eed",
+        "eip155:421614",
+        "0x66eee",
     )
     .await;
 
@@ -98,13 +98,4 @@ async fn infura_provider(ctx: &mut ServerContext) {
         "0xa4ec",
     )
     .await;
-
-    // Base Sepolia
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &ProviderKind::Infura,
-        "eip155:84532",
-        "0x14a34",
-    )
-    .await
 }

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -18,15 +18,6 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
     )
     .await;
 
-    // Ethereum goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &ProviderKind::Publicnode,
-        "eip155:5",
-        "0x5",
-    )
-    .await;
-
     // Ethereum holesky
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,

--- a/tests/functional/http/zora.rs
+++ b/tests/functional/http/zora.rs
@@ -18,12 +18,12 @@ async fn zora_provider_eip155_7777777_and_999(ctx: &mut ServerContext) {
     )
     .await;
 
-    // Zora Goerli
+    // Zora Sepolia
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
         &ProviderKind::Zora,
-        "eip155:999",
-        "0x3e7",
+        "eip155:999999999",
+        "0x3b9ac9ff",
     )
     .await
 }

--- a/tests/functional/websocket/infura.rs
+++ b/tests/functional/websocket/infura.rs
@@ -18,11 +18,12 @@ async fn infura_provider_websocket(ctx: &mut ServerContext) {
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:10", "0xa").await;
 
     // Optimism goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:420", "0x1A4").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:11155420", "0xaa37dc")
+        .await;
 
     // Arbitrum mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:42161", "0xa4b1").await;
 
     // Arbitrum goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:421613", "0x66eed").await;
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:421614", "0x66eee").await;
 }


### PR DESCRIPTION
# Description

This PR updates provider's supported chains list and tests to the up-to-date state:

* Infura
  * `optimism-goerli` was removed in favor of `optimism-sepolia`,
  * `arbitrum-goerli` was removed in favor of `arbitrum-sepolia`,
  * `Base Sepolia` was removed as it's not supported by the provider anymore.
* Publicnode
  * `Ethereum goerli` was removed as it's not supported by the provider anymore.
* Zora
  * `Zora Goerli` was removed in favor of `Zora Sepolia`. 

## How Has This Been Tested?

Tested by running updated integration tests for each provider.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
