### PR TITLE
fix: removing excessive json header

### DIFF
--- a/src/providers/coinbase.rs
+++ b/src/providers/coinbase.rs
@@ -189,7 +189,6 @@ impl OnRampProvider for CoinbaseProvider {
         let response = http_client
             .post(url)
             .json(&params)
-            .header("Content-Type", "application/json")
             .header("CBPAY-APP-ID", self.app_id.clone())
             .header("CBPAY-API-KEY", self.api_key.clone())
             .send()


### PR DESCRIPTION
# Description

This PR removes the excessive content JSON header from the `json` reqwest method as [this header is added inside the method itself](https://github.com/seanmonstar/reqwest/blob/e639bdc1264c266a84dae3bae3193e07cae6861b/src/async_impl/request.rs#L445).

## How Has This Been Tested?

* Current integration tests are passed.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
