### PR TITLE
feat(analytics): updating `utils-rs` to the `0.8.0` tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 [[package]]
 name = "alloc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.7.0#5f636b8f7f447a1c8a588744877794a2e7662130"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.8.0#ad42551ea3e9f6ee1bf8513f267033b46c567867"
 dependencies = [
  "metrics",
  "serde",
@@ -98,13 +98,14 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 [[package]]
 name = "analytics"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.7.0#5f636b8f7f447a1c8a588744877794a2e7662130"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.8.0#ad42551ea3e9f6ee1bf8513f267033b46c567867"
 dependencies = [
  "anyhow",
  "async-trait",
  "aws-sdk-s3",
  "bytes",
  "chrono",
+ "future",
  "parquet",
  "parquet_derive",
  "tap",
@@ -240,19 +241,20 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "0.56.1"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6b3804dca60326e07205179847f17a4fce45af3a1106939177ad41ac08a6de"
+checksum = "297b64446175a73987cedc3c438d79b2a654d0fff96f65ff530fbe039347644c"
 dependencies = [
  "aws-credential-types",
- "aws-http",
+ "aws-runtime",
  "aws-sdk-sso",
+ "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-client",
  "aws-smithy-http",
- "aws-smithy-http-tower",
  "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -260,55 +262,33 @@ dependencies = [
  "hex",
  "http 0.2.11",
  "hyper",
- "ring 0.16.20",
+ "ring 0.17.7",
  "time",
  "tokio",
- "tower",
  "tracing",
+ "url",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-credential-types"
-version = "0.56.1"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a66ac8ef5fa9cf01c2d999f39d16812e90ec1467bd382cbbb74ba23ea86201"
+checksum = "fa8587ae17c8e967e4b05a62d495be2fb7701bec52a97f7acfe8a29f938384c8"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
- "fastrand",
- "tokio",
- "tracing",
  "zeroize",
 ]
 
 [[package]]
-name = "aws-http"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e626370f9ba806ae4c439e49675fd871f5767b093075cdf4fef16cac42ba900"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-http",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "http 0.2.11",
- "http-body",
- "lazy_static",
- "percent-encoding",
- "pin-project-lite",
- "tracing",
-]
-
-[[package]]
 name = "aws-runtime"
-version = "0.56.1"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ac5cf0ff19c1bca0cea7932e11b239d1025a45696a4f44f72ea86e2b8bdd07"
+checksum = "b13dc54b4b49f8288532334bba8f87386a40571c47c37b1304979b556dc613c8"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
@@ -316,26 +296,27 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
+ "bytes",
  "fastrand",
  "http 0.2.11",
+ "http-body",
  "percent-encoding",
+ "pin-project-lite",
  "tracing",
  "uuid 1.6.1",
 ]
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.31.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c681fef332c3462634cd97fced8d1ac3cfdf790829bd7bfb4006cfba76712053"
+checksum = "5076637347e7d0218e61facae853110682ae58efabd2f4e2a9e530c203d5fa7b"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-checksums",
- "aws-smithy-client",
  "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-json",
@@ -349,23 +330,20 @@ dependencies = [
  "http-body",
  "once_cell",
  "percent-encoding",
- "regex",
- "tokio-stream",
+ "regex-lite",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.30.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903f888ff190e64f6f5c83fb0f8d54f9c20481f1dc26359bb8896f5d99908949"
+checksum = "019a07902c43b03167ea5df0182f0cb63fae89f9a9682c44d18cf2e4a042cb34"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-client",
  "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-runtime",
@@ -374,22 +352,42 @@ dependencies = [
  "aws-types",
  "bytes",
  "http 0.2.11",
- "regex",
- "tokio-stream",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c46ee08a48a7f4eaa4ad201dcc1dd537b49c50859d14d4510e00ad9d3f9af2"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.11",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.30.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47ad6bf01afc00423d781d464220bf69fb6a674ad6629cbbcb06d88cdc2be82"
+checksum = "f752ac730125ca6017f72f9db5ec1772c9ecc664f87aa7507a7d81b023c23713"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-client",
  "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-query",
@@ -399,48 +397,56 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "http 0.2.11",
- "regex",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "0.56.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b28f4910bb956b7ab320b62e98096402354eca976c587d1eeccd523d9bac03"
+checksum = "11d6f29688a4be9895c0ba8bef861ad0c0dac5c15e9618b9b7a6c233990fc263"
 dependencies = [
+ "aws-credential-types",
  "aws-smithy-eventstream",
  "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "bytes",
+ "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
  "hmac",
  "http 0.2.11",
+ "http 1.1.0",
  "once_cell",
+ "p256",
  "percent-encoding",
- "regex",
+ "ring 0.17.7",
  "sha2",
+ "subtle",
  "time",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.56.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdb73f85528b9d19c23a496034ac53703955a59323d581c06aa27b4e4e247af"
+checksum = "f7a41ccd6b74401a49ca828617049e5c23d83163d330a4f90a8081aadee0ac45"
 dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
- "tokio-stream",
 ]
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.56.1"
+version = "0.60.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb15946af1b8d3beeff53ad991d9bff68ac22426b6d40372b958a75fa61eaed"
+checksum = "6ee554133eca2611b66d23548e48f9b44713befdb025ab76bc00185b878397a1"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -458,34 +464,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-client"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27b2756264c82f830a91cb4d2d485b2d19ad5bea476d9a966e03d27f27ba59a"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-types",
- "bytes",
- "fastrand",
- "http 0.2.11",
- "http-body",
- "hyper",
- "hyper-rustls",
- "lazy_static",
- "pin-project-lite",
- "rustls",
- "tokio",
- "tower",
- "tracing",
-]
-
-[[package]]
 name = "aws-smithy-eventstream"
-version = "0.56.1"
+version = "0.60.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "850233feab37b591b7377fd52063aa37af615687f5896807abe7f49bd4e1d25b"
+checksum = "e6363078f927f612b970edf9d1903ef5cef9a64d1e8423525ebb1f0a1633c858"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -494,57 +476,39 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.56.1"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cdcf365d8eee60686885f750a34c190e513677db58bbc466c44c588abf4199"
+checksum = "3f10fa66956f01540051b0aa7ad54574640f748f9839e843442d99b970d3aff9"
 dependencies = [
  "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.11",
  "http-body",
- "hyper",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http-tower"
-version = "0.56.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822de399d0ce62829a69dfa8c5cd08efdbe61a7426b953e2268f8b8b52a607bd"
-dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
- "bytes",
- "http 0.2.11",
- "http-body",
- "pin-project-lite",
- "tower",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.56.1"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1e7ab8fa7ad10c193af7ae56d2420989e9f4758bf03601a342573333ea34f"
+checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.56.1"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28556a3902091c1f768a34f6c998028921bdab8d47d92586f363f14a4a32d047"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -552,74 +516,87 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "0.56.1"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745e096b3553e7e0f40622aa04971ce52765af82bebdeeac53aa6fc82fe801e6"
+checksum = "ec81002d883e5a7fd2bb063d6fb51c4999eb55d404f4fff3dd878bf4733b9f01"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-client",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "fastrand",
+ "h2",
  "http 0.2.11",
  "http-body",
+ "hyper",
+ "hyper-rustls",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
+ "rustls",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "0.56.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d0ae0c9cfd57944e9711ea610b48a963fb174a53aabacc08c5794a594b1d02"
+checksum = "9acb931e0adaf5132de878f1398d83f8677f90ba70f01f65ff87f6d7244be1c5"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
  "http 0.2.11",
+ "http 1.1.0",
+ "pin-project-lite",
  "tokio",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.56.1"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90dbc8da2f6be461fa3c1906b20af8f79d14968fe47f2b7d29d086f62a51728"
+checksum = "abe14dceea1e70101d38fbf2a99e6a34159477c0fb95e68e05c66bd7ae4c3729"
 dependencies = [
  "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.11",
+ "http-body",
  "itoa",
  "num-integer",
+ "pin-project-lite",
+ "pin-utils",
  "ryu",
  "serde",
  "time",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.56.1"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01d2dedcdd8023043716cfeeb3c6c59f2d447fce365d8e194838891794b23b6"
+checksum = "872c68cf019c0e4afc5de7753c4f7288ce4b71663212771bf5e4542eb9346ca9"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "0.56.1"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85aa0451bf8af1bf22a4f028d5d28054507a14be43cb8ac0597a8471fba9edfe"
+checksum = "0dbf2f3da841a8930f159163175cf6a3d16ddde517c1b0fba7aa776822800f40"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "http 0.2.11",
  "rustc_version",
@@ -722,6 +699,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base16ct"
@@ -1230,6 +1213,18 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
@@ -1307,6 +1302,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
 dependencies = [
  "tokio",
+]
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -1422,16 +1427,28 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.8",
  "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1445,19 +1462,39 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest",
+ "ff 0.12.1",
+ "generic-array",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
+ "rand_core",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest",
- "ff",
+ "ff 0.13.0",
  "generic-array",
- "group",
- "pkcs8",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
  "rand_core",
- "sec1",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -1716,7 +1753,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "const-hex",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "ethabi",
  "generic-array",
  "k256",
@@ -1821,7 +1858,7 @@ dependencies = [
  "coins-bip32",
  "coins-bip39",
  "const-hex",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "eth-keystore",
  "ethers-core",
  "rand",
@@ -1882,6 +1919,16 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "ff"
@@ -1997,7 +2044,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "future"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.7.0#5f636b8f7f447a1c8a588744877794a2e7662130"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.8.0#ad42551ea3e9f6ee1bf8513f267033b46c567867"
 dependencies = [
  "metrics",
  "pin-project",
@@ -2149,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "geoip"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.7.0#5f636b8f7f447a1c8a588744877794a2e7662130"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.8.0#ad42551ea3e9f6ee1bf8513f267033b46c567867"
 dependencies = [
  "aws-sdk-s3",
  "axum-client-ip",
@@ -2227,11 +2274,22 @@ dependencies = [
 
 [[package]]
 name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.0",
  "rand_core",
  "subtle",
 ]
@@ -2340,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "http"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.7.0#5f636b8f7f447a1c8a588744877794a2e7662130"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.8.0#ad42551ea3e9f6ee1bf8513f267033b46c567867"
 dependencies = [
  "future",
  "hyper",
@@ -2353,6 +2411,17 @@ name = "http"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -2696,11 +2765,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
  "sha2",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -2875,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.7.0#5f636b8f7f447a1c8a588744877794a2e7662130"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.8.0#ad42551ea3e9f6ee1bf8513f267033b46c567867"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -3287,6 +3356,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3542,9 +3622,19 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.8",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -3553,8 +3643,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.8",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -3896,6 +3986,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+
+[[package]]
 name = "regex-syntax"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3950,6 +4046,17 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
 ]
 
 [[package]]
@@ -4114,10 +4221,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -4292,14 +4399,28 @@ dependencies = [
 
 [[package]]
 name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct 0.1.1",
+ "der 0.6.1",
+ "generic-array",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.8",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -4525,6 +4646,16 @@ dependencies = [
 
 [[package]]
 name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
+name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -4607,12 +4738,22 @@ dependencies = [
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.8",
 ]
 
 [[package]]
@@ -5809,7 +5950,7 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 [[package]]
 name = "wc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.7.0#5f636b8f7f447a1c8a588744877794a2e7662130"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.8.0#ad42551ea3e9f6ee1bf8513f267033b46c567867"
 dependencies = [
  "alloc",
  "analytics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 build = "build.rs"
 
 [dependencies]
-wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.7.0", features = ["alloc", "analytics", "future", "http", "metrics", "geoip", "geoblock"] }
+wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.8.0", features = ["alloc", "analytics", "future", "http", "metrics", "geoip", "geoblock"] }
 
 # Async
 async-trait = "0.1.57"
@@ -39,8 +39,8 @@ strum = "0.26"
 strum_macros = "0.26"
 
 # Storage
-aws-config = "0.56"
-aws-sdk-s3 = "0.31"
+aws-config = "1.1"
+aws-sdk-s3 = "1.13"
 deadpool-redis = "0.13"
 sqlx = { version = "0.7.3", features = ["runtime-tokio-native-tls", "postgres", "chrono"] }
 

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -1,16 +1,25 @@
 use {
     aws_sdk_s3::Client as S3Client,
-    std::{net::IpAddr, sync::Arc},
+    std::{net::IpAddr, sync::Arc, time::Duration},
     tap::TapFallible,
     tracing::info,
     wc::{
         analytics::{
-            collectors::{batch::BatchOpts, noop::NoopCollector},
-            exporters::aws::{AwsExporter, AwsOpts},
-            writers::parquet::ParquetWriter,
-            Analytics,
+            self,
+            AnalyticsExt,
+            ArcCollector,
+            AwsConfig,
+            AwsExporter,
+            BatchCollector,
+            BatchObserver,
+            CollectionObserver,
+            Collector,
+            CollectorConfig,
+            ExportObserver,
+            ParquetBatchFactory,
         },
         geoip::{self, MaxMindResolver, Resolver},
+        metrics::otel,
     },
 };
 pub use {
@@ -27,12 +36,126 @@ mod identity_lookup_info;
 mod message_info;
 mod onramp_history_lookup_info;
 
+const ANALYTICS_EXPORT_TIMEOUT: Duration = Duration::from_secs(30);
+const DATA_QUEUE_CAPACITY: usize = 8192;
+
+#[derive(Clone, Copy)]
+enum DataKind {
+    RpcRequests,
+    IdentityLookups,
+    HistoryLookups,
+    OnrampHistoryLookups,
+}
+
+impl DataKind {
+    #[inline]
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::RpcRequests => "rpc_requests",
+            Self::IdentityLookups => "identity_lookups",
+            Self::HistoryLookups => "history_lookups",
+            Self::OnrampHistoryLookups => "onramp_history_lookups",
+        }
+    }
+
+    #[inline]
+    fn as_kv(&self) -> otel::KeyValue {
+        otel::KeyValue::new("data_kind", self.as_str())
+    }
+}
+
+fn success_kv(success: bool) -> otel::KeyValue {
+    otel::KeyValue::new("success", success)
+}
+
+#[derive(Clone, Copy)]
+struct Observer(DataKind);
+
+impl<T, E> BatchObserver<T, E> for Observer
+where
+    E: std::error::Error,
+{
+    fn observe_batch_serialization(&self, elapsed: Duration, res: &Result<Vec<u8>, E>) {
+        let size = res.as_deref().map(|data| data.len()).unwrap_or(0);
+        let elapsed = elapsed.as_millis() as u64;
+
+        wc::metrics::counter!("analytics_batches_finished", 1, &[
+            self.0.as_kv(),
+            success_kv(res.is_ok())
+        ]);
+
+        if let Err(err) = res {
+            tracing::warn!(
+                ?err,
+                data_kind = self.0.as_str(),
+                "failed to serialize analytics batch"
+            );
+        } else {
+            tracing::info!(
+                size,
+                elapsed,
+                data_kind = self.0.as_str(),
+                "analytics data batch serialized"
+            );
+        }
+    }
+}
+
+impl<T, E> CollectionObserver<T, E> for Observer
+where
+    E: std::error::Error,
+{
+    fn observe_collection(&self, res: &Result<(), E>) {
+        wc::metrics::counter!("analytics_records_collected", 1, &[
+            self.0.as_kv(),
+            success_kv(res.is_ok())
+        ]);
+
+        if let Err(err) = res {
+            tracing::warn!(
+                ?err,
+                data_kind = self.0.as_str(),
+                "failed to collect analytics data"
+            );
+        }
+    }
+}
+
+impl<E> ExportObserver<E> for Observer
+where
+    E: std::error::Error,
+{
+    fn observe_export(&self, elapsed: Duration, res: &Result<(), E>) {
+        wc::metrics::counter!("analytics_batches_exported", 1, &[
+            self.0.as_kv(),
+            success_kv(res.is_ok())
+        ]);
+
+        let elapsed = elapsed.as_millis() as u64;
+
+        if let Err(err) = res {
+            tracing::warn!(
+                ?err,
+                elapsed,
+                data_kind = self.0.as_str(),
+                "analytics export failed"
+            );
+        } else {
+            tracing::info!(
+                elapsed,
+                data_kind = self.0.as_str(),
+                "analytics export failed"
+            );
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct RPCAnalytics {
-    messages: Analytics<MessageInfo>,
-    identity_lookups: Analytics<IdentityLookupInfo>,
-    history_lookups: Analytics<HistoryLookupInfo>,
-    onramp_history_lookups: Analytics<OnrampHistoryLookupInfo>,
+    messages: ArcCollector<MessageInfo>,
+    identity_lookups: ArcCollector<IdentityLookupInfo>,
+    history_lookups: ArcCollector<HistoryLookupInfo>,
+    onramp_history_lookups: ArcCollector<OnrampHistoryLookupInfo>,
     geoip_resolver: Option<Arc<MaxMindResolver>>,
 }
 
@@ -56,10 +179,10 @@ impl RPCAnalytics {
         info!("initializing analytics with noop export");
 
         Self {
-            messages: Analytics::new(NoopCollector),
-            identity_lookups: Analytics::new(NoopCollector),
-            history_lookups: Analytics::new(NoopCollector),
-            onramp_history_lookups: Analytics::new(NoopCollector),
+            messages: analytics::noop_collector().boxed_shared(),
+            identity_lookups: analytics::noop_collector().boxed_shared(),
+            history_lookups: analytics::noop_collector().boxed_shared(),
+            onramp_history_lookups: analytics::noop_collector().boxed_shared(),
             geoip_resolver: None,
         }
     }
@@ -67,69 +190,92 @@ impl RPCAnalytics {
     fn with_aws_export(
         s3_client: S3Client,
         export_bucket: &str,
-        node_ip: IpAddr,
+        node_addr: IpAddr,
         geoip_resolver: Option<Arc<MaxMindResolver>>,
     ) -> anyhow::Result<Self> {
-        info!(%export_bucket, "initializing analytics with aws export");
-
-        let opts = BatchOpts {
-            event_queue_limit: 8192,
-            ..Default::default()
-        };
-        let bucket_name: Arc<str> = export_bucket.into();
-        let node_ip: Arc<str> = node_ip.to_string().into();
-
-        let messages = {
-            let exporter = AwsExporter::new(AwsOpts {
-                export_prefix: "blockchain-api/rpc-requests",
-                export_name: "rpc_requests",
-                file_extension: "parquet",
-                bucket_name: bucket_name.clone(),
+        let observer = Observer(DataKind::RpcRequests);
+        let messages = BatchCollector::new(
+            CollectorConfig {
+                data_queue_capacity: DATA_QUEUE_CAPACITY,
+                ..Default::default()
+            },
+            ParquetBatchFactory::new(Default::default()).with_observer(observer),
+            AwsExporter::new(AwsConfig {
+                export_prefix: "blockchain-api/rpc-requests".to_owned(),
+                export_name: "rpc_requests".to_owned(),
+                node_addr,
+                file_extension: "parquet".to_owned(),
+                bucket_name: export_bucket.to_owned(),
                 s3_client: s3_client.clone(),
-                node_ip: node_ip.clone(),
-            });
+                upload_timeout: ANALYTICS_EXPORT_TIMEOUT,
+            })
+            .with_observer(observer),
+        )
+        .with_observer(observer)
+        .boxed_shared();
 
-            Analytics::new(ParquetWriter::new(opts.clone(), exporter)?)
-        };
-
-        let identity_lookups = {
-            let exporter = AwsExporter::new(AwsOpts {
-                export_prefix: "blockchain-api/identity-lookups",
-                export_name: "identity_lookups",
-                file_extension: "parquet",
-                bucket_name: bucket_name.clone(),
+        let observer = Observer(DataKind::IdentityLookups);
+        let identity_lookups = BatchCollector::new(
+            CollectorConfig {
+                data_queue_capacity: DATA_QUEUE_CAPACITY,
+                ..Default::default()
+            },
+            ParquetBatchFactory::new(Default::default()).with_observer(observer),
+            AwsExporter::new(AwsConfig {
+                export_prefix: "blockchain-api/identity-lookups".to_owned(),
+                export_name: "identity_lookups".to_owned(),
+                node_addr,
+                file_extension: "parquet".to_owned(),
+                bucket_name: export_bucket.to_owned(),
                 s3_client: s3_client.clone(),
-                node_ip: node_ip.clone(),
-            });
+                upload_timeout: ANALYTICS_EXPORT_TIMEOUT,
+            })
+            .with_observer(observer),
+        )
+        .with_observer(observer)
+        .boxed_shared();
 
-            Analytics::new(ParquetWriter::new(opts.clone(), exporter)?)
-        };
-
-        let history_lookups = {
-            let exporter = AwsExporter::new(AwsOpts {
-                export_prefix: "blockchain-api/history-lookups",
-                export_name: "history_lookups",
-                file_extension: "parquet",
-                bucket_name: bucket_name.clone(),
+        let observer = Observer(DataKind::HistoryLookups);
+        let history_lookups = BatchCollector::new(
+            CollectorConfig {
+                data_queue_capacity: DATA_QUEUE_CAPACITY,
+                ..Default::default()
+            },
+            ParquetBatchFactory::new(Default::default()).with_observer(observer),
+            AwsExporter::new(AwsConfig {
+                export_prefix: "blockchain-api/history-lookups".to_owned(),
+                export_name: "history_lookups".to_owned(),
+                node_addr,
+                file_extension: "parquet".to_owned(),
+                bucket_name: export_bucket.to_owned(),
                 s3_client: s3_client.clone(),
-                node_ip: node_ip.clone(),
-            });
+                upload_timeout: ANALYTICS_EXPORT_TIMEOUT,
+            })
+            .with_observer(observer),
+        )
+        .with_observer(observer)
+        .boxed_shared();
 
-            Analytics::new(ParquetWriter::new(opts.clone(), exporter)?)
-        };
-
-        let onramp_history_lookups = {
-            let exporter = AwsExporter::new(AwsOpts {
-                export_prefix: "blockchain-api/onramp-history-lookups",
-                export_name: "onramp-history_lookups",
-                file_extension: "parquet",
-                bucket_name,
+        let observer = Observer(DataKind::OnrampHistoryLookups);
+        let onramp_history_lookups = BatchCollector::new(
+            CollectorConfig {
+                data_queue_capacity: DATA_QUEUE_CAPACITY,
+                ..Default::default()
+            },
+            ParquetBatchFactory::new(Default::default()).with_observer(observer),
+            AwsExporter::new(AwsConfig {
+                export_prefix: "blockchain-api/onramp-history-lookups".to_owned(),
+                export_name: "onramp-history_lookups".to_owned(),
+                node_addr,
+                file_extension: "parquet".to_owned(),
+                bucket_name: export_bucket.to_owned(),
                 s3_client,
-                node_ip,
-            });
-
-            Analytics::new(ParquetWriter::new(opts, exporter)?)
-        };
+                upload_timeout: ANALYTICS_EXPORT_TIMEOUT,
+            })
+            .with_observer(observer),
+        )
+        .with_observer(observer)
+        .boxed_shared();
 
         Ok(Self {
             messages,
@@ -141,19 +287,43 @@ impl RPCAnalytics {
     }
 
     pub fn message(&self, data: MessageInfo) {
-        self.messages.collect(data);
+        if let Err(err) = self.messages.collect(data) {
+            tracing::warn!(
+                ?err,
+                data_kind = DataKind::RpcRequests.as_str(),
+                "failed to collect analytics"
+            );
+        }
     }
 
     pub fn identity_lookup(&self, data: IdentityLookupInfo) {
-        self.identity_lookups.collect(data);
+        if let Err(err) = self.identity_lookups.collect(data) {
+            tracing::warn!(
+                ?err,
+                data_kind = DataKind::IdentityLookups.as_str(),
+                "failed to collect analytics"
+            );
+        }
     }
 
     pub fn history_lookup(&self, data: HistoryLookupInfo) {
-        self.history_lookups.collect(data);
+        if let Err(err) = self.history_lookups.collect(data) {
+            tracing::warn!(
+                ?err,
+                data_kind = DataKind::HistoryLookups.as_str(),
+                "failed to collect analytics"
+            );
+        }
     }
 
     pub fn onramp_history_lookup(&self, data: OnrampHistoryLookupInfo) {
-        self.onramp_history_lookups.collect(data);
+        if let Err(err) = self.onramp_history_lookups.collect(data) {
+            tracing::warn!(
+                ?err,
+                data_kind = DataKind::OnrampHistoryLookups.as_str(),
+                "failed to collect analytics"
+            );
+        }
     }
 
     pub fn geoip_resolver(&self) -> &Option<Arc<MaxMindResolver>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,7 +412,10 @@ fn init_providers(config: &ProvidersConfig) -> ProviderRepository {
 
 async fn get_s3_client(config: &Config) -> S3Client {
     let region_provider = RegionProviderChain::first_try(Region::new("eu-central-1"));
-    let shared_config = aws_config::from_env().region(region_provider).load().await;
+    let shared_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(region_provider)
+        .load()
+        .await;
 
     let aws_config = if let Some(s3_endpoint) = &config.server.s3_endpoint {
         info!(%s3_endpoint, "initializing custom s3 endpoint");


### PR DESCRIPTION
# Description

This PR updating the [utils-rs](https://github.com/WalletConnect/utils-rs) to the latest `0.8.0` tag.
The `0.8.0` version introduces [breaking changes in analytics](https://github.com/WalletConnect/utils-rs/pull/13) (introducing observers). 
This PR making appropriate changes in the blockchain-api to support the latest version. The changes made are the same as in the relay [#1406](https://github.com/WalletConnect/rs-relay/pull/1406) to update the analytics (converting to use observer).

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
