### PR TITLE
fix(providers): removing deprecated endpoints from Grove/Pokt

### DIFF
--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -96,11 +96,6 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:1".into(),
             ("eth-mainnet".into(), Weight::new(Priority::Max).unwrap()),
         ),
-        // Ethereum goerli
-        (
-            "eip155:5".into(),
-            ("eth-goerli".into(), Weight::new(Priority::Normal).unwrap()),
-        ),
         // Ethereum holesky
         (
             "eip155:17000".into(),
@@ -108,6 +103,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 "holesky-fullnode-testnet".into(),
                 Weight::new(Priority::High).unwrap(),
             ),
+        ),
+        // Ethereum sepolia
+        (
+            "eip155:11155111".into(),
+            ("sepolia".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         // Optimism
         (
@@ -129,13 +129,6 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         (
             "eip155:137".into(),
             ("poly-mainnet".into(), Weight::new(Priority::High).unwrap()),
-        ),
-        (
-            "eip155:80001".into(),
-            (
-                "polygon-mumbai".into(),
-                Weight::new(Priority::Normal).unwrap(),
-            ),
         ),
         (
             "eip155:1101".into(),

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -54,16 +54,21 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:1", "0x1")
         .await;
 
-    // Ethereum goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:5", "0x5")
-        .await;
-
     // Ethereum holesky
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
         &provider,
         "eip155:17000",
         "0x4268",
+    )
+    .await;
+
+    // Ethereum Sepolia
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &provider,
+        "eip155:11155111",
+        "0xaa36a7",
     )
     .await;
 
@@ -83,15 +88,6 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
     // Polygon mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:137", "0x89")
         .await;
-
-    // Polygon mumbai
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &provider,
-        "eip155:80001",
-        "0x13881",
-    )
-    .await;
 
     // Polygon zkevm
     check_if_rpc_is_responding_correctly_for_supported_chain(


### PR DESCRIPTION
# Description

This PR removes the deprecated Ethereum Goerli and Polygon Mumbai endpoints from the Pokt/Grove provider and adds the Ethereum Sepolia endpoint.

## How Has This Been Tested?

* Tested by the updated provider's integration test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
