### PR TITLE
feat(providers): fungible price endpoint implementation

### DIFF
--- a/integration/fungible_price.test.ts
+++ b/integration/fungible_price.test.ts
@@ -2,14 +2,21 @@ import { getTestSetup } from './init';
 
 describe('Fungible price', () => {
   const { baseUrl, projectId, httpClient } = getTestSetup();
+  const endpoint = `${baseUrl}/v1/fungible/price`;
 
   // RSR token address
   const implementation_address = 'eip155:1:0x320623b8e4ff03373931769a31fc52a4e78b5d70'
   const currency = 'usd'
 
   it('get token price', async () => {
-    let resp: any = await httpClient.get(
-      `${baseUrl}/v1/fungible/price?projectId=${projectId}&currency=${currency}&address=${implementation_address}`
+    let request_data = {
+      projectId: projectId,
+      currency: currency,
+      addresses: [implementation_address]
+    }
+    let resp: any = await httpClient.post(
+      `${endpoint}`,
+      request_data
     )
     expect(resp.status).toBe(200)
     expect(typeof resp.data.fungibles).toBe('object')
@@ -21,5 +28,32 @@ describe('Fungible price', () => {
       expect(typeof item.iconUrl).toBe('string')
       expect(typeof item.price).toBe('number')
     }
+  })
+
+  it('bad arguments', async () => {
+    // Empty addresses
+    let request_data = {
+      projectId: projectId,
+      currency: currency,
+      addresses: []
+    }
+    let resp: any = await httpClient.post(
+      `${endpoint}`,
+      request_data
+    )
+    expect(resp.status).toBe(400)
+
+    // Wrong currency
+    request_data = {
+      projectId: projectId,
+      currency: "irn",
+      addresses: [implementation_address]
+    }
+    resp = await httpClient.post(
+      `${endpoint}`,
+      request_data
+    )
+    expect(resp.status).toBe(422)
+    
   })
 })

--- a/integration/fungible_price.test.ts
+++ b/integration/fungible_price.test.ts
@@ -1,0 +1,25 @@
+import { getTestSetup } from './init';
+
+describe('Fungible price', () => {
+  const { baseUrl, projectId, httpClient } = getTestSetup();
+
+  // RSR token address
+  const implementation_address = 'eip155:1:0x320623b8e4ff03373931769a31fc52a4e78b5d70'
+  const currency = 'usd'
+
+  it('get token price', async () => {
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/fungible/price?projectId=${projectId}&currency=${currency}&address=${implementation_address}`
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.fungibles).toBe('object')
+    expect(resp.data.fungibles.length).toBeGreaterThan(0)
+
+    for (const item of resp.data.fungibles) {
+      expect(typeof item.name).toBe('string')
+      expect(typeof item.symbol).toBe('string')
+      expect(typeof item.iconUrl).toBe('string')
+      expect(typeof item.price).toBe('number')
+    }
+  })
+})

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,8 +62,14 @@ pub enum RpcError {
     #[error("Failed to reach the balance provider")]
     BalanceProviderError,
 
+    #[error("Failed to reach the fungible price provider")]
+    FungiblePriceProviderError,
+
     #[error("Failed to parse balance provider url")]
     BalanceParseURLError,
+
+    #[error("Failed to parse fungible price provider url")]
+    FungiblePriceParseURLError,
 
     #[error("Failed to reach the conversion provider")]
     ConversionProviderError,

--- a/src/handlers/fungible_price.rs
+++ b/src/handlers/fungible_price.rs
@@ -1,0 +1,98 @@
+use {
+    super::HANDLER_TASK_METRICS,
+    crate::{error::RpcError, state::AppState, utils::crypto},
+    axum::{
+        extract::{Query, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    serde::{Deserialize, Serialize},
+    std::{fmt::Display, sync::Arc},
+    tap::TapFallible,
+    tracing::log::error,
+    wc::future::FutureExt,
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum PriceCurrencies {
+    BTC,
+    ETH,
+    USD,
+    EUR,
+    GBP,
+    AUD,
+    CAD,
+    INR,
+    JPY,
+}
+
+impl Display for PriceCurrencies {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            PriceCurrencies::BTC => "btc",
+            PriceCurrencies::ETH => "eth",
+            PriceCurrencies::USD => "usd",
+            PriceCurrencies::EUR => "eur",
+            PriceCurrencies::GBP => "gbp",
+            PriceCurrencies::AUD => "aud",
+            PriceCurrencies::CAD => "cad",
+            PriceCurrencies::INR => "inr",
+            PriceCurrencies::JPY => "jpy",
+        })
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PriceQueryParams {
+    pub project_id: String,
+    pub currency: PriceCurrencies,
+    pub address: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PriceResponseBody {
+    pub fungibles: Vec<FungiblePriceItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FungiblePriceItem {
+    pub name: String,
+    pub symbol: String,
+    pub icon_url: String,
+    pub price: f64,
+}
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    query: Query<PriceQueryParams>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, query)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("fungible_price"))
+        .await
+}
+
+#[tracing::instrument(skip_all)]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    query: Query<PriceQueryParams>,
+) -> Result<Response, RpcError> {
+    let project_id = query.project_id.clone();
+    state.validate_project_access_and_quota(&project_id).await?;
+
+    let (_, _, address) = crypto::disassemble_caip10(&query.address)?;
+
+    let response = state
+        .providers
+        .fungible_price_provider
+        .get_price(&address, &query.currency, state.http_client.clone())
+        .await
+        .tap_err(|e| {
+            error!("Failed to call fungible price with {}", e);
+        })?;
+
+    Ok(Json(response).into_response())
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -14,6 +14,7 @@ use {
 
 pub mod balance;
 pub mod convert;
+pub mod fungible_price;
 pub mod generators;
 pub mod health;
 pub mod history;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         // Fungible price
         .route(
             "/v1/fungible/price",
-            get(handlers::fungible_price::handler),
+            post(handlers::fungible_price::handler),
         )
         .route("/health", get(handlers::health::handler))
         .route_layer(tracing_and_metrics_layer)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,6 +325,11 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/convert/build-transaction",
             post(handlers::convert::transaction::handler),
         )
+        // Fungible price
+        .route(
+            "/v1/fungible/price",
+            get(handlers::fungible_price::handler),
+        )
         .route("/health", get(handlers::health::handler))
         .route_layer(tracing_and_metrics_layer)
         .layer(cors);

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -579,6 +579,7 @@ pub trait BalanceProvider: Send + Sync + Debug {
 pub trait FungiblePriceProvider: Send + Sync + Debug {
     async fn get_price(
         &self,
+        chain_id: &str,
         address: &str,
         currency: &PriceCurrencies,
         http_client: reqwest::Client,

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -11,6 +11,7 @@ use {
                 tokens::{TokensListQueryParams, TokensListResponseBody},
                 transaction::{ConvertTransactionQueryParams, ConvertTransactionResponseBody},
             },
+            fungible_price::{PriceCurrencies, PriceResponseBody},
             history::{HistoryQueryParams, HistoryResponseBody},
             onramp::{
                 options::{OnRampBuyOptionsParams, OnRampBuyOptionsResponse},
@@ -114,6 +115,7 @@ pub struct ProviderRepository {
     pub onramp_provider: Arc<dyn OnRampProvider>,
     pub balance_provider: Arc<dyn BalanceProvider>,
     pub conversion_provider: Arc<dyn ConversionProvider>,
+    pub fungible_price_provider: Arc<dyn FungiblePriceProvider>,
 }
 
 impl ProviderRepository {
@@ -165,7 +167,8 @@ impl ProviderRepository {
         let zerion_provider = Arc::new(ZerionProvider::new(zerion_api_key));
         let history_provider = zerion_provider.clone();
         let portfolio_provider = zerion_provider.clone();
-        let balance_provider = zerion_provider;
+        let balance_provider = zerion_provider.clone();
+        let fungible_price_provider = zerion_provider;
         let conversion_provider = Arc::new(OneInchProvider::new(one_inch_api_key));
 
         let coinbase_pay_provider = Arc::new(CoinbaseProvider::new(
@@ -191,6 +194,7 @@ impl ProviderRepository {
             onramp_provider: coinbase_pay_provider,
             balance_provider,
             conversion_provider,
+            fungible_price_provider,
         }
     }
 
@@ -569,6 +573,16 @@ pub trait BalanceProvider: Send + Sync + Debug {
         params: BalanceQueryParams,
         http_client: reqwest::Client,
     ) -> RpcResult<BalanceResponseBody>;
+}
+
+#[async_trait]
+pub trait FungiblePriceProvider: Send + Sync + Debug {
+    async fn get_price(
+        &self,
+        address: &str,
+        currency: &PriceCurrencies,
+        http_client: reqwest::Client,
+    ) -> RpcResult<PriceResponseBody>;
 }
 
 #[async_trait]

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -512,6 +512,7 @@ impl FungiblePriceProvider for ZerionProvider {
     #[tracing::instrument(skip(self, http_client), fields(provider = "Zerion"))]
     async fn get_price(
         &self,
+        chain_id: &str,
         address: &str,
         currency: &PriceCurrencies,
         http_client: reqwest::Client,
@@ -521,6 +522,8 @@ impl FungiblePriceProvider for ZerionProvider {
         let currency = format!("{}", currency);
 
         url.query_pairs_mut().append_pair("currency", &currency);
+        url.query_pairs_mut()
+            .append_pair("filter[chain_id]", chain_id);
         url.query_pairs_mut()
             .append_pair("filter[implementation_address]", address);
 


### PR DESCRIPTION
# Description

This PR implements a fungible price endpoint according to the [SPEC proposal](https://walletconnect-specs-git-feat-tokenprices-walletconnect1.vercel.app/2.0/specs/servers/blockchain/blockchain-server-api#price) to get actual prices.
Since the API is compatible with different providers like Zerion and 1Inch, the Zerion provider adapter implementation was added.

## How Has This Been Tested?

* [New integration test](https://github.com/WalletConnect/blockchain-api/pull/608/files#diff-4493ff1a59d5bf63fc4e0b226e9908932f9c2ef71dafddf6ecf99f00c5739487).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
