### PR TITLE
fix: hardcode mainnet

### DIFF
--- a/src/analytics/identity_lookup_info.rs
+++ b/src/analytics/identity_lookup_info.rs
@@ -1,5 +1,5 @@
 use {
-    crate::handlers::{identity::IdentityLookupSource, RpcQueryParams},
+    crate::handlers::identity::{IdentityLookupSource, IdentityQueryParams},
     ethers::types::H160,
     parquet_derive::ParquetRecordWriter,
     serde::Serialize,
@@ -30,7 +30,7 @@ pub struct IdentityLookupInfo {
 impl IdentityLookupInfo {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        query_params: &RpcQueryParams,
+        query_params: &IdentityQueryParams,
         address: H160,
         name_present: bool,
         avatar_present: bool,
@@ -51,7 +51,7 @@ impl IdentityLookupInfo {
             latency_secs: latency.as_secs_f64(),
 
             project_id: query_params.project_id.to_owned(),
-            chain_id: query_params.chain_id.to_lowercase(),
+            chain_id: "1".to_string(),
 
             origin,
 

--- a/src/analytics/identity_lookup_info.rs
+++ b/src/analytics/identity_lookup_info.rs
@@ -1,5 +1,5 @@
 use {
-    crate::handlers::identity::{IdentityLookupSource, IdentityQueryParams},
+    crate::handlers::identity::{IdentityLookupSource, IdentityQueryParams, ETHEREUM_MAINNET},
     ethers::types::H160,
     parquet_derive::ParquetRecordWriter,
     serde::Serialize,
@@ -51,7 +51,7 @@ impl IdentityLookupInfo {
             latency_secs: latency.as_secs_f64(),
 
             project_id: query_params.project_id.to_owned(),
-            chain_id: "1".to_string(),
+            chain_id: ETHEREUM_MAINNET.to_owned(),
 
             origin,
 

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -44,7 +44,7 @@ pub struct IdentityResponse {
 pub async fn handler(
     state: State<Arc<AppState>>,
     connect_info: ConnectInfo<SocketAddr>,
-    query: Query<RpcQueryParams>,
+    query: Query<IdentityQueryParams>,
     path: MatchedPath,
     headers: HeaderMap,
     address: Path<String>,
@@ -58,7 +58,7 @@ pub async fn handler(
 async fn handler_internal(
     state: State<Arc<AppState>>,
     connect_info: ConnectInfo<SocketAddr>,
-    query: Query<RpcQueryParams>,
+    query: Query<IdentityQueryParams>,
     path: MatchedPath,
     headers: HeaderMap,
     Path(address): Path<String>,
@@ -139,12 +139,18 @@ impl IdentityLookupSource {
     }
 }
 
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityQueryParams {
+    pub project_id: String,
+}
+
 #[tracing::instrument(skip_all, level = "debug")]
 async fn lookup_identity(
     address: H160,
     state: State<Arc<AppState>>,
     connect_info: ConnectInfo<SocketAddr>,
-    Query(query): Query<RpcQueryParams>,
+    Query(query): Query<IdentityQueryParams>,
     path: MatchedPath,
     headers: HeaderMap,
 ) -> Result<(IdentityLookupSource, IdentityResponse), RpcError> {

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -196,6 +196,8 @@ async fn lookup_identity(
     Ok((IdentityLookupSource::Rpc, res))
 }
 
+pub const ETHEREUM_MAINNET: &str = "1";
+
 #[tracing::instrument(skip_all, level = "debug")]
 async fn lookup_identity_rpc(
     address: H160,
@@ -210,7 +212,8 @@ async fn lookup_identity_rpc(
         connect_info,
         query: Query(RpcQueryParams {
             project_id,
-            chain_id: "1".to_string(),
+            // ENS registry contract is only deployed on mainnet
+            chain_id: ETHEREUM_MAINNET.to_owned(),
             provider_id: None,
         }),
         path,


### PR DESCRIPTION
# Description

Since the ethers library uses a hardcoded registry contract address, it doesn't support non-mainnet resolution anyway. So hardcoding mainnet. Additionally, changing the query params that this endpoint accepts to just be projectId since the other parameters were for the RPC endpoint.

[Slack conversation](https://walletconnect.slack.com/archives/C03RVH94K5K/p1712418300123819?thread_ts=1712373328.103609&cid=C03RVH94K5K)

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
