### PR TITLE
feat(names): moving to `wcn.id` root zone

### DIFF
--- a/integration/names.test.ts
+++ b/integration/names.test.ts
@@ -15,7 +15,7 @@ describe('Account profile names', () => {
   // Generate a random name
   const randomString = Array.from({ length: 10 }, 
     () => (Math.random().toString(36)[2] || '0')).join('')
-  const zone = 'wc.ink';
+  const zone = 'wcn.id';
   const name = `integration-test-${randomString}.${zone}`;
 
   // Create a message to sign

--- a/src/handlers/profile/mod.rs
+++ b/src/handlers/profile/mod.rs
@@ -14,7 +14,7 @@ pub mod suggestions;
 pub mod utils;
 
 /// List of allowed name zones
-pub const ALLOWED_ZONES: [&str; 1] = ["wc.ink"];
+pub const ALLOWED_ZONES: [&str; 1] = ["wcn.id"];
 
 pub const UNIXTIMESTAMP_SYNC_THRESHOLD: u64 = 10;
 


### PR DESCRIPTION
# Description

This PR making changes for the off-chain names gateway service to move from the `wc.ink` to `wcn.id` root zone.
This change is necessary as we have decided to move forward with the `wcn.id` zone instead of `wc.ink`.

## How Has This Been Tested?

Integration tests were changed to use the updated root zone.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
