### PR TITLE
feat(1inch): handling of the unsupported chain ID

### DIFF
--- a/integration/convert.test.ts
+++ b/integration/convert.test.ts
@@ -36,6 +36,14 @@ describe('Token conversion (single chain)', () => {
     }
   })
 
+  it('unsupported chain', async () => {
+    const unsupportedChainId = 'eip155:92374624';
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/convert/tokens?projectId=${projectId}&chainId=${unsupportedChainId}`
+    )
+    expect(resp.status).toBe(400)
+  })
+
   it('get conversion quote', async () => {
     let resp: any = await httpClient.get(
       `${baseUrl}/v1/convert/quotes?projectId=${projectId}&amount=${amount}&from=${srcAsset}&to=${destAsset}`

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -181,6 +181,13 @@ impl ConversionProvider for OneInchProvider {
                     response_error.error.description,
                 ));
             }
+            // 404 response is expected when the chain ID is not supported
+            if response.status() == reqwest::StatusCode::NOT_FOUND {
+                return Err(RpcError::ConversionInvalidParameter(format!(
+                    "Chain ID {} is not supported",
+                    params.chain_id
+                )));
+            };
 
             error!(
                 "Error on getting tokens list for conversion from 1inch provider. Status is not \


### PR DESCRIPTION
# Description

This PR adds proper handling of the unsupported chain ID in the `1Inch` provider call for available tokens for swaps.
This should change the error from `HTTP 500` to `HTTP 400` with the proper error description in case of not supported chain provided.

## How Has This Been Tested?

* Integration test is updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
