### PR TITLE
feat(identity): adding local names resolution support

### DIFF
--- a/integration/names.test.ts
+++ b/integration/names.test.ts
@@ -244,6 +244,15 @@ describe('Account profile names', () => {
     expect(first_address.address).toBe(address)
   })
 
+  it('name reverse lookup (identity endpoint)', async () => {
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/identity/${address}?projectId=${projectId}`
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data).toBe('object')
+    expect(resp.data.name).toBe(name)
+  })
+
   it('update name attributes', async () => {
     // Prepare updated attributes payload
     const randomBioString = Array.from({ length: 24 }, 

--- a/src/error.rs
+++ b/src/error.rs
@@ -137,6 +137,9 @@ pub enum RpcError {
     #[error("No name is found for address")]
     NameByAddressNotFound,
 
+    #[error("Internal name resolver error")]
+    InternalNameResolverError,
+
     #[error("Invalid name format: {0}")]
     InvalidNameFormat(String),
 


### PR DESCRIPTION
# Description

This PR adds the local name lookup if the name is not present in the ENS contract lookup. Since our `identity` endpoint API supports only one name return, we will use the ENS as a first priority and use our local gateway name resolver as a second-level priority. 
This extends our `identity` endpoint to lookup and cache our names registry and local registered names resolution will be available for all web3m users without any API modification.

## How Has This Been Tested?

A new [integration test was added](https://github.com/WalletConnect/blockchain-api/pull/651/files#diff-28b661942cfc4edae43683709afac7c88cdd3d5bdcc47e602ee9ea4c876dbaf1R247).

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
