### PR TITLE
feat(providers): using 1Inch instead of Zerion for fungible prices

### DIFF
--- a/integration/fungible_price.test.ts
+++ b/integration/fungible_price.test.ts
@@ -33,7 +33,7 @@ describe('Fungible price', () => {
     const native_tokens = [
       { chainId: 1, symbol: 'ETH' },
       { chainId: 56, symbol: 'BNB' },
-      { chainId: 100, symbol: 'XDAI' },
+      { chainId: 100, symbol: 'xDAI' },
       { chainId: 137, symbol: 'MATIC' },
       { chainId: 250, symbol: 'FTM' },
       { chainId: 43114, symbol: 'AVAX' },

--- a/src/handlers/fungible_price.rs
+++ b/src/handlers/fungible_price.rs
@@ -97,12 +97,7 @@ async fn handler_internal(
     let response = state
         .providers
         .fungible_price_provider
-        .get_price(
-            &chain_id,
-            &address,
-            &query.currency,
-            state.http_client.clone(),
-        )
+        .get_price(&chain_id, &address, &query.currency)
         .await
         .tap_err(|e| {
             error!("Failed to call fungible price with {}", e);

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -167,11 +167,10 @@ impl ProviderRepository {
             .unwrap_or("ONE_INCH_API_KEY".into());
 
         let zerion_provider = Arc::new(ZerionProvider::new(zerion_api_key));
+        let one_inch_provider = Arc::new(OneInchProvider::new(one_inch_api_key));
         let history_provider = zerion_provider.clone();
         let portfolio_provider = zerion_provider.clone();
         let balance_provider = zerion_provider.clone();
-        let fungible_price_provider = zerion_provider;
-        let conversion_provider = Arc::new(OneInchProvider::new(one_inch_api_key));
 
         let coinbase_pay_provider = Arc::new(CoinbaseProvider::new(
             coinbase_api_key,
@@ -195,8 +194,8 @@ impl ProviderRepository {
             coinbase_pay_provider: coinbase_pay_provider.clone(),
             onramp_provider: coinbase_pay_provider,
             balance_provider,
-            conversion_provider,
-            fungible_price_provider,
+            conversion_provider: one_inch_provider.clone(),
+            fungible_price_provider: one_inch_provider.clone(),
         }
     }
 
@@ -606,7 +605,6 @@ pub trait FungiblePriceProvider: Send + Sync + Debug {
         chain_id: &str,
         address: &str,
         currency: &PriceCurrencies,
-        http_client: reqwest::Client,
     ) -> RpcResult<PriceResponseBody>;
 }
 

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -74,8 +74,10 @@ impl OneInchProvider {
         address: &str,
         currency: &PriceCurrencies,
     ) -> Result<String, RpcError> {
-        let base = format!("{}/price/v1.1/{}/{}", &self.base_api_url, chain_id, address);
-        let mut url = Url::parse(&base).map_err(|_| RpcError::ConversionParseURLError)?;
+        let mut url = Url::parse(
+            format!("{}/price/v1.1/{}/{}", &self.base_api_url, chain_id, address).as_str(),
+        )
+        .map_err(|_| RpcError::ConversionParseURLError)?;
         url.query_pairs_mut()
             .append_pair("currency", &currency.to_string());
 
@@ -114,11 +116,14 @@ impl OneInchProvider {
         chain_id: &str,
         address: &str,
     ) -> Result<OneInchTokenItem, RpcError> {
-        let base = format!(
-            "{}/token/v1.2/{}/custom/{}",
-            &self.base_api_url, chain_id, address
-        );
-        let url = Url::parse(&base).map_err(|_| RpcError::ConversionParseURLError)?;
+        let url = Url::parse(
+            format!(
+                "{}/token/v1.2/{}/custom/{}",
+                &self.base_api_url, chain_id, address
+            )
+            .as_str(),
+        )
+        .map_err(|_| RpcError::ConversionParseURLError)?;
 
         let response = self.send_request(url, &self.http_client.clone()).await?;
 


### PR DESCRIPTION
# Description

This PR changes the provider for fungibles prices from Zerion to 1Inch to support native token prices from 1Inch conversion parameters. 1Inch uses `0xeee` for the native tokens and Zerion uses just unique internal IDs. 
This change will fix errors while getting the conversion token prices. Before this change, we used the hardcoded list of the native tokens and Zerion ids.

## How Has This Been Tested?

Updated integration tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
