### PR TITLE
fix(identity): proper RPC errors handling in avatar lookup

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -107,11 +107,8 @@ pub enum RpcError {
     #[error("Failed to parse provider cursor")]
     HistoryParseCursorError,
 
-    #[error("Name lookup error: {0}")]
-    NameLookup(String),
-
-    #[error("Avatar lookup error: {0}")]
-    AvatarLookup(String),
+    #[error("Identity lookup error: {0}")]
+    IdentityLookup(String),
 
     #[error("Quota limit reached")]
     QuotaLimitReached,


### PR DESCRIPTION
# Description

This PR adds proper RPC call error handling during the avatar lookup in the identity endpoint. The error handling for the avatar RPC lookup is the same as for the name lookup, so the handling flow was consolidated into the function. Two different errors `NameLookup` and `AvatarLookup` were consolidated into one `IdentityLookup`. The source of the call of `IdentityLookup` error can be traced using the tracing `instrument` so we don't need two different errors.

## How Has This Been Tested?

* Start the server locally and run identity lookup. The error handling was as expected.
* Current integration tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
