### PR TITLE
fix(names): decreasing minimum name length to `3`

### DIFF
--- a/src/handlers/profile/utils.rs
+++ b/src/handlers/profile/utils.rs
@@ -17,7 +17,7 @@ static DOMAIN_FORMAT_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^[a-zA-Z0-9.-]+$").expect("Failed to initialize regexp for the domain format")
 });
 
-const NAME_MIN_LENGTH: usize = 5;
+const NAME_MIN_LENGTH: usize = 3;
 const NAME_MAX_LENGTH: usize = 64;
 
 #[tracing::instrument]


### PR DESCRIPTION
# Description

This PR decreases the minimal name length to register from `5` to `3` to be in sync with the ENS minimum length.

## How Has This Been Tested?

* Current integration tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
