### PR TITLE
fix(fungibles): adding more exception to native tokens

### DIFF
--- a/integration/fungible_price.test.ts
+++ b/integration/fungible_price.test.ts
@@ -3,18 +3,15 @@ import { getTestSetup } from './init';
 describe('Fungible price', () => {
   const { baseUrl, projectId, httpClient } = getTestSetup();
   const endpoint = `${baseUrl}/v1/fungible/price`;
-
-  // BNB token address
-  const bnb_implementation_address = 'eip155:1:0xb8c77482e45f1f44de1745f52c74426c631bdd52'
-  // ETH token address representing native ETH
-  const eth_native_address = 'eip155:1:0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
   const currency = 'usd'
+  const native_token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 
-  it('get BNB token price', async () => {
+  it('get erc20 mainnet token price', async () => {
+    const shib_token_address = 'eip155:1:0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce';
     let request_data = {
       projectId: projectId,
       currency: currency,
-      addresses: [bnb_implementation_address]
+      addresses: [shib_token_address]
     }
     let resp: any = await httpClient.post(
       `${endpoint}`,
@@ -26,31 +23,43 @@ describe('Fungible price', () => {
 
     for (const item of resp.data.fungibles) {
       expect(typeof item.name).toBe('string')
-      expect(item.symbol).toBe('BNB')
+      expect(item.symbol).toBe('SHIB')
       expect(typeof item.iconUrl).toBe('string')
       expect(typeof item.price).toBe('number')
     }
   })
 
-  it('get ETH native token price', async () => {
-    let request_data = {
-      projectId: projectId,
-      currency: currency,
-      addresses: [eth_native_address]
-    }
-    let resp: any = await httpClient.post(
-      `${endpoint}`,
-      request_data
-    )
-    expect(resp.status).toBe(200)
-    expect(typeof resp.data.fungibles).toBe('object')
-    expect(resp.data.fungibles.length).toBe(1)
+  it('get native tokens price', async () => {
+    const native_tokens = [
+      { chainId: 1, symbol: 'ETH' },
+      { chainId: 56, symbol: 'BNB' },
+      { chainId: 100, symbol: 'XDAI' },
+      { chainId: 137, symbol: 'MATIC' },
+      { chainId: 250, symbol: 'FTM' },
+      { chainId: 43114, symbol: 'AVAX' },
+    ];
 
-    for (const item of resp.data.fungibles) {
-      expect(typeof item.name).toBe('string')
-      expect(item.symbol).toBe('ETH')
-      expect(typeof item.iconUrl).toBe('string')
-      expect(typeof item.price).toBe('number')
+    for (const token of native_tokens) {
+      let request_data = {
+        projectId: projectId,
+        currency: currency,
+        addresses: [`eip155:${token.chainId}:${native_token_address}`],
+        chainId: token.chainId
+      }
+      let resp: any = await httpClient.post(
+        `${endpoint}`,
+        request_data
+      )
+      expect(resp.status).toBe(200)
+      expect(typeof resp.data.fungibles).toBe('object')
+      expect(resp.data.fungibles.length).toBe(1)
+
+      for (const item of resp.data.fungibles) {
+        expect(typeof item.name).toBe('string')
+        expect(item.symbol).toBe(token.symbol)
+        expect(typeof item.iconUrl).toBe('string')
+        expect(typeof item.price).toBe('number')
+      }
     }
   })
 
@@ -71,7 +80,7 @@ describe('Fungible price', () => {
     request_data = {
       projectId: projectId,
       currency: "irn",
-      addresses: [eth_native_address]
+      addresses: [`eip155:1:${native_token_address}`]
     }
     resp = await httpClient.post(
       `${endpoint}`,

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -538,12 +538,60 @@ impl FungiblePriceProvider for ZerionProvider {
         url.query_pairs_mut()
             .append_pair("filter[chain_id]", chain_id);
 
-        // Exception for the Ethereum native token since Zerion contract address for it
-        // is `null` we should filter it by the token name
+        // We are using `0xeee...` for the native token address to be consistent withing
+        // all endpoints
         const NATIVE_TOKEN_ADDRESS: &str = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+        // Exceptions for native tokens since Zerion contract address for them
+        // are `null` or `0x000` we should filter them by ids
         if address == NATIVE_TOKEN_ADDRESS {
-            url.query_pairs_mut()
-                .append_pair("filter[fungible_ids]", "eth");
+            match chain_id {
+                // Ethereum ETH
+                "1" => {
+                    url.query_pairs_mut()
+                        .append_pair("filter[fungible_ids]", "eth");
+                }
+                // BNB
+                "56" => {
+                    url.query_pairs_mut().append_pair(
+                        "filter[fungible_ids]",
+                        "0xb8c77482e45f1f44de1745f52c74426c631bdd52",
+                    );
+                }
+                // xDAI
+                "100" => {
+                    url.query_pairs_mut().append_pair(
+                        "filter[fungible_ids]",
+                        "b99ea659-0ab1-4832-bf44-3bf1cc1acac7",
+                    );
+                }
+                // Matic
+                "137" => {
+                    url.query_pairs_mut().append_pair(
+                        "filter[fungible_ids]",
+                        "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+                    );
+                }
+                // FTM
+                "250" => {
+                    url.query_pairs_mut().append_pair(
+                        "filter[fungible_ids]",
+                        "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
+                    );
+                }
+                // Avax
+                "43114" => {
+                    url.query_pairs_mut().append_pair(
+                        "filter[fungible_ids]",
+                        "43e05303-bf43-48df-be45-352d7567ff39",
+                    );
+                }
+                _ => {
+                    error!("Unsupported chain id for native token address");
+                    url.query_pairs_mut()
+                        .append_pair("filter[implementation_address]", address);
+                }
+            }
         } else {
             url.query_pairs_mut()
                 .append_pair("filter[implementation_address]", address);


### PR DESCRIPTION
# Description

This PR adds more exceptions for the native tokens contract addresses. 
In #639 we added `eth` as an exception for the native token address when getting its price. 
We are sticking to the `0xeee...` address as the representation of the `null` contract address for native tokens to be consistent across all endpoints and different providers. We have found that Zerion same as 1Inch has more exceptions for native tokens. We should handle the price request to Zerion differently for the below native tokens and stick to they `ids` since there are no contract addresses to stick to:

* BNB
* xDAI
* Matic
* FTM
* Avax

## How Has This Been Tested?

* New integration test for exceptions.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
