### PR TITLE
feat(monitoring): using `3` minutes period for 5xx alerts

### DIFF
--- a/terraform/monitoring/panels/lb/error_5xx.libsonnet
+++ b/terraform/monitoring/panels/lb/error_5xx.libsonnet
@@ -23,14 +23,14 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
   message       = '%(env)s - 5XX alert'  % { env: grafana.utils.strings.capitalize(env) },
   notifications = notifications,
   noDataState   = 'no_data',
-  period        = '0m',
+  period        = '3m',
   conditions    = [
     grafana.alertCondition.new(
-      evaluatorParams = [ 2000 ],
+      evaluatorParams = [ 1000 ],
       evaluatorType   = 'gt',
       operatorType    = 'or',
       queryRefId      = 'ELB',
-      queryTimeStart  = '5m',
+      queryTimeStart  = '15m',
       queryTimeEnd    = 'now',
       reducerType     = grafana.alert_reducers.Avg
     ),
@@ -39,7 +39,7 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
       evaluatorType   = 'gt',
       operatorType    = 'or',
       queryRefId      = 'Target',
-      queryTimeStart  = '5m',
+      queryTimeStart  = '15m',
       queryTimeEnd    = 'now',
       reducerType     = grafana.alert_reducers.Avg
     ),


### PR DESCRIPTION
# Description

This PR increases the period from `0` to `3` minutes for `5xx` alerts monitoring and decreases the alert threshold to `1000`.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
