### PR TITLE
fix(Zerion): return only non-spam items

### DIFF
--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -223,6 +223,11 @@ pub struct ZerionMarketData {
     pub price: Option<f64>,
 }
 
+fn add_filter_non_trash_only(url: &mut Url) {
+    url.query_pairs_mut()
+        .append_pair("filter[trash]", "only_non_trash");
+}
+
 #[async_trait]
 impl HistoryProvider for ZerionProvider {
     #[tracing::instrument(skip(self, params), fields(provider = "Zerion"))]
@@ -243,8 +248,7 @@ impl HistoryProvider for ZerionProvider {
         url.query_pairs_mut()
             .append_pair("currency", &params.currency.unwrap_or("usd".to_string()));
         // Return only non-spam transactions
-        url.query_pairs_mut()
-            .append_pair("filter[trash]", "only_non_trash");
+        add_filter_non_trash_only(&mut url);
 
         if let Some(cursor) = params.cursor {
             url.query_pairs_mut().append_pair("page[after]", &cursor);
@@ -442,8 +446,7 @@ impl BalanceProvider for ZerionProvider {
         url.query_pairs_mut()
             .append_pair("filter[position_types]", "wallet");
         // Return only non-spam transactions
-        url.query_pairs_mut()
-            .append_pair("filter[trash]", "only_non_trash");
+        add_filter_non_trash_only(&mut url);
 
         if let Some(chain_id) = params.chain_id {
             let chain_name = crypto::ChainId::from_caip2(&chain_id)

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -242,6 +242,9 @@ impl HistoryProvider for ZerionProvider {
         })?;
         url.query_pairs_mut()
             .append_pair("currency", &params.currency.unwrap_or("usd".to_string()));
+        // Return only non-spam transactions
+        url.query_pairs_mut()
+            .append_pair("filter[trash]", "only_non_trash");
 
         if let Some(cursor) = params.cursor {
             url.query_pairs_mut().append_pair("page[after]", &cursor);
@@ -438,6 +441,9 @@ impl BalanceProvider for ZerionProvider {
             .append_pair("currency", &params.currency.to_string());
         url.query_pairs_mut()
             .append_pair("filter[position_types]", "wallet");
+        // Return only non-spam transactions
+        url.query_pairs_mut()
+            .append_pair("filter[trash]", "only_non_trash");
 
         if let Some(chain_id) = params.chain_id {
             let chain_name = crypto::ChainId::from_caip2(&chain_id)


### PR DESCRIPTION
# Description

This PR adds an additional filter to Zerion requests to filter out only non-spam items in transactions history and address balance since we don't need to return spam items. According to the Zerion API docs filter `filter[trash]` is applied.

## How Has This Been Tested?

* Current integration tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
