### PR TITLE
feat(convertion): adding optional `gasPrice` to the quote endpoint

### DIFF
--- a/integration/convert.test.ts
+++ b/integration/convert.test.ts
@@ -45,8 +45,11 @@ describe('Token conversion (single chain)', () => {
   })
 
   it('get conversion quote', async () => {
+    // Optional gas price
+    const gasPrice = "1000000000";
+    
     let resp: any = await httpClient.get(
-      `${baseUrl}/v1/convert/quotes?projectId=${projectId}&amount=${amount}&from=${srcAsset}&to=${destAsset}`
+      `${baseUrl}/v1/convert/quotes?projectId=${projectId}&amount=${amount}&from=${srcAsset}&to=${destAsset}&gasPrice=${gasPrice}`
     )
     expect(resp.status).toBe(200)
     expect(typeof resp.data.quotes).toBe('object')

--- a/src/handlers/convert/quotes.rs
+++ b/src/handlers/convert/quotes.rs
@@ -20,6 +20,7 @@ pub struct ConvertQuoteQueryParams {
     pub amount: String,
     pub from: String,
     pub to: String,
+    pub gas_price: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/src/providers/one_inch.rs
+++ b/src/providers/one_inch.rs
@@ -338,6 +338,9 @@ impl ConversionProvider for OneInchProvider {
             url.query_pairs_mut()
                 .append_pair("fee", ONEINCH_FEE.to_string().as_str());
         }
+        if let Some(gas_price) = &params.gas_price {
+            url.query_pairs_mut().append_pair("gasPrice", gas_price);
+        }
 
         let response = self.send_request(url, &self.http_client.clone()).await?;
 


### PR DESCRIPTION
# Description

This PR adds an optional `gasPrice` parameter to the convert quote endpoint to allow users to choose the gas price instead of using the default fastest. [SPEC](https://github.com/WalletConnect/walletconnect-specs/pull/232) is also updated.

## How Has This Been Tested?

The integration test was updated.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
