### PR TITLE
fix(tests): fixing error code in identity test with wrong project ID

### DIFF
--- a/integration/identity.test.ts
+++ b/integration/identity.test.ts
@@ -25,7 +25,7 @@ describe('Identity', () => {
     resp = await httpClient.get(
       `${baseUrl}/v1/identity/${knownAddress}?chainId=eip155%3A1&projectId=${notAllowedProjectId}&useCache=false`,
     )
-    expect(resp.status).toBe(400)
+    expect(resp.status).toBe(401)
   })
   it('unknown ens', async () => {
     let resp: any = await httpClient.get(


### PR DESCRIPTION
# Description

This PR changes the error code to `HTTP 401` in the identity integration test when the project ID is wrong. PR #623 changed the order of project ID validation to fail early, this PR made a change to the integration tests.

## How Has This Been Tested?

* Run the identity integration tests locally.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
