### PR TITLE
fix(providers): varying priority for the GetBlock provider

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -431,6 +431,7 @@ pub trait RpcWsProvider: Provider {
 
 const MAX_PRIORITY: u64 = 100;
 
+#[derive(Debug, Clone, Copy)]
 pub enum Priority {
     Max,
     High,


### PR DESCRIPTION
# Description

This PR changing priorities to `Low` for the most used chains `eip155:1` and `eip155:56` for the GetBlock provider, since our quota drains very fast with the current priority.

## How Has This Been Tested?

Not tested, but should be tested by the current integration and canary tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
