### PR TITLE
feat: adding sdk type and version to CORS allowed headers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,8 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         http::header::ACCESS_CONTROL_REQUEST_HEADERS,
         HeaderName::from_static("solana-client"),
         HeaderName::from_static("sec-fetch-mode"),
+        HeaderName::from_static("x-sdk-type"),
+        HeaderName::from_static("x-sdk-version"),
     ]);
 
     let proxy_state = state_arc.clone();


### PR DESCRIPTION
# Description

This PR adds `x-sdk-type` and `x-sdk-version` headers to CORS allowed headers list.
This is useful for different behaviors based on the client SDK version. Currently, we need to make an exception for the certain SDK-version for the balances endpoint.

## How Has This Been Tested?

* Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
