### PR TITLE
fix(weights): excluding zero weight providers from iteration

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -213,11 +213,12 @@ impl ProviderRepository {
         }
 
         let weights: Vec<_> = providers.iter().map(|(_, weight)| weight.value()).collect();
+        let non_zero_weight_providers = weights.iter().filter(|&x| *x > 0).count();
         let keys = providers.keys().cloned().collect::<Vec<_>>();
 
         match WeightedIndex::new(weights) {
             Ok(mut dist) => {
-                let providers_to_iterate = std::cmp::min(max_providers, providers.len());
+                let providers_to_iterate = std::cmp::min(max_providers, non_zero_weight_providers);
                 let providers_result = (0..providers_to_iterate)
                     .map(|i| {
                         let dist_key = dist.sample(&mut OsRng);


### PR DESCRIPTION
# Description

This PR updates #624 with the minor fix to exclude zero-weighted providers from the iteration count, as it doesn't make sense to make additional iterations for zero-weighted providers during the sampling.

## How Has This Been Tested?

1. Manually tuned to zero-weight a few providers for a certain chain ID,
2. Run rpc call for the certain chain ID,
3. The number of iterations during the sampling is equal to the non-zero weighted providers count.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
