### PR TITLE
fix(tests): fixing address to be `undefined` and not `null`

### DIFF
--- a/integration/balance.test.ts
+++ b/integration/balance.test.ts
@@ -19,10 +19,10 @@ describe('Account balance', () => {
       expect(typeof item.name).toBe('string')
       expect(typeof item.symbol).toBe('string')
       expect(item.chainId).toEqual(expect.stringMatching(/^(eip155:)?\d+$/))
-      if (item.address !== null) {
+      if (item.address !== undefined) {
         expect(item.address).toEqual(expect.stringMatching(/^(eip155:\d+:0x[0-9a-fA-F]{40})$/))
       } else {
-        expect(item.address).toBeNull()
+        expect(item.address).toBeUndefined()
       }
       expect(typeof item.price).toBe('number')
       expect(typeof item.quantity).toBe('object')


### PR DESCRIPTION
# Description

This PR fixed the balance endpoint integration test by checking the `address` can be `undefined` but not `null`.

## How Has This Been Tested?

* Run integration test locally.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
