### PR TITLE
fix(conversion): making `amount` optional in approval

### DIFF
--- a/integration/convert.test.ts
+++ b/integration/convert.test.ts
@@ -51,13 +51,27 @@ describe('Token conversion (single chain)', () => {
   })
 
   it('build approve tx', async () => {
+    // Amount specified
     let resp: any = await httpClient.get(
       `${baseUrl}/v1/convert/build-approve?projectId=${projectId}&amount=${amount}&from=${srcAsset}&to=${destAsset}`
     )
     expect(resp.status).toBe(200)
     expect(typeof resp.data.tx).toBe('object')
 
-    const tx = resp.data.tx;
+    let tx = resp.data.tx;
+    expect(tx.from).toEqual(srcAsset);
+    expect(tx.to).toEqual(destAsset);
+    expect(tx.data).toEqual(expect.stringMatching(/^0x.*/));
+    expect(tx.eip155.gasPrice).toEqual(expect.stringMatching(/[0-9].*/));
+
+    // Infinite amount
+    resp = await httpClient.get(
+      `${baseUrl}/v1/convert/build-approve?projectId=${projectId}&from=${srcAsset}&to=${destAsset}`
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.tx).toBe('object')
+
+    tx = resp.data.tx;
     expect(tx.from).toEqual(srcAsset);
     expect(tx.to).toEqual(destAsset);
     expect(tx.data).toEqual(expect.stringMatching(/^0x.*/));

--- a/src/handlers/convert/approve.rs
+++ b/src/handlers/convert/approve.rs
@@ -17,9 +17,9 @@ use {
 #[serde(rename_all = "camelCase")]
 pub struct ConvertApproveQueryParams {
     pub project_id: String,
-    pub amount: String,
     pub from: String,
     pub to: String,
+    pub amount: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -302,7 +302,9 @@ impl ConversionProvider for OneInchProvider {
 
         url.query_pairs_mut()
             .append_pair("tokenAddress", &dst_address);
-        url.query_pairs_mut().append_pair("amount", &params.amount);
+        if let Some(amount) = &params.amount {
+            url.query_pairs_mut().append_pair("amount", amount);
+        }
 
         let response = self.send_request(url, &self.http_client.clone()).await?;
 


### PR DESCRIPTION
# Description

This PR modified the `amount` parameter to become optional to allow the infinite amount for the approval since `0` in the amount means that no approval at all. So we should handle both cases: infinite amount and `0`.

## How Has This Been Tested?

* Updated integration test for the endpoint.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
