### PR TITLE
fix(server): decreasing keep-alive intervals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,8 +77,8 @@ use {
 };
 
 const SERVICE_TASK_TIMEOUT: Duration = Duration::from_secs(15);
-const KEEPALIVE_IDLE_DURATION: Duration = Duration::from_secs(65);
-const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(65);
+const KEEPALIVE_IDLE_DURATION: Duration = Duration::from_secs(60);
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 const KEEPALIVE_RETRIES: u32 = 1;
 
 mod analytics;


### PR DESCRIPTION
# Description

This PR decreases the keep-alive intervals.
The keep-alive ping interval should logically be shorter than the keep-alive timeout. 
We have the same now and this might risk the connection being closed just as a keep-alive message is sent to the ALB, which defeats the purpose of detecting whether the connection is still active.
The keep-alive ping interval is set to `10` seconds.
The idle timeout also decreased to `60` seconds to align with the ALB settings.

## How Has This Been Tested?

*Not tested (can't be tested without deploying to the at least staging).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
