### PR TITLE
fix(conversion): changing amounts to `String`

### DIFF
--- a/integration/convert.test.ts
+++ b/integration/convert.test.ts
@@ -10,7 +10,7 @@ describe('Token conversion (single chain)', () => {
   const srcAsset = `${namespace}:${chainId}:0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`;
   const destAsset = `${namespace}:${chainId}:0x111111111117dc0aa78b770fa6a738034120c302`;
   const userAddress = `${namespace}:${chainId}:0xf3ea39310011333095cfcccc7c4ad74034caba63`;
-  const amount = 100000;
+  const amount = "100000";
 
   it('available tokens list', async () => {
     let resp: any = await httpClient.get(

--- a/src/handlers/convert/approve.rs
+++ b/src/handlers/convert/approve.rs
@@ -17,7 +17,7 @@ use {
 #[serde(rename_all = "camelCase")]
 pub struct ConvertApproveQueryParams {
     pub project_id: String,
-    pub amount: usize,
+    pub amount: String,
     pub from: String,
     pub to: String,
 }

--- a/src/handlers/convert/quotes.rs
+++ b/src/handlers/convert/quotes.rs
@@ -17,7 +17,7 @@ use {
 #[serde(rename_all = "camelCase")]
 pub struct ConvertQuoteQueryParams {
     pub project_id: String,
-    pub amount: usize,
+    pub amount: String,
     pub from: String,
     pub to: String,
 }

--- a/src/handlers/convert/transaction.rs
+++ b/src/handlers/convert/transaction.rs
@@ -17,7 +17,7 @@ use {
 #[serde(rename_all = "camelCase")]
 pub struct ConvertTransactionQueryParams {
     pub project_id: String,
-    pub amount: usize,
+    pub amount: String,
     pub from: String,
     pub to: String,
     pub user_address: String,

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -176,8 +176,7 @@ impl ConversionProvider for OneInchProvider {
 
         url.query_pairs_mut().append_pair("src", &src_address);
         url.query_pairs_mut().append_pair("dst", &dst_address);
-        url.query_pairs_mut()
-            .append_pair("amount", &params.amount.to_string());
+        url.query_pairs_mut().append_pair("amount", &params.amount);
 
         let response = self.send_request(url, &self.http_client.clone()).await?;
 
@@ -194,7 +193,7 @@ impl ConversionProvider for OneInchProvider {
         let response = ConvertQuoteResponseBody {
             quotes: vec![QuoteItem {
                 id: None,
-                from_amount: params.amount.to_string(),
+                from_amount: params.amount,
                 from_account: params.from,
                 to_amount: body.dst_amount,
                 to_account: params.to,
@@ -224,8 +223,7 @@ impl ConversionProvider for OneInchProvider {
 
         url.query_pairs_mut()
             .append_pair("tokenAddress", &dst_address);
-        url.query_pairs_mut()
-            .append_pair("amount", &params.amount.to_string());
+        url.query_pairs_mut().append_pair("amount", &params.amount);
 
         let response = self.send_request(url, &self.http_client.clone()).await?;
 
@@ -275,8 +273,7 @@ impl ConversionProvider for OneInchProvider {
 
         url.query_pairs_mut().append_pair("src", &src_address);
         url.query_pairs_mut().append_pair("dst", &dst_address);
-        url.query_pairs_mut()
-            .append_pair("amount", &params.amount.to_string());
+        url.query_pairs_mut().append_pair("amount", &params.amount);
         url.query_pairs_mut().append_pair("from", &user_address);
 
         if let Some(eip155) = &params.eip155 {


### PR DESCRIPTION
# Description

This PR changes `amount` to `String` instead of `usize`. Since the `usize` is pretty much huge in size we should protect ourselves from overflow of `usize`. Also, this adds better compatibility with the client's JS integration.

We don't need any migration because this feature is under development now.

## How Has This Been Tested?

* Updated integration test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
