### PR TITLE
fix(providers): removing Goerli and Polygon Mumbai chains

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -7,7 +7,6 @@ Chain name with associated `chainId` query param to use.
 | Network                                                  | Chain ID             |
 |----------------------------------------------------------|----------------------|
 | Ethereum                                                 | eip155:1             |
-| Ethereum Goerli                                          | eip155:5             |
 | Optimism                                                 | eip155:10            |
 | Binance Smart Chain                                      | eip155:56            |
 | Binance Smart Chain Testnet <sup>[1](#footnote1)</sup>   | eip155:97            |
@@ -25,7 +24,6 @@ Chain name with associated `chainId` query param to use.
 | Celo                                                     | eip155:42220         |
 | Avalanche Fuji Testnet <sup>[1](#footnote1)</sup>        | eip155:43113         |
 | Avalanche C-Chain                                        | eip155:43114         |
-| Polygon Mumbai                                           | eip155:80001         |
 | Base Sepolia                                             | eip155:84532         |
 | Arbitrum Sepolia                                         | eip155:421614        |
 | Zora <sup>[1](#footnote1)</sup>                          | eip155:7777777       |
@@ -46,7 +44,6 @@ WebSocket RPC **is not recommended for production use**, and may be removed in t
 | Network            | Chain ID        |
 |--------------------|-----------------|
 | Ethereum           | eip155:1        |
-| Ethereum Goerli    | eip155:5        |
 | Optimism           | eip155:10       |
 | Arbitrum           | eip155:42161    |
 | Arbitrum Sepolia   | eip155:421614   |

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -47,10 +47,6 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             ("mainnet".into(), Weight::new(Priority::Max).unwrap()),
         ),
         (
-            "eip155:5".into(),
-            ("goerli".into(), Weight::new(Priority::Normal).unwrap()),
-        ),
-        (
             "eip155:11155111".into(),
             ("sepolia".into(), Weight::new(Priority::Normal).unwrap()),
         ),
@@ -92,13 +88,6 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::High).unwrap(),
             ),
         ),
-        (
-            "eip155:80001".into(),
-            (
-                "polygon-mumbai".into(),
-                Weight::new(Priority::Normal).unwrap(),
-            ),
-        ),
         // Celo
         (
             "eip155:42220".into(),
@@ -118,10 +107,6 @@ fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
         (
             "eip155:1".into(),
             ("mainnet".into(), Weight::new(Priority::Normal).unwrap()),
-        ),
-        (
-            "eip155:5".into(),
-            ("goerli".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         (
             "eip155:11155111".into(),

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -84,14 +84,6 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:137".into(),
             ("polygon-bor".into(), Weight::new(Priority::Normal).unwrap()),
         ),
-        // Polygon bor testnet
-        (
-            "eip155:80001".into(),
-            (
-                "polygon-mumbai-bor".into(),
-                Weight::new(Priority::High).unwrap(),
-            ),
-        ),
         // Mantle mainnet
         (
             "eip155:5000".into(),

--- a/tests/functional/http/infura.rs
+++ b/tests/functional/http/infura.rs
@@ -18,15 +18,6 @@ async fn infura_provider(ctx: &mut ServerContext) {
     )
     .await;
 
-    // Ethereum Goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &ProviderKind::Infura,
-        "eip155:5",
-        "0x5",
-    )
-    .await;
-
     // Ethereum Sepolia
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
@@ -42,15 +33,6 @@ async fn infura_provider(ctx: &mut ServerContext) {
         &ProviderKind::Infura,
         "eip155:137",
         "0x89",
-    )
-    .await;
-
-    // Polygon mumbai
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &ProviderKind::Infura,
-        "eip155:80001",
-        "0x13881",
     )
     .await;
 
@@ -81,7 +63,7 @@ async fn infura_provider(ctx: &mut ServerContext) {
     )
     .await;
 
-    // Arbitrum goerli
+    // Arbitrum Sepolia
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
         &ProviderKind::Infura,

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -81,15 +81,6 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
     )
     .await;
 
-    // Polygon mumbai
-    check_if_rpc_is_responding_correctly_for_supported_chain(
-        ctx,
-        &ProviderKind::Publicnode,
-        "eip155:80001",
-        "0x13881",
-    )
-    .await;
-
     // Mantle mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,

--- a/tests/functional/websocket/infura.rs
+++ b/tests/functional/websocket/infura.rs
@@ -11,19 +11,16 @@ async fn infura_provider_websocket(ctx: &mut ServerContext) {
     // Ethereum mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:1", "0x1").await;
 
-    // Goerli
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:5", "0x5").await;
-
     // Optimism mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:10", "0xa").await;
 
-    // Optimism goerli
+    // Optimism Sepolia
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:11155420", "0xaa37dc")
         .await;
 
     // Arbitrum mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:42161", "0xa4b1").await;
 
-    // Arbitrum goerli
+    // Arbitrum Sepolia
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:421614", "0x66eee").await;
 }


### PR DESCRIPTION
# Description

This PR removing Ethereum Goerli and Polygon Mumbai testnets, [as they are sunsetted on April 13](https://blog.ethereum.org/2023/11/30/goerli-lts-update). 

## How Has This Been Tested?

* Updated providers tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
