### PR TITLE
feat(analytics): adding analytics for balance lookups

### DIFF
--- a/src/analytics/balance_lookup_info.rs
+++ b/src/analytics/balance_lookup_info.rs
@@ -1,0 +1,51 @@
+use {
+    parquet_derive::ParquetRecordWriter,
+    serde::Serialize,
+    std::{sync::Arc, time::Duration},
+};
+
+#[derive(Debug, Clone, Serialize, ParquetRecordWriter)]
+#[serde(rename_all = "camelCase")]
+pub struct BalanceLookupInfo {
+    pub timestamp: chrono::NaiveDateTime,
+    pub latency_secs: f64,
+
+    pub symbol: String,
+    pub quantity: String,
+
+    pub address: String,
+    pub project_id: String,
+
+    pub origin: Option<String>,
+    pub region: Option<String>,
+    pub country: Option<Arc<str>>,
+    pub continent: Option<Arc<str>>,
+}
+
+impl BalanceLookupInfo {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        latency: Duration,
+        symbol: String,
+        quantity: String,
+        address: String,
+        project_id: String,
+        origin: Option<String>,
+        region: Option<Vec<String>>,
+        country: Option<Arc<str>>,
+        continent: Option<Arc<str>>,
+    ) -> Self {
+        Self {
+            timestamp: wc::analytics::time::now(),
+            latency_secs: latency.as_secs_f64(),
+            symbol,
+            quantity,
+            address,
+            project_id,
+            origin,
+            region: region.map(|r| r.join(", ")),
+            country,
+            continent,
+        }
+    }
+}

--- a/src/analytics/balance_lookup_info.rs
+++ b/src/analytics/balance_lookup_info.rs
@@ -15,6 +15,7 @@ pub struct BalanceLookupInfo {
     pub quantity: String,
     pub value: f64,
     pub price: f64,
+    pub currency: String,
 
     pub address: String,
     pub project_id: String,
@@ -34,6 +35,7 @@ impl BalanceLookupInfo {
         quantity: String,
         value: f64,
         price: f64,
+        currency: String,
         address: String,
         project_id: String,
         origin: Option<String>,
@@ -49,6 +51,7 @@ impl BalanceLookupInfo {
             quantity,
             value,
             price,
+            currency,
             address,
             project_id,
             origin,

--- a/src/analytics/balance_lookup_info.rs
+++ b/src/analytics/balance_lookup_info.rs
@@ -11,7 +11,10 @@ pub struct BalanceLookupInfo {
     pub latency_secs: f64,
 
     pub symbol: String,
+    pub implementation_chain_id: String,
     pub quantity: String,
+    pub value: f64,
+    pub price: f64,
 
     pub address: String,
     pub project_id: String,
@@ -27,7 +30,10 @@ impl BalanceLookupInfo {
     pub fn new(
         latency: Duration,
         symbol: String,
+        implementation_chain_id: String,
         quantity: String,
+        value: f64,
+        price: f64,
         address: String,
         project_id: String,
         origin: Option<String>,
@@ -39,7 +45,10 @@ impl BalanceLookupInfo {
             timestamp: wc::analytics::time::now(),
             latency_secs: latency.as_secs_f64(),
             symbol,
+            implementation_chain_id,
             quantity,
+            value,
+            price,
             address,
             project_id,
             origin,

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -125,7 +125,7 @@ async fn handler_internal(
     let response = state
         .providers
         .balance_provider
-        .get_balance(address.clone(), query.0, state.http_client.clone())
+        .get_balance(address.clone(), query.clone().0, state.http_client.clone())
         .await
         .tap_err(|e| {
             error!("Failed to call balance with {}", e);
@@ -152,6 +152,7 @@ async fn handler_internal(
                 balance.quantity.numeric.clone(),
                 balance.value.unwrap_or(0 as f64),
                 balance.price,
+                query.currency.to_string(),
                 address.clone(),
                 project_id.clone(),
                 origin.clone(),

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -1,15 +1,20 @@
 use {
     super::HANDLER_TASK_METRICS,
-    crate::{error::RpcError, state::AppState},
+    crate::{analytics::BalanceLookupInfo, error::RpcError, state::AppState, utils::network},
     axum::{
-        extract::{Path, Query, State},
+        extract::{ConnectInfo, Path, Query, State},
         response::{IntoResponse, Response},
         Json,
     },
     ethers::abi::Address,
     hyper::HeaderMap,
     serde::{Deserialize, Serialize},
-    std::{fmt::Display, sync::Arc},
+    std::{
+        fmt::Display,
+        net::SocketAddr,
+        sync::Arc,
+        time::{Duration, SystemTime},
+    },
     tap::TapFallible,
     tracing::log::error,
     wc::future::FutureExt,
@@ -85,10 +90,11 @@ pub struct BalanceQuantity {
 pub async fn handler(
     state: State<Arc<AppState>>,
     query: Query<BalanceQueryParams>,
+    connect_info: ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     address: Path<String>,
 ) -> Result<Response, RpcError> {
-    handler_internal(state, query, headers, address)
+    handler_internal(state, query, connect_info, headers, address)
         .with_metrics(HANDLER_TASK_METRICS.with_name("balance"))
         .await
 }
@@ -97,6 +103,7 @@ pub async fn handler(
 async fn handler_internal(
     state: State<Arc<AppState>>,
     query: Query<BalanceQueryParams>,
+    connect_info: ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Path(address): Path<String>,
 ) -> Result<Response, RpcError> {
@@ -114,14 +121,43 @@ async fn handler_internal(
         return Ok(Json(BalanceResponseBody { balances: vec![] }).into_response());
     }
 
+    let start = SystemTime::now();
     let response = state
         .providers
         .balance_provider
-        .get_balance(address, query.0, state.http_client.clone())
+        .get_balance(address.clone(), query.0, state.http_client.clone())
         .await
         .tap_err(|e| {
             error!("Failed to call balance with {}", e);
         })?;
+    let latency = start.elapsed().unwrap_or(Duration::from_secs(0));
+
+    {
+        let origin = headers
+            .get("origin")
+            .map(|v| v.to_str().unwrap_or("invalid_header").to_string());
+
+        let (country, continent, region) = state
+            .analytics
+            .lookup_geo_data(
+                network::get_forwarded_ip(headers).unwrap_or_else(|| connect_info.0.ip()),
+            )
+            .map(|geo| (geo.country, geo.continent, geo.region))
+            .unwrap_or((None, None, None));
+        for balance in &response.balances {
+            state.analytics.balance_lookup(BalanceLookupInfo::new(
+                latency,
+                balance.symbol.clone(),
+                balance.quantity.numeric.clone(),
+                address.clone(),
+                project_id.clone(),
+                origin.clone(),
+                region.clone(),
+                country.clone(),
+                continent.clone(),
+            ));
+        }
+    }
 
     Ok(Json(response).into_response())
 }

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -148,7 +148,10 @@ async fn handler_internal(
             state.analytics.balance_lookup(BalanceLookupInfo::new(
                 latency,
                 balance.symbol.clone(),
+                balance.chain_id.clone().unwrap_or_default(),
                 balance.quantity.numeric.clone(),
+                balance.value.unwrap_or(0 as f64),
+                balance.price,
                 address.clone(),
                 project_id.clone(),
                 origin.clone(),


### PR DESCRIPTION
# Description

This PR adds analytics export for balance lookups with the following analytics item structure:

* timestamp,
* latency,
* symbol (token symbol),
* implementation chain ID
* quantity (token quantity according to decimals),
* value
* price
* currency
* address (lookup address)
* project_id,
* origin,
* region,
* country,
* continent.

Analytics export_prefix: `blockchain-api/balance-lookups`, export_name: `balance_lookups`.

## How Has This Been Tested?

* Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
