### PR TITLE
fix(providers): removing zkSync Goerli testnet, adding Sepolia instead

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -12,7 +12,7 @@ Chain name with associated `chainId` query param to use.
 | Binance Smart Chain Testnet <sup>[1](#footnote1)</sup>   | eip155:97            |
 | Gnosis Chain                                             | eip155:100           |
 | Polygon                                                  | eip155:137           |
-| zkSync Era Testnet <sup>[1](#footnote1)</sup>            | eip155:280           |
+| zkSync Era Sepolia Testnet <sup>[1](#footnote1)</sup>    | eip155:300           |
 | zkSync Era                                               | eip155:324           |
 | Polygon Zkevm                                            | eip155:1101          |
 | Mantle <sup>[1](#footnote1)</sup>                        | eip155:5000          |

--- a/src/env/zksync.rs
+++ b/src/env/zksync.rs
@@ -35,11 +35,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
     // Keep in-sync with SUPPORTED_CHAINS.md
 
     HashMap::from([
-        // zkSync Testnet
+        // zkSync Sepolia Testnet
         (
-            "eip155:280".into(),
+            "eip155:300".into(),
             (
-                "https://zksync2-testnet.zksync.dev".into(),
+                "https://sepolia.era.zksync.dev".into(),
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),

--- a/tests/functional/http/zksync.rs
+++ b/tests/functional/http/zksync.rs
@@ -18,12 +18,12 @@ async fn zksync_provider_eip155_324_and_280(ctx: &mut ServerContext) {
     )
     .await;
 
-    // ZkSync testnet
+    // ZkSync Sepolia testnet
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
         &ProviderKind::ZKSync,
-        "eip155:280",
-        "0x118",
+        "eip155:300",
+        "0x12c",
     )
     .await
 }


### PR DESCRIPTION
# Description

This PR removes zkSync Goerli testnet chain `eip155:280` and adds zkSync Sepolia Testnet `eip155:300` because of the Goerli deprecation. [zkSync endpoints docs](https://docs.zksync.io/build/api.html#rpc-endpoint-urls).

## How Has This Been Tested?

* Updated provider test.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
