### PR TITLE
fix(identity): handling properly errors in RPC call response

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -125,6 +125,12 @@ pub enum RpcError {
     #[error("invalid parameter: {0}")]
     InvalidParameter(String),
 
+    #[error("contract execution reverted")]
+    ContractExecutionReverted,
+
+    #[error("method not allowed: {0}")]
+    MethodNotAllowed(String),
+
     // Profile names errors
     #[error("Name is already registered: {0}")]
     NameAlreadyRegistered(String),
@@ -252,6 +258,22 @@ impl IntoResponse for RpcError {
                 .into_response(),
             Self::InvalidParameter(e) => (
                 StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "".to_string(),
+                    format!("Invalid parameter: {}", e),
+                )),
+            )
+                .into_response(),
+            Self::ContractExecutionReverted => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "".to_string(),
+                    "Contract returned execution reverted".to_string(),
+                )),
+            )
+                .into_response(),
+            Self::MethodNotAllowed(e) => (
+                StatusCode::METHOD_NOT_ALLOWED,
                 Json(new_error_response(
                     "".to_string(),
                     format!("Invalid parameter: {}", e),

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,12 +125,6 @@ pub enum RpcError {
     #[error("invalid parameter: {0}")]
     InvalidParameter(String),
 
-    #[error("contract execution reverted")]
-    ContractExecutionReverted,
-
-    #[error("method not allowed: {0}")]
-    MethodNotAllowed(String),
-
     // Profile names errors
     #[error("Name is already registered: {0}")]
     NameAlreadyRegistered(String),
@@ -258,22 +252,6 @@ impl IntoResponse for RpcError {
                 .into_response(),
             Self::InvalidParameter(e) => (
                 StatusCode::BAD_REQUEST,
-                Json(new_error_response(
-                    "".to_string(),
-                    format!("Invalid parameter: {}", e),
-                )),
-            )
-                .into_response(),
-            Self::ContractExecutionReverted => (
-                StatusCode::BAD_REQUEST,
-                Json(new_error_response(
-                    "".to_string(),
-                    "Contract returned execution reverted".to_string(),
-                )),
-            )
-                .into_response(),
-            Self::MethodNotAllowed(e) => (
-                StatusCode::METHOD_NOT_ALLOWED,
                 Json(new_error_response(
                     "".to_string(),
                     format!("Invalid parameter: {}", e),

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -243,17 +243,27 @@ async fn lookup_name(
     address: Address,
 ) -> Result<Option<String>, RpcError> {
     provider.lookup_address(address).await.map_or_else(
-        |e| match e {
-            ProviderError::CustomError(e)
-                if &e == "SelfProviderError: RpcError: ProjectDataError(NotFound)" =>
-            {
-                Err(RpcError::ProjectDataError(ProjectDataError::NotFound))
+        |error| match error {
+            ProviderError::CustomError(e) if e.starts_with(SELF_PROVIDER_ERROR_PREFIX) => {
+                let error_detail = e.trim_start_matches(SELF_PROVIDER_ERROR_PREFIX);
+                // Exceptions for the detailed HTTP error return on RPC call
+                if error_detail.contains("ProjectDataError(NotFound)") {
+                    Err(RpcError::ProjectDataError(ProjectDataError::NotFound))
+                } else if error_detail.contains("QuotaLimitReached") {
+                    Err(RpcError::QuotaLimitReached)
+                } else {
+                    Err(RpcError::NameLookup(error_detail.to_string()))
+                }
             }
-            ProviderError::CustomError(e) if e.starts_with(SELF_PROVIDER_ERROR_PREFIX) => Err(
-                RpcError::NameLookup(e[SELF_PROVIDER_ERROR_PREFIX.len()..].to_string()),
-            ),
-            e => {
-                debug!("Error while looking up name: {e:?}");
+            ProviderError::CustomError(e) => {
+                debug!("Error while looking up name: {:?}", e);
+                Ok(None)
+            }
+            _ => {
+                debug!(
+                    "Non-matching provider error while looking up name: {:?}",
+                    error
+                );
                 Ok(None)
             }
         },

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -251,6 +251,14 @@ async fn lookup_name(
                     Err(RpcError::ProjectDataError(ProjectDataError::NotFound))
                 } else if error_detail.contains("QuotaLimitReached") {
                     Err(RpcError::QuotaLimitReached)
+                } else if error_detail.contains("503 Service Unavailable") {
+                    Err(RpcError::ProviderError)
+                } else if error_detail.contains("405 Method Not Allowed JSON-RPC result is 0x") {
+                    Err(RpcError::MethodNotAllowed(
+                        "JSON-RPC result is 0x".to_string(),
+                    ))
+                } else if error_detail.contains("execution reverted") {
+                    Err(RpcError::ContractExecutionReverted)
                 } else {
                     Err(RpcError::NameLookup(error_detail.to_string()))
                 }

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -253,18 +253,12 @@ async fn lookup_name(
                     Err(RpcError::QuotaLimitReached)
                 } else if error_detail.contains("503 Service Unavailable") {
                     Err(RpcError::ProviderError)
-                } else if error_detail.contains("405 Method Not Allowed JSON-RPC result is 0x") {
-                    Err(RpcError::MethodNotAllowed(
-                        "JSON-RPC result is 0x".to_string(),
-                    ))
-                } else if error_detail.contains("execution reverted") {
-                    Err(RpcError::ContractExecutionReverted)
                 } else {
                     Err(RpcError::NameLookup(error_detail.to_string()))
                 }
             }
             ProviderError::CustomError(e) => {
-                debug!("Error while looking up name: {:?}", e);
+                debug!("Custom error while looking up name: {:?}", e);
                 Ok(None)
             }
             _ => {


### PR DESCRIPTION
# Description

This PR adds a proper handling of the following errors from the RPC call during the identity lookup:

* `Project Quota`: We have a lot of `HTTP 500` errors with the `NameLookup("RpcError: QuotaLimitReached")` message that should be returned as `HTTP 429`.
* `503 Service Unavailable`: When the RPC provider is unavailable.

All of the above errors are HTTP 500 now and should be distinguished.

## How Has This Been Tested?

* Current integration tests cover the good and bad names resolution. Quota limiting can't be tested as we have high quotas in prod.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
