### PR TITLE
feat(convert): adding `referrer` to 1Inch provider

### DIFF
--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -148,6 +148,7 @@ mod test {
             ("RPC_PROXY_PROVIDER_COINBASE_API_KEY", "COINBASE_API_KEY"),
             ("RPC_PROXY_PROVIDER_COINBASE_APP_ID", "COINBASE_APP_ID"),
             ("RPC_PROXY_PROVIDER_ONE_INCH_API_KEY", "ONE_INCH_API_KEY"),
+            ("RPC_PROXY_PROVIDER_ONE_INCH_REFERRER", "ONE_INCH_REFERRER"),
             ("RPC_PROXY_PROVIDER_GETBLOCK_ACCESS_TOKENS", "{}"),
             (
                 "RPC_PROXY_PROVIDER_PROMETHEUS_QUERY_URL",
@@ -233,6 +234,7 @@ mod test {
                     coinbase_api_key: Some("COINBASE_API_KEY".to_owned()),
                     coinbase_app_id: Some("COINBASE_APP_ID".to_owned()),
                     one_inch_api_key: Some("ONE_INCH_API_KEY".to_owned()),
+                    one_inch_referrer: Some("ONE_INCH_REFERRER".to_owned()),
                     getblock_access_tokens: Some("{}".to_owned()),
                 },
                 rate_limiting: RateLimitingConfig {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -167,6 +167,9 @@ impl ProviderRepository {
             .clone()
             .unwrap_or("ONE_INCH_API_KEY".into());
         let one_inch_referrer = config.one_inch_referrer.clone();
+        if one_inch_referrer.is_none() {
+            warn!("ONE_INCH_REFERRER is not set");
+        }
 
         let zerion_provider = Arc::new(ZerionProvider::new(zerion_api_key));
         let one_inch_provider = Arc::new(OneInchProvider::new(one_inch_api_key, one_inch_referrer));

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -89,6 +89,7 @@ pub struct ProvidersConfig {
     pub coinbase_api_key: Option<String>,
     pub coinbase_app_id: Option<String>,
     pub one_inch_api_key: Option<String>,
+    pub one_inch_referrer: Option<String>,
     /// GetBlock provider access tokens in JSON format
     pub getblock_access_tokens: Option<String>,
 }
@@ -165,9 +166,10 @@ impl ProviderRepository {
             .one_inch_api_key
             .clone()
             .unwrap_or("ONE_INCH_API_KEY".into());
+        let one_inch_referrer = config.one_inch_referrer.clone();
 
         let zerion_provider = Arc::new(ZerionProvider::new(zerion_api_key));
-        let one_inch_provider = Arc::new(OneInchProvider::new(one_inch_api_key));
+        let one_inch_provider = Arc::new(OneInchProvider::new(one_inch_api_key, one_inch_referrer));
         let history_provider = zerion_provider.clone();
         let portfolio_provider = zerion_provider.clone();
         let balance_provider = zerion_provider.clone();

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -33,16 +33,18 @@ use {
 #[derive(Debug)]
 pub struct OneInchProvider {
     pub api_key: String,
+    pub referrer: Option<String>,
     pub base_api_url: String,
     pub http_client: reqwest::Client,
 }
 
 impl OneInchProvider {
-    pub fn new(api_key: String) -> Self {
+    pub fn new(api_key: String, referrer: Option<String>) -> Self {
         let base_api_url = "https://api.1inch.dev".to_string();
         let http_client = reqwest::Client::new();
         Self {
             api_key,
+            referrer,
             base_api_url,
             http_client,
         }
@@ -329,6 +331,9 @@ impl ConversionProvider for OneInchProvider {
         url.query_pairs_mut().append_pair("src", &src_address);
         url.query_pairs_mut().append_pair("dst", &dst_address);
         url.query_pairs_mut().append_pair("amount", &params.amount);
+        if let Some(referrer) = &self.referrer {
+            url.query_pairs_mut().append_pair("referrer", referrer);
+        }
 
         let response = self.send_request(url, &self.http_client.clone()).await?;
 
@@ -452,6 +457,9 @@ impl ConversionProvider for OneInchProvider {
         url.query_pairs_mut().append_pair("dst", &dst_address);
         url.query_pairs_mut().append_pair("amount", &params.amount);
         url.query_pairs_mut().append_pair("from", &user_address);
+        if let Some(referrer) = &self.referrer {
+            url.query_pairs_mut().append_pair("referrer", referrer);
+        }
 
         if let Some(eip155) = &params.eip155 {
             url.query_pairs_mut()

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -92,6 +92,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_PROVIDER_COINBASE_API_KEY", value = var.coinbase_api_key },
         { name = "RPC_PROXY_PROVIDER_COINBASE_APP_ID", value = var.coinbase_app_id },
         { name = "RPC_PROXY_PROVIDER_ONE_INCH_API_KEY", value = var.one_inch_api_key },
+        { name = "RPC_PROXY_PROVIDER_ONE_INCH_REFERRER", value = var.one_inch_referrer },
         { name = "RPC_PROXY_PROVIDER_GETBLOCK_ACCESS_TOKENS", value = var.getblock_access_tokens },
 
         { name = "RPC_PROXY_PROVIDER_PROMETHEUS_QUERY_URL", value = "http://127.0.0.1:${local.prometheus_proxy_port}/workspaces/${var.prometheus_workspace_id}" },

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -201,6 +201,12 @@ variable "one_inch_api_key" {
   sensitive   = true
 }
 
+variable "one_inch_referrer" {
+  description = "The referrer address for 1inch"
+  type        = string
+  sensitive   = true
+}
+
 variable "getblock_access_tokens" {
   description = "Mapping of API access tokens for GetBlock in JSON format"
   type        = string

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -69,6 +69,7 @@ module "ecs" {
   coinbase_api_key       = var.coinbase_api_key
   coinbase_app_id        = var.coinbase_app_id
   one_inch_api_key       = var.one_inch_api_key
+  one_inch_referrer      = var.one_inch_referrer
   getblock_access_tokens = var.getblock_access_tokens
 
   # Project Registry

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -121,6 +121,12 @@ variable "one_inch_api_key" {
   sensitive   = true
 }
 
+variable "one_inch_referrer" {
+  description = "The referrer address for 1inch"
+  type        = string
+  sensitive   = true
+}
+
 variable "getblock_access_tokens" {
   description = "Mapping of API access tokens for GetBlock in JSON format"
   type        = string


### PR DESCRIPTION
# Description

This PR adds `referrer` to the 1Inch `quote` and `swap` calls to pass fees depositor address. This will add fees redirection. For security reason, the referrer is stored as a TFC variable.

## How Has This Been Tested?

Configuration variables test were updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
