### PR TITLE
fix: provider-returned non-200s should be 503s & fix autoscaling

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -152,6 +152,7 @@ async fn handler_internal(
                 response.body()
             );
             state.metrics.add_failed_provider_call(provider.borrow());
+            *response.status_mut() = http::StatusCode::SERVICE_UNAVAILABLE;
         }
     };
     Ok(response)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,19 +34,19 @@ variable "log_level" {
 variable "app_autoscaling_desired_count" {
   description = "The desired number of tasks to run"
   type        = number
-  default     = 1
+  default     = 2
 }
 
 variable "app_autoscaling_min_capacity" {
   description = "The minimum number of tasks to run when autoscaling"
   type        = number
-  default     = 1
+  default     = 2
 }
 
 variable "app_autoscaling_max_capacity" {
   description = "The maximum number of tasks to run when autoscaling"
   type        = number
-  default     = 1
+  default     = 8
 }
 
 variable "ofac_blocked_countries" {


### PR DESCRIPTION
# Description

If a provider returns a non-200 status code, we return this as-is instead of transforming into a 503 which we use to indicate a provider-side error. [Slack conversation](https://walletconnect.slack.com/archives/C03SCF66K2T/p1711134896606019?thread_ts=1711133669.730169&cid=C03SCF66K2T)

Also fixes that the default min/max autoscaling was set to 1 incorrectly. Also updated to match in Terraform.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
