### PR TITLE
fix(monitoring): decreasing system metrics sampling interval

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
     let system_metrics_updater = {
         let state_arc = state_arc.clone();
         async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            let mut interval = tokio::time::interval(Duration::from_secs(10));
             loop {
                 interval.tick().await;
                 state_arc.clone().metrics.gather_system_metrics().await;


### PR DESCRIPTION
# Description

This PR decreased system metrics sampling interval from `60` seconds to `10` seconds, for a better average accuracy.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
