### PR TITLE
fix(Docker): adding `curl` to the Docker runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ ENV                 RPC_PROXY_HOST=0.0.0.0
 WORKDIR             /app
 COPY --from=build   /app/target/${binpath:-debug}/rpc-proxy /usr/local/bin/rpc-proxy
 RUN                 apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates libssl-dev \
+    && apt-get install -y --no-install-recommends ca-certificates libssl-dev curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
# Description

This PR adds `curl` to the service runtime Docker image. The `curl` will be used for the ECS Container health check command by using `curl -sS http://localhost:8080/health || exit 1` in the ECS configuration.

## How Has This Been Tested?

Built the Docker image locally.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
