### PR TITLE
fix(server): enabling `tcp_nodelay` and `tcp_sleep_on_accept_errors`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ use {
 const SERVICE_TASK_TIMEOUT: Duration = Duration::from_secs(15);
 const KEEPALIVE_IDLE_DURATION: Duration = Duration::from_secs(60);
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
-const KEEPALIVE_RETRIES: u32 = 1;
+const KEEPALIVE_RETRIES: u32 = 5;
 
 mod analytics;
 pub mod database;
@@ -433,7 +433,8 @@ fn create_server(
         .tcp_keepalive(Some(KEEPALIVE_IDLE_DURATION))
         .tcp_keepalive_interval(Some(KEEPALIVE_INTERVAL))
         .tcp_keepalive_retries(Some(KEEPALIVE_RETRIES))
-        .tcp_sleep_on_accept_errors(false)
+        .tcp_sleep_on_accept_errors(true)
+        .tcp_nodelay(true)
         .serve(app.into_make_service_with_connect_info::<SocketAddr>())
 }
 


### PR DESCRIPTION
# Description

This PR making the following changes:
* Enables `tcp_nodelay` for a lower latency (this means data is sent immediately over the network without waiting for the buffer to fill or for an acknowledgment of previously sent data).
* Enables `tcp_sleep_on_accept_errors` to log errors if there are no unix sockets available and wait other than just silently shutdowns. So we can catch the exact error if this happens.
* Increasing retrying for keep-alive from 1 to 5.

## How Has This Been Tested?

* Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
