### PR TITLE
fix(fungibles): adding `eth` token address representation

### DIFF
--- a/integration/fungible_price.test.ts
+++ b/integration/fungible_price.test.ts
@@ -4,15 +4,17 @@ describe('Fungible price', () => {
   const { baseUrl, projectId, httpClient } = getTestSetup();
   const endpoint = `${baseUrl}/v1/fungible/price`;
 
-  // RSR token address
-  const implementation_address = 'eip155:1:0x320623b8e4ff03373931769a31fc52a4e78b5d70'
+  // BNB token address
+  const bnb_implementation_address = 'eip155:1:0xb8c77482e45f1f44de1745f52c74426c631bdd52'
+  // ETH token address representing native ETH
+  const eth_native_address = 'eip155:1:0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
   const currency = 'usd'
 
-  it('get token price', async () => {
+  it('get BNB token price', async () => {
     let request_data = {
       projectId: projectId,
       currency: currency,
-      addresses: [implementation_address]
+      addresses: [bnb_implementation_address]
     }
     let resp: any = await httpClient.post(
       `${endpoint}`,
@@ -20,11 +22,33 @@ describe('Fungible price', () => {
     )
     expect(resp.status).toBe(200)
     expect(typeof resp.data.fungibles).toBe('object')
-    expect(resp.data.fungibles.length).toBeGreaterThan(0)
+    expect(resp.data.fungibles.length).toBe(1)
 
     for (const item of resp.data.fungibles) {
       expect(typeof item.name).toBe('string')
-      expect(typeof item.symbol).toBe('string')
+      expect(item.symbol).toBe('BNB')
+      expect(typeof item.iconUrl).toBe('string')
+      expect(typeof item.price).toBe('number')
+    }
+  })
+
+  it('get ETH native token price', async () => {
+    let request_data = {
+      projectId: projectId,
+      currency: currency,
+      addresses: [eth_native_address]
+    }
+    let resp: any = await httpClient.post(
+      `${endpoint}`,
+      request_data
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.fungibles).toBe('object')
+    expect(resp.data.fungibles.length).toBe(1)
+
+    for (const item of resp.data.fungibles) {
+      expect(typeof item.name).toBe('string')
+      expect(item.symbol).toBe('ETH')
       expect(typeof item.iconUrl).toBe('string')
       expect(typeof item.price).toBe('number')
     }
@@ -47,7 +71,7 @@ describe('Fungible price', () => {
     request_data = {
       projectId: projectId,
       currency: "irn",
-      addresses: [implementation_address]
+      addresses: [eth_native_address]
     }
     resp = await httpClient.post(
       `${endpoint}`,

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -537,8 +537,17 @@ impl FungiblePriceProvider for ZerionProvider {
         url.query_pairs_mut().append_pair("currency", &currency);
         url.query_pairs_mut()
             .append_pair("filter[chain_id]", chain_id);
-        url.query_pairs_mut()
-            .append_pair("filter[implementation_address]", address);
+
+        // Exception for the Ethereum native token since Zerion contract address for it
+        // is `null` we should filter it by the token name
+        const NATIVE_TOKEN_ADDRESS: &str = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        if address == NATIVE_TOKEN_ADDRESS {
+            url.query_pairs_mut()
+                .append_pair("filter[fungible_ids]", "eth");
+        } else {
+            url.query_pairs_mut()
+                .append_pair("filter[implementation_address]", address);
+        };
 
         let response = http_client
             .get(url)


### PR DESCRIPTION
# Description

This PR adds an address representation for the `eth` native token as `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`. By default, Zerion uses `null` for the address of the native token, but for consistency across all endpoints and support for swaps, it's better to stick to the `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` representation of the native token address.

## How Has This Been Tested?

* [New integration test](https://github.com/WalletConnect/blockchain-api/pull/639/files#diff-4493ff1a59d5bf63fc4e0b226e9908932f9c2ef71dafddf6ecf99f00c5739487).

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
