### PR TITLE
feat(providers): adding zkSync support to Pokt

### DIFF
--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -160,6 +160,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // zkSync
+        (
+            "eip155:324".into(),
+            ("zksync-era".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Near protocol
         (
             "near:mainnet".into(),

--- a/tests/functional/http/pokt.rs
+++ b/tests/functional/http/pokt.rs
@@ -124,6 +124,10 @@ async fn pokt_provider_eip155(ctx: &mut ServerContext) {
         "0x2019",
     )
     .await;
+
+    // zkSync era
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, &provider, "eip155:324", "0x144")
+        .await;
 }
 
 #[test_context(ServerContext)]


### PR DESCRIPTION
# Description

This PR adds zkSync support to the Pokt/Grove provider. zkSync support was recently announced by the Pokt/Grove.

## How Has This Been Tested?

Provider test was updated, zkSync test was added.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
