### PR TITLE
fix(one_inch): adding `fee` argument to quotes and swap

### DIFF
--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -335,9 +335,9 @@ impl ConversionProvider for OneInchProvider {
         url.query_pairs_mut().append_pair("amount", &params.amount);
         if let Some(referrer) = &self.referrer {
             url.query_pairs_mut().append_pair("referrer", referrer);
+            url.query_pairs_mut()
+                .append_pair("fee", ONEINCH_FEE.to_string().as_str());
         }
-        url.query_pairs_mut()
-            .append_pair("fee", ONEINCH_FEE.to_string().as_str());
 
         let response = self.send_request(url, &self.http_client.clone()).await?;
 
@@ -463,9 +463,9 @@ impl ConversionProvider for OneInchProvider {
         url.query_pairs_mut().append_pair("from", &user_address);
         if let Some(referrer) = &self.referrer {
             url.query_pairs_mut().append_pair("referrer", referrer);
+            url.query_pairs_mut()
+                .append_pair("fee", ONEINCH_FEE.to_string().as_str());
         }
-        url.query_pairs_mut()
-            .append_pair("fee", ONEINCH_FEE.to_string().as_str());
 
         if let Some(eip155) = &params.eip155 {
             url.query_pairs_mut()
@@ -480,7 +480,6 @@ impl ConversionProvider for OneInchProvider {
         }
 
         let response = self.send_request(url, &self.http_client.clone()).await?;
-
         if !response.status().is_success() {
             // Passing through error description for the error context
             // if user parameter is invalid (got 400 status code from the provider)

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -30,6 +30,8 @@ use {
     url::Url,
 };
 
+const ONEINCH_FEE: f64 = 0.85;
+
 #[derive(Debug)]
 pub struct OneInchProvider {
     pub api_key: String,
@@ -334,6 +336,8 @@ impl ConversionProvider for OneInchProvider {
         if let Some(referrer) = &self.referrer {
             url.query_pairs_mut().append_pair("referrer", referrer);
         }
+        url.query_pairs_mut()
+            .append_pair("fee", ONEINCH_FEE.to_string().as_str());
 
         let response = self.send_request(url, &self.http_client.clone()).await?;
 
@@ -460,6 +464,8 @@ impl ConversionProvider for OneInchProvider {
         if let Some(referrer) = &self.referrer {
             url.query_pairs_mut().append_pair("referrer", referrer);
         }
+        url.query_pairs_mut()
+            .append_pair("fee", ONEINCH_FEE.to_string().as_str());
 
         if let Some(eip155) = &params.eip155 {
             url.query_pairs_mut()


### PR DESCRIPTION
# Description

This PR adds a `fee` argument that passed to `quote` and `swap` 1Inch endpoints with the value of `0.85` that was agreed upon for the `referrer` integration and using the fee depositor.

## How Has This Been Tested?

Current integration tests for converts.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
