### PR TITLE
fix(balance): using the correct implementation chain address instead of just first

### DIFF
--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -440,16 +440,20 @@ impl BalanceProvider for ZerionProvider {
                 symbol: f.attributes.fungible_info.symbol,
                 chain_id: crypto::ChainId::to_caip2(&f.relationships.chain.data.id),
                 address: {
-                    let formatted_address = f
+                    let chain_id_human = f.relationships.chain.data.id;
+                    let chain_address = f
                         .attributes
                         .fungible_info
                         .implementations
-                        .first()
+                        .iter()
+                        .find(|f| f.chain_id == chain_id_human)
                         .and_then(|f| f.address.clone());
-                    formatted_address.map(|address| {
-                        // Token address is always on the mainnet
-                        crypto::format_to_caip10(crypto::CaipNamespaces::Eip155, "1", &address)
-                    })
+                    let chain_id = crypto::ChainId::to_caip2(&chain_id_human);
+                    if let Some(chain_address) = chain_address {
+                        chain_id.map(|chain_id| format!("{}:{}", &chain_id, chain_address))
+                    } else {
+                        None
+                    }
                 },
                 value: f.attributes.value,
                 price: f.attributes.price,


### PR DESCRIPTION
# Description

This PR fixes the bug where we are using the only first address token implementation instead of using the actual chain in the Zerion response.

## How Has This Been Tested?

* Manually tested by comparing the address with the actual token contract address.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
