### PR TITLE
fix(identity): hardcode ethereum mainnet

### DIFF
--- a/integration/identity.test.ts
+++ b/integration/identity.test.ts
@@ -7,7 +7,7 @@ describe('Identity', () => {
 
   it('known ens with the cache enabled (default)', async () => {
     let resp: any = await httpClient.get(
-      `${baseUrl}/v1/identity/${knownAddress}?chainId=eip155%3A1&projectId=${projectId}`,
+      `${baseUrl}/v1/identity/${knownAddress}?projectId=${projectId}`,
     )
     expect(resp.status).toBe(200)
     expect(resp.data.name).toBe('cyberdrk.eth')
@@ -29,7 +29,7 @@ describe('Identity', () => {
   })
   it('unknown ens', async () => {
     let resp: any = await httpClient.get(
-      `${baseUrl}/v1/identity/${unknownAddress}?chainId=eip155%3A1&projectId=${projectId}`,
+      `${baseUrl}/v1/identity/${unknownAddress}?projectId=${projectId}`,
     )
     expect(resp.status).toBe(200)
     expect(resp.data.name).toBe(null)

--- a/src/analytics/identity_lookup_info.rs
+++ b/src/analytics/identity_lookup_info.rs
@@ -1,5 +1,5 @@
 use {
-    crate::handlers::{identity::IdentityLookupSource, RpcQueryParams},
+    crate::handlers::identity::{IdentityLookupSource, IdentityQueryParams, ETHEREUM_MAINNET},
     ethers::types::H160,
     parquet_derive::ParquetRecordWriter,
     serde::Serialize,
@@ -30,7 +30,7 @@ pub struct IdentityLookupInfo {
 impl IdentityLookupInfo {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        query_params: &RpcQueryParams,
+        query_params: &IdentityQueryParams,
         address: H160,
         name_present: bool,
         avatar_present: bool,
@@ -51,7 +51,7 @@ impl IdentityLookupInfo {
             latency_secs: latency.as_secs_f64(),
 
             project_id: query_params.project_id.to_owned(),
-            chain_id: query_params.chain_id.to_lowercase(),
+            chain_id: ETHEREUM_MAINNET.to_owned(),
 
             origin,
 

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -34,6 +34,7 @@ use {
 
 const SELF_PROVIDER_ERROR_PREFIX: &str = "SelfProviderError: ";
 const EMPTY_RPC_RESPONSE: &str = "0x";
+pub const ETHEREUM_MAINNET: &str = "eip155:1";
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -222,8 +223,6 @@ async fn lookup_identity(
 
     Ok((IdentityLookupSource::Rpc, res))
 }
-
-pub const ETHEREUM_MAINNET: &str = "1";
 
 #[tracing::instrument(skip_all, level = "debug")]
 async fn lookup_identity_rpc(

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -145,6 +145,9 @@ impl IdentityLookupSource {
 #[serde(rename_all = "camelCase")]
 pub struct IdentityQueryParams {
     pub project_id: String,
+    /// Optional flag to control the cache to fetch the data from the provider
+    /// or serve from the cache where applicable
+    pub use_cache: Option<bool>,
 }
 
 #[tracing::instrument(skip_all, level = "debug")]

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -36,9 +36,6 @@ pub struct RpcQueryParams {
     pub project_id: String,
     /// Optional provider ID for the exact provider request
     pub provider_id: Option<String>,
-    /// Optional flag to control the cache to fetch the data from the provider
-    /// or serve from the cache where applicable
-    pub use_cache: Option<bool>,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
# Description

This PR is the reopened #610 with the tiny fix of the mainnet in CAIP-2 format and updated integration test.

## How Has This Been Tested?

* Started the server locally. Run the identity lookup with the wrong `chainId` and without `chainId` query argument. The result was a successful lookup response.

## Merging policy 🚧

* [ ] Merge the updated integration test in https://github.com/WalletConnect/blockchain-api/pull/619 first.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
