### PR TITLE
feat(rpc): adding rpc call retrying

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -161,6 +161,9 @@ pub enum RpcError {
 
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
+
+    #[error("Weighted providers index error: {0}")]
+    WeightedProvidersIndex(String),
 }
 
 impl IntoResponse for RpcError {

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -20,11 +20,13 @@ use {
     },
     tap::TapFallible,
     tracing::{
-        log::{error, warn},
+        log::{debug, error, warn},
         Span,
     },
     wc::future::FutureExt,
 };
+
+const RPC_MAX_RETRIES: usize = 3;
 
 pub async fn handler(
     state: State<Arc<AppState>>,
@@ -56,12 +58,12 @@ async fn handler_internal(
 
     // Exact provider proxy request for testing suite
     // This request is allowed only for the RPC_PROXY_TESTING_PROJECT_ID
-    let provider = match query_params.provider_id.clone() {
+    let providers = match query_params.provider_id.clone() {
         Some(provider_id) => {
-            let provider = state
+            let provider = vec![state
                 .providers
                 .get_provider_by_provider_id(&provider_id)
-                .ok_or_else(|| RpcError::UnsupportedProvider(provider_id.clone()))?;
+                .ok_or_else(|| RpcError::UnsupportedProvider(provider_id.clone()))?];
 
             if let Some(ref testing_project_id) = state.config.server.testing_project_id {
                 if !crypto::constant_time_eq(testing_project_id, &query_params.project_id) {
@@ -79,9 +81,55 @@ async fn handler_internal(
 
             provider
         }
-        None => state.providers.get_provider_for_chain_id(&chain_id)?,
+        None => state
+            .providers
+            .get_provider_for_chain_id(&chain_id, RPC_MAX_RETRIES)?,
     };
 
+    for provider in providers {
+        let response = rpc_call(
+            state.clone(),
+            addr,
+            query_params.clone(),
+            headers.clone(),
+            body.clone(),
+            chain_id.clone(),
+            provider.clone(),
+        )
+        .await;
+
+        match response {
+            Ok(response) => {
+                // If the response is a 503 (we are rate-limited) we should try the next
+                // provider
+                if response.status() == http::StatusCode::SERVICE_UNAVAILABLE {
+                    debug!(
+                        "Provider '{}' returned a 503, trying the next provider",
+                        provider.provider_kind()
+                    );
+                    continue;
+                }
+                return Ok(response);
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        }
+    }
+    debug!("All providers failed for chain_id: {}", chain_id);
+    Err(RpcError::ChainTemporarilyUnavailable(chain_id))
+}
+
+#[tracing::instrument(skip(state), level = "debug")]
+pub async fn rpc_call(
+    state: Arc<AppState>,
+    addr: SocketAddr,
+    query_params: RpcQueryParams,
+    headers: HeaderMap,
+    body: Bytes,
+    chain_id: String,
+    provider: Arc<dyn crate::providers::RpcProvider>,
+) -> Result<Response, RpcError> {
     Span::current().record("provider", &provider.provider_kind().to_string());
 
     state.metrics.add_rpc_call(chain_id.clone());

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -86,7 +86,7 @@ async fn handler_internal(
             .get_provider_for_chain_id(&chain_id, RPC_MAX_RETRIES)?,
     };
 
-    for provider in providers {
+    for (i, provider) in providers.iter().enumerate() {
         let response = rpc_call(
             state.clone(),
             addr,
@@ -109,9 +109,11 @@ async fn handler_internal(
                     );
                     continue;
                 }
+                state.metrics.add_rpc_call_retries(i as u64, chain_id);
                 return Ok(response);
             }
             Err(e) => {
+                state.metrics.add_rpc_call_retries(i as u64, chain_id);
                 return Err(e);
             }
         }


### PR DESCRIPTION
# Description

This PR implements a retrying mechanism for RPC calls. This should be useful for the user experience when one of the providers returns a `rate-limited` error and we can retry up to max retries (currently is `3`) or fall with the appropriate error if all providers are rate-limited.

Metrics for attempts per chain ID are also added.

Resolve #265 and #452 

## How Has This Been Tested?

* Integration and provider tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
