### PR TITLE
fix(identity): handling `0x` RPC response for identity

### DIFF
--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -327,6 +327,9 @@ pub enum SelfProviderError {
 
     #[error("JsonRpcError: {0:?}")]
     JsonRpcError(JsonRpcError),
+
+    #[error("Generic parameter error: {0}")]
+    GenericParameterError(String),
 }
 
 impl ethers::providers::RpcError for SelfProviderError {
@@ -413,8 +416,11 @@ impl JsonRpcClient for SelfProvider {
                 }
             }
         };
-        let result =
-            serde_json::from_value(result).map_err(SelfProviderError::ProviderBodySerde)?;
+        let result = serde_json::from_value(result).map_err(|_| {
+            SelfProviderError::GenericParameterError(
+                "Caller always provides generic parameter R=Bytes".into(),
+            )
+        })?;
         Ok(result)
     }
 }

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -32,6 +32,8 @@ use {
     wc::future::FutureExt,
 };
 
+const EMPTY_RPC_RESPONSE: &str = "0x";
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentityResponse {
@@ -401,10 +403,10 @@ impl JsonRpcClient for SelfProvider {
             JsonRpcResponse::Result(r) => {
                 // We shouldn't process with `0x` result because this leads to the ethers-rs
                 // panic when looking for an avatar
-                if r.result == "0x" {
+                if r.result == EMPTY_RPC_RESPONSE {
                     return Err(SelfProviderError::ProviderError {
                         status: StatusCode::METHOD_NOT_ALLOWED,
-                        body: "JSON-RPC result is `0x`".to_string(),
+                        body: format!("JSON-RPC result is {}", EMPTY_RPC_RESPONSE),
                     });
                 } else {
                     r.result

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -413,8 +413,8 @@ impl JsonRpcClient for SelfProvider {
                 }
             }
         };
-        let result = serde_json::from_value(result)
-            .expect("Caller always provides generic parameter R=Bytes");
+        let result =
+            serde_json::from_value(result).map_err(SelfProviderError::ProviderBodySerde)?;
         Ok(result)
     }
 }


### PR DESCRIPTION
# Description

This PR adds proper handling of the `0x` (method not exist) RPC responses on the avatar lookup passing the result to the `ethers-rs`.
At the current state, we have rare app panics from `ethers-rs` when the RPC responds with `0x` for some of the identity requests:
```
thread 'tokio-runtime-worker' panicked at /usr/local/cargo/git/checkouts/ethers-rs-c3a7c0a0ae0fe6be/40cc8cc/ethers-providers/src/rpc/provider.rs:1353:10
could not abi-decode bytes to address tokens: InvalidName("please ensure the contract and method you're calling exist! failed to decode empty bytes. if you're using jsonrpc this is likely due to jsonrpc returning `0x` in case contract or method don't exist")
```

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
