### PR TITLE
feat(providers): adding Linea mainnet to supported chains

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -24,6 +24,7 @@ Chain name with associated `chainId` query param to use.
 | Celo                                                     | eip155:42220         |
 | Avalanche Fuji Testnet <sup>[1](#footnote1)</sup>        | eip155:43113         |
 | Avalanche C-Chain                                        | eip155:43114         |
+| Linea <sup>[1](#footnote1)</sup>                         | eip155:59144         |
 | Base Sepolia                                             | eip155:84532         |
 | Arbitrum Sepolia                                         | eip155:421614        |
 | Zora <sup>[1](#footnote1)</sup>                          | eip155:7777777       |

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -96,6 +96,14 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Linea Mainnet
+        (
+            "eip155:59144".into(),
+            (
+                "linea-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
     ])
 }
 

--- a/tests/functional/http/infura.rs
+++ b/tests/functional/http/infura.rs
@@ -80,4 +80,13 @@ async fn infura_provider(ctx: &mut ServerContext) {
         "0xa4ec",
     )
     .await;
+
+    // Linea Mainnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Infura,
+        "eip155:59144",
+        "0xe708",
+    )
+    .await;
 }


### PR DESCRIPTION
# Description

This PR adds the Linea Mainnet chain to our supported chains.
The full context of the [request for the Linea chain](https://walletconnect.slack.com/archives/C03SCF66K2T/p1712580939102439).

## How Has This Been Tested?

* Updated Infura provider test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
