### PR TITLE
fix(monitoring): increasing the CPU alarm interval

### DIFF
--- a/terraform/monitoring/panels/ecs/cpu.libsonnet
+++ b/terraform/monitoring/panels/ecs/cpu.libsonnet
@@ -18,7 +18,7 @@ local overrides       = defaults.overrides;
       namespace     = 'Blockchain API',
       name          = "%s - High CPU usage" % vars.environment,
       message       = "%s - High CPU usage" % vars.environment,
-      period        = '15m',
+      period        = '20m',
       frequency     = '5m',
       noDataState   = 'alerting',
       notifications = vars.notifications,
@@ -39,8 +39,8 @@ local overrides       = defaults.overrides;
     .addTarget(targets.prometheus(
       datasource    = ds.prometheus,
       expr          = 'sum(rate(cpu_usage_sum[$__rate_interval])) / sum(rate(cpu_usage_count[$__rate_interval]))',
-      interval      = '3m',
-      legendFormat  = 'CPU Utilization 3m avg.',
+      interval      = '5m',
+      legendFormat  = 'CPU Utilization 5m avg.',
       refId         = 'CPU_Avg',
     ))
 }


### PR DESCRIPTION
# Description

This PR increases the CPU threshold interval for alarming to remove false alarms.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
