### PR TITLE
fix(balance): adding token contract address

### DIFF
--- a/integration/balance.test.ts
+++ b/integration/balance.test.ts
@@ -19,6 +19,11 @@ describe('Account balance', () => {
       expect(typeof item.name).toBe('string')
       expect(typeof item.symbol).toBe('string')
       expect(item.chainId).toEqual(expect.stringMatching(/^(eip155:)?\d+$/))
+      if (item.address !== null) {
+        expect(item.address).toEqual(expect.stringMatching(/^(eip155:\d+:0x[0-9a-fA-F]{40})$/))
+      } else {
+        expect(item.address).toBeNull()
+      }
       expect(typeof item.price).toBe('number')
       expect(typeof item.quantity).toBe('object')
       expect(typeof item.iconUrl).toBe('string')

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -63,7 +63,11 @@ pub struct BalanceResponseBody {
 pub struct BalanceItem {
     pub name: String,
     pub symbol: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub chain_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<f64>,
     pub price: f64,
     pub quantity: BalanceQuantity,

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -135,6 +135,7 @@ pub struct ZerionFungibleInfoAttribute {
     pub name: String,
     pub symbol: String,
     pub icon: Option<ZerionTransactionURLItem>,
+    pub implementations: Vec<ZerionImplementation>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
@@ -180,6 +181,12 @@ pub struct ZerionTransactionApplicationMetadata {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ZerionUrlItem {
     pub url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ZerionImplementation {
+    pub chain_id: String,
+    pub address: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -432,6 +439,18 @@ impl BalanceProvider for ZerionProvider {
                 name: f.attributes.fungible_info.name,
                 symbol: f.attributes.fungible_info.symbol,
                 chain_id: crypto::ChainId::to_caip2(&f.relationships.chain.data.id),
+                address: {
+                    let formatted_address = f
+                        .attributes
+                        .fungible_info
+                        .implementations
+                        .first()
+                        .and_then(|f| f.address.clone());
+                    formatted_address.map(|address| {
+                        // Token address is always on the mainnet
+                        crypto::format_to_caip10(crypto::CaipNamespaces::Eip155, "1", &address)
+                    })
+                },
                 value: f.attributes.value,
                 price: f.attributes.price,
                 quantity: BalanceQuantity {


### PR DESCRIPTION
# Description

This PR adds a missed token contract address for the balances.

## How Has This Been Tested?

* Updated integration test.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [x] Requires a documentation update
* [ ] Requires a e2e/integration test update
