### PR TITLE
feat(conversion): passing through error description in case of wrong parameters

### DIFF
--- a/integration/convert.test.ts
+++ b/integration/convert.test.ts
@@ -94,4 +94,26 @@ describe('Token conversion (single chain)', () => {
     expect(eip155.gas).toEqual(expect.stringMatching(/[0-9].*/));
     expect(eip155.gasPrice).toEqual(expect.stringMatching(/[0-9].*/));
   })
+
+  it('handling invalid parameter', async () => {
+    const payload = {
+      projectId,
+      amount: "100000",
+      from: srcAsset,
+      to: destAsset,
+      userAddress: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      eip155: {
+        slippage: 1,
+      }
+    };
+
+    let resp: any = await httpClient.post(
+      `${baseUrl}/v1/convert/build-transaction`,
+      payload
+    )
+    
+    expect(resp.status).toBe(400)
+    expect(typeof resp.data.reasons).toBe('object')
+    expect(typeof resp.data.reasons[0].description).toBe('string')
+  })
 })

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,12 +71,6 @@ pub enum RpcError {
     #[error("Failed to parse fungible price provider url")]
     FungiblePriceParseURLError,
 
-    #[error("Failed to reach the conversion provider")]
-    ConversionProviderError,
-
-    #[error("Failed to parse conversion provider url")]
-    ConversionParseURLError,
-
     #[error("Failed to parse onramp provider url")]
     OnRampParseURLError,
 
@@ -121,6 +115,16 @@ pub enum RpcError {
 
     #[error("invalid parameter: {0}")]
     InvalidParameter(String),
+
+    // Conversion errors
+    #[error("Failed to reach the conversion provider")]
+    ConversionProviderError,
+
+    #[error("Failed to parse conversion provider url")]
+    ConversionParseURLError,
+
+    #[error("Invalid conversion parameter: {0}")]
+    ConversionInvalidParameter(String),
 
     // Profile names errors
     #[error("Name is already registered: {0}")]
@@ -284,6 +288,14 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response(),
+            Self::ConversionInvalidParameter(e) => (
+                    StatusCode::BAD_REQUEST,
+                    Json(new_error_response(
+                        "".to_string(),
+                        format!("Conversion parameter error: {}", e),
+                    )),
+                )
+                    .into_response(),
             Self::UnsupportedCoinType(e) => (
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -107,9 +107,21 @@ struct OneInchTxTransaction {
     gas_price: String,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OneInchErrorResponse {
+    error: OneInchErrorItem,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OneInchErrorItem {
+    description: String,
+}
+
 #[async_trait]
 impl ConversionProvider for OneInchProvider {
-    #[tracing::instrument(skip(self, params), fields(provider = "1inch"))]
+    #[tracing::instrument(skip(self), fields(provider = "1inch"), level = "debug")]
     async fn get_tokens_list(
         &self,
         params: TokensListQueryParams,
@@ -121,6 +133,15 @@ impl ConversionProvider for OneInchProvider {
         let response = self.send_request(url, &self.http_client.clone()).await?;
 
         if !response.status().is_success() {
+            // Passing through error description for the error context
+            // if user parameter is invalid (got 400 status code from the provider)
+            if response.status() == reqwest::StatusCode::BAD_REQUEST {
+                let response_error = response.json::<OneInchErrorResponse>().await?;
+                return Err(RpcError::ConversionInvalidParameter(
+                    response_error.error.description,
+                ));
+            }
+
             error!(
                 "Error on getting tokens list for conversion from 1inch provider. Status is not \
                  OK: {:?}",
@@ -156,6 +177,7 @@ impl ConversionProvider for OneInchProvider {
         Ok(response)
     }
 
+    #[tracing::instrument(skip(self), fields(provider = "1inch"), level = "debug")]
     async fn get_convert_quote(
         &self,
         params: ConvertQuoteQueryParams,
@@ -182,6 +204,15 @@ impl ConversionProvider for OneInchProvider {
         let response = self.send_request(url, &self.http_client.clone()).await?;
 
         if !response.status().is_success() {
+            // Passing through error description for the error context
+            // if user parameter is invalid (got 400 status code from the provider)
+            if response.status() == reqwest::StatusCode::BAD_REQUEST {
+                let response_error = response.json::<OneInchErrorResponse>().await?;
+                return Err(RpcError::ConversionInvalidParameter(
+                    response_error.error.description,
+                ));
+            }
+
             error!(
                 "Error on getting quotes for conversion from 1inch provider. Status is not OK: \
                  {:?}",
@@ -204,6 +235,7 @@ impl ConversionProvider for OneInchProvider {
         Ok(response)
     }
 
+    #[tracing::instrument(skip(self), fields(provider = "1inch"), level = "debug")]
     async fn build_approve_tx(
         &self,
         params: ConvertApproveQueryParams,
@@ -230,6 +262,15 @@ impl ConversionProvider for OneInchProvider {
         let response = self.send_request(url, &self.http_client.clone()).await?;
 
         if !response.status().is_success() {
+            // Passing through error description for the error context
+            // if user parameter is invalid (got 400 status code from the provider)
+            if response.status() == reqwest::StatusCode::BAD_REQUEST {
+                let response_error = response.json::<OneInchErrorResponse>().await?;
+                return Err(RpcError::ConversionInvalidParameter(
+                    response_error.error.description,
+                ));
+            }
+
             error!(
                 "Error on building approval tx for conversion from 1inch provider. Status is not \
                  OK: {:?}",
@@ -254,6 +295,7 @@ impl ConversionProvider for OneInchProvider {
         Ok(response)
     }
 
+    #[tracing::instrument(skip(self), fields(provider = "1inch"), level = "debug")]
     async fn build_convert_tx(
         &self,
         params: ConvertTransactionQueryParams,
@@ -294,6 +336,15 @@ impl ConversionProvider for OneInchProvider {
         let response = self.send_request(url, &self.http_client.clone()).await?;
 
         if !response.status().is_success() {
+            // Passing through error description for the error context
+            // if user parameter is invalid (got 400 status code from the provider)
+            if response.status() == reqwest::StatusCode::BAD_REQUEST {
+                let response_error = response.json::<OneInchErrorResponse>().await?;
+                return Err(RpcError::ConversionInvalidParameter(
+                    response_error.error.description,
+                ));
+            }
+
             error!(
                 "Error on building convert tx from 1inch provider. Status is not OK: {:?}",
                 response.status(),


### PR DESCRIPTION
# Description

This PR adds passing through error message description from the 1Inch provider in case wrong parameters were passed and `HTTP 400 Bad Request` was returned from the provider request. This adds context to the client about what parameters were wrong.

Resolves # (issue)

## How Has This Been Tested?

* New [integration test were implemented](https://github.com/WalletConnect/blockchain-api/pull/635/files#diff-d2a40c4ae4e4965cd2ea19db3965e98a04e70177954587a2a3edecfcf1263ce0R98).

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
