### PR TITLE
feat(Docker): bumping the Rust image to `bookworm`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # Build args
 #
 ################################################################################
-ARG                 base="rust:buster"
-ARG                 runtime="debian:buster-slim"
+ARG                 base="rust:bookworm"
+ARG                 runtime="debian:bookworm-slim"
 ARG                 bin="rpc-proxy"
 ARG                 version="unknown"
 ARG                 sha="unknown"
@@ -19,7 +19,7 @@ ARG                 WORK_DIR="/app"
 ################################################################################
 FROM                ${base} AS chef
 
-WORKDIR             ${WORK_DIR} 
+WORKDIR             ${WORK_DIR}
 RUN                 cargo install cargo-chef --locked
 
 ################################################################################


### PR DESCRIPTION
# Description

This PR updates the Docker rust image to the latest stable Debian version: (12) `Bookworm`. This bump will also fix the [foundry GLIBC building error](https://github.com/WalletConnect/blockchain-api/actions/runs/8988920075/job/24691402178#step:8:1326).

## How Has This Been Tested?

The docker image was built successfully and without GLIBC error locally.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
