### PR TITLE
fix: replace with erc6492 lib and call rpc directly w/o http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,41 +110,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-contract"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=d68a6b7#d68a6b787b2904061f0ae7fcc02ece8513e3c500"
-dependencies = [
- "alloy-dyn-abi",
- "alloy-json-abi",
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
- "alloy-sol-types",
- "alloy-transport",
- "futures",
- "futures-util",
- "thiserror",
-]
-
-[[package]]
-name = "alloy-dyn-abi"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ab339ca7b4ea9115f0578c941abc80a171edf8e5eadd01e6c4237b68db8083"
-dependencies = [
- "alloy-json-abi",
- "alloy-primitives",
- "alloy-sol-type-parser",
- "alloy-sol-types",
- "const-hex",
- "itoa",
- "serde",
- "serde_json",
- "winnow 0.6.5",
-]
-
-[[package]]
 name = "alloy-eips"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy.git?rev=d68a6b7#d68a6b787b2904061f0ae7fcc02ece8513e3c500"
@@ -165,18 +130,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-serde",
  "serde",
-]
-
-[[package]]
-name = "alloy-json-abi"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44294729c145cf7ae65feab544b5b81fb2bb7e2fd060214842eb3989a1e9d882"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-type-parser",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -205,21 +158,6 @@ dependencies = [
  "async-trait",
  "futures-utils-wasm",
  "thiserror",
-]
-
-[[package]]
-name = "alloy-node-bindings"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=d68a6b7#d68a6b787b2904061f0ae7fcc02ece8513e3c500"
-dependencies = [
- "alloy-genesis",
- "alloy-primitives",
- "k256",
- "serde_json",
- "tempfile",
- "thiserror",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -398,15 +336,6 @@ dependencies = [
  "quote 1.0.35",
  "syn 2.0.57",
  "syn-solidity",
-]
-
-[[package]]
-name = "alloy-sol-type-parser"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c8d6e74e4feeaa2bcfdecfd3da247ab53c67bd654ba1907270c32e02b142331"
-dependencies = [
- "winnow 0.6.5",
 ]
 
 [[package]]
@@ -1351,12 +1280,6 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
-
-[[package]]
-name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
@@ -1548,7 +1471,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
 dependencies = [
- "bs58 0.5.1",
+ "bs58",
  "coins-core",
  "digest 0.10.7",
  "hmac",
@@ -1582,7 +1505,7 @@ checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
 dependencies = [
  "base64 0.21.7",
  "bech32",
- "bs58 0.5.1",
+ "bs58",
  "digest 0.10.7",
  "generic-array",
  "hex",
@@ -1810,34 +1733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "platforms",
- "rustc_version 0.4.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.57",
-]
-
-[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,31 +1944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,6 +2061,20 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erc6492"
+version = "0.1.0"
+source = "git+https://github.com/WalletConnect/erc6492.git#f2b37fda5ed9b43cb7e0ca9d547978c799779892"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types",
+ "alloy-sol-types",
+ "alloy-transport",
+ "serde_json",
+]
 
 [[package]]
 name = "errno"
@@ -2581,12 +2465,6 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
 
 [[package]]
 name = "finl_unicode"
@@ -4430,12 +4308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
-
-[[package]]
 name = "pnet_base"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4849,42 +4721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
-name = "relay_rpc"
-version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.30.0#edd6b6bcaa360e0887b4930ba78d56c958700612"
-dependencies = [
- "alloy-contract",
- "alloy-json-abi",
- "alloy-json-rpc",
- "alloy-node-bindings",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
- "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
- "bs58 0.4.0",
- "chrono",
- "data-encoding",
- "derive_more",
- "ed25519-dalek",
- "hex",
- "jsonwebtoken",
- "k256",
- "once_cell",
- "rand",
- "regex",
- "serde",
- "serde-aux 4.5.0",
- "serde_json",
- "sha2",
- "sha3",
- "strum",
- "thiserror",
- "url",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5077,7 +4913,11 @@ dependencies = [
 name = "rpc-proxy"
 version = "0.60.0"
 dependencies = [
+ "alloy-json-rpc",
  "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-transport",
  "anyhow",
  "async-trait",
  "async-tungstenite",
@@ -5092,6 +4932,7 @@ dependencies = [
  "derive_more",
  "dotenv",
  "envy",
+ "erc6492",
  "ethers",
  "futures-util",
  "hex",
@@ -5108,11 +4949,10 @@ dependencies = [
  "prometheus-http-query",
  "rand",
  "regex",
- "relay_rpc",
  "reqwest 0.11.27",
  "rmp-serde",
  "serde",
- "serde-aux 3.1.0",
+ "serde-aux",
  "serde_json",
  "serde_piecewise_default",
  "sha256",
@@ -5502,16 +5342,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a77223b653fa95f3f9864f3eb25b93e4ed170687eb42d85b6b98af21d5e1de"
 dependencies = [
  "chrono",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "serde-aux"
-version = "4.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2e8bfba469d06512e11e3311d4d051a4a387a5b42d010404fecf3200321c95"
-dependencies = [
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,11 @@ build = "build.rs"
 
 [dependencies]
 wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.9.0", features = ["alloc", "analytics", "future", "http", "metrics", "geoip", "geoblock", "rate_limit"] }
-relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.30.0", features = ["cacao"] }
+erc6492 = { git = "https://github.com/WalletConnect/erc6492.git" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy.git", rev = "d68a6b7" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy.git", rev = "d68a6b7" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy.git", rev = "d68a6b7" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy.git", rev = "d68a6b7" }
 
 # Async
 async-trait = "0.1.57"
@@ -31,7 +35,7 @@ reqwest = { version= "0.11", features = ["deflate", "brotli", "gzip"] }
 # Serialization
 rmp-serde = "1.1"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["raw_value"] }
 serde_piecewise_default = "0.2"
 serde-aux = "3.1"
 validator = { version = "0.16", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Endpoint: `https://rpc.walletconnect.com/v1?chainId=eip155:1&projectId=<your-pro
 For example:
 
 ```bash
-curl -X POST "https://rpc.walletconnect.com/v1?chainId=eip155:1&projectId=<your-project-id>" --data '{"id":"1","jsonrpc":"2.0","method":"eth_chainId","params":[]}'
+curl -H "Content-Type: application/json" -X POST "https://rpc.walletconnect.com/v1?chainId=eip155:1&projectId=<your-project-id>" --data '{"id":"1","jsonrpc":"2.0","method":"eth_chainId","params":[]}'
 ```
 
 Obtain a `projectId` from <https://cloud.walletconnect.com>
@@ -41,7 +41,7 @@ just run
 
 ```bash
 # projectId is not validated under default .env.example configuration
-curl -X POST "http://localhost:3000/v1?chainId=eip155:1&projectId=someid" --data '{"id":"1","jsonrpc":"2.0","method":"eth_chainId","params":[]}'
+curl -H "Content-Type: application/json" -X POST "http://localhost:3000/v1?chainId=eip155:1&projectId=someid" --data '{"id":"1","jsonrpc":"2.0","method":"eth_chainId","params":[]}'
 ```
 
 ## Testing

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,4 +2,5 @@ pub mod build;
 pub mod crypto;
 pub mod network;
 pub mod rate_limit;
+pub mod self_transport;
 pub mod suggestions;

--- a/src/utils/self_transport.rs
+++ b/src/utils/self_transport.rs
@@ -1,0 +1,108 @@
+use {
+    crate::{
+        handlers::{proxy::rpc_call, RpcQueryParams},
+        state::AppState,
+    },
+    alloy_json_rpc::{RequestPacket, Response, ResponsePacket},
+    alloy_transport::{TransportError, TransportFut},
+    hyper::{body::to_bytes, HeaderMap},
+    std::{net::SocketAddr, sync::Arc, task::Poll},
+    tower::Service,
+};
+
+#[derive(Clone)]
+pub struct SelfTransport {
+    pub state: Arc<AppState>,
+    pub connect_info: SocketAddr,
+    pub query: RpcQueryParams,
+    pub headers: HeaderMap,
+}
+
+impl Service<RequestPacket> for SelfTransport {
+    type Error = TransportError;
+    type Future = TransportFut<'static>;
+    type Response = ResponsePacket;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: RequestPacket) -> Self::Future {
+        let state = self.state.clone();
+        let connect_info = self.connect_info;
+        let query = self.query.clone();
+        let headers = self.headers.clone();
+
+        Box::pin(async move {
+            // TODO handle batch
+            let req = match req {
+                RequestPacket::Single(req) => req,
+                RequestPacket::Batch(_) => unimplemented!(),
+            };
+            // let id = SystemTime::now()
+            //     .duration_since(UNIX_EPOCH)
+            //     .expect("Time should't go backwards")
+            //     .as_millis()
+            //     .to_string();
+
+            let body = req.serialized().to_string().into_bytes().into();
+            let response = rpc_call(state, connect_info, query, headers, body)
+            .await
+            // .map_err(SelfProviderError::RpcError)?;
+            .unwrap();
+
+            // TODO handle error response status
+
+            // if response.status() != StatusCode::OK {
+            //     return Err(SelfProviderError::ProviderError {
+            //         status: response.status(),
+            //         body: format!("{:?}", response.body()),
+            //     });
+            // }
+
+            // response.body().
+
+            let bytes = to_bytes(response.into_body()).await.unwrap();
+            // .map_err(SelfProviderError::ProviderBody)?;
+            let body = String::from_utf8(bytes.to_vec()).unwrap();
+
+            // let response = serde_json::from_slice::<JsonRpcResponse>(&bytes)
+            // .unwrap();
+            //     // .map_err(SelfProviderError::ProviderBodySerde)?;
+
+            // let result = match response {
+            //     JsonRpcResponse::Error(e) => return
+            // Err(SelfProviderError::JsonRpcError(e)),
+            //     JsonRpcResponse::Result(r) => {
+            //         // We shouldn't process with `0x` result because this leads to the
+            // ethers-rs         // panic when looking for an avatar
+            //         if r.result == EMPTY_RPC_RESPONSE {
+            //             return Err(SelfProviderError::ProviderError {
+            //                 status: StatusCode::METHOD_NOT_ALLOWED,
+            //                 body: format!("JSON-RPC result is {}", EMPTY_RPC_RESPONSE),
+            //             });
+            //         } else {
+            //             r.result
+            //         }
+            //     }
+            // };
+            // let result = serde_json::from_value(result).unwrap();
+            // // .map_err(|_| {
+            // //     SelfProviderError::GenericParameterError(
+            // //         "Caller always provides generic parameter R=Bytes".into(),
+            // //     )
+            // // })?;
+            // Ok(result)
+
+            Ok(ResponsePacket::Single(Response {
+                id: req.id().clone(),
+                payload: alloy_json_rpc::ResponsePayload::Success(
+                    serde_json::value::RawValue::from_string(body).unwrap(),
+                ),
+            }))
+        })
+    }
+}


### PR DESCRIPTION
# Description

Removes the dependency on WalletConnectRust and uses the erc6492 library directly. Also upgrades to use a "self provider" pattern where the EVM library directly calls into the RPC proxy function rather than using HTTP.

Remaining work:
- [ ] Iron out error handling in self_transport.rs

## How Has This Been Tested?

Not tested?

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
