### PR TITLE
fix(tests): adding integration test for registering name with different coin type

### DIFF
--- a/integration/names.test.ts
+++ b/integration/names.test.ts
@@ -217,6 +217,24 @@ describe('Account profile names', () => {
     expect(resp.status).toBe(400)
   })
 
+  it('try register already registered name with different coin_type', async () => {
+    // Sign the message
+    const signature = await wallet.signMessage(registerMessage);
+    const coin_type = 2147483748; // ENSIP-11 xdai
+
+    const payload = {
+      message: registerMessage,
+      signature,
+      coin_type,
+      address,
+    };
+    let resp: any = await httpClient.post(
+      `${baseUrl}/v1/profile/account`,
+      payload
+    )
+    expect(resp.status).toBe(400)
+  })
+
   it('name forward lookup', async () => {
     let resp: any = await httpClient.get(
       `${baseUrl}/v1/profile/account/${name}`


### PR DESCRIPTION
# Description

@tomiir raised concerns about the possibility of registering the same name but with a different `coin_type`. That should be prohibited. The new integration test should cover this on each CD.

## How Has This Been Tested?

* Testes by invoking local integration test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
