### PR TITLE
fix(balance): injecting forced balance update to the zero balance token response

### DIFF
--- a/integration/balance.test.ts
+++ b/integration/balance.test.ts
@@ -90,6 +90,36 @@ describe('Account balance', () => {
     }
   })
 
+  it('force update balance for the ERC20 token (injected)', async () => {
+    // Test for injected token balance if it's not in the response
+    // due to the zero balance
+
+    // Getting the empty balance without forcing balance update
+    const zero_balance_address = '0x5b6262592954B925B510651462b63ddEbcc22eaD'
+    const token_contract_address = 'eip155:8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
+    const endpoint = `/v1/account/${zero_balance_address}/balance`;
+    let queryParams = `?projectId=${projectId}&currency=${currency}`;
+    let url = `${baseUrl}${endpoint}${queryParams}`;
+    const headers = {
+        'x-sdk-version': sdk_version,
+    };
+    let resp = await httpClient.get(url, { headers });
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.balances).toBe('object')
+    expect(resp.data.balances.length).toBe(0)
+
+    // Forcing update and checking injected balance in response
+    queryParams = `${queryParams}&forceUpdate=${token_contract_address}`;
+    url = `${baseUrl}${endpoint}${queryParams}`;
+    resp = await httpClient.get(url, { headers });
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.balances).toBe('object')
+    expect(resp.data.balances.length).toBe(1)
+    const firstItem = resp.data.balances[0]
+    expect(firstItem.symbol).toBe('USDC')
+    expect(firstItem.address).toBe(token_contract_address)
+  })
+
   it('force update balance for the native token', async () => {
     // ETH token
     // We are using `0xe...` as a contract address for native tokens

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -1,5 +1,5 @@
 use {
-    super::HANDLER_TASK_METRICS,
+    super::{SupportedCurrencies, HANDLER_TASK_METRICS},
     crate::{
         analytics::BalanceLookupInfo,
         error::RpcError,
@@ -15,7 +15,6 @@ use {
     hyper::HeaderMap,
     serde::{Deserialize, Serialize},
     std::{
-        fmt::Display,
         net::SocketAddr,
         sync::Arc,
         time::{Duration, SystemTime},
@@ -25,45 +24,11 @@ use {
     wc::future::FutureExt,
 };
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum BalanceCurrencies {
-    BTC,
-    ETH,
-    USD,
-    EUR,
-    GBP,
-    AUD,
-    CAD,
-    INR,
-    JPY,
-}
-
-impl Display for BalanceCurrencies {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                BalanceCurrencies::BTC => "btc",
-                BalanceCurrencies::ETH => "eth",
-                BalanceCurrencies::USD => "usd",
-                BalanceCurrencies::EUR => "eur",
-                BalanceCurrencies::GBP => "gbp",
-                BalanceCurrencies::AUD => "aud",
-                BalanceCurrencies::CAD => "cad",
-                BalanceCurrencies::INR => "inr",
-                BalanceCurrencies::JPY => "jpy",
-            }
-        )
-    }
-}
-
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BalanceQueryParams {
     pub project_id: String,
-    pub currency: BalanceCurrencies,
+    pub currency: SupportedCurrencies,
     pub chain_id: Option<String>,
     /// Comma separated list of CAIP-10 contract addresses to force update the balance
     pub force_update: Option<String>,
@@ -223,6 +188,7 @@ async fn handler_internal(
                     balance.price,
                     balance.quantity.decimals.parse::<u32>().unwrap_or(0),
                 ));
+                continue;
             }
             if contract_address == H160::repeat_byte(0xee) {
                 if let Some(balance) = response
@@ -240,8 +206,52 @@ async fn handler_internal(
                         balance.price,
                         balance.quantity.decimals.parse::<u32>().unwrap_or(0),
                     ));
+                    continue;
                 }
             }
+            // Appending the token item to the response if it's not in
+            // the balance response due to the zero balance
+            let get_price_info = state
+                .providers
+                .fungible_price_provider
+                .get_price(
+                    &chain_id.clone(),
+                    format!("{:#x}", contract_address).as_str(),
+                    &query.currency,
+                )
+                .await
+                .tap_err(|e| {
+                    error!("Failed to call fungible get_price with {}", e);
+                })?;
+            let token_info = get_price_info.fungibles.first().ok_or_else(|| {
+                error!(
+                    "Empty tokens list result from get_price for address: {:#x}",
+                    contract_address
+                );
+                RpcError::BalanceProviderError
+            })?;
+
+            response.balances.push(BalanceItem {
+                name: token_info.name.clone(),
+                symbol: token_info.symbol.clone(),
+                chain_id: Some(caip2_chain_id.clone()),
+                address: if contract_address == H160::repeat_byte(0xee) {
+                    None
+                } else {
+                    Some(caip_contract_address.to_string())
+                },
+                value: Some(crypto::convert_token_amount_to_value(
+                    rpc_balance,
+                    token_info.price,
+                    token_info.decimals,
+                )),
+                price: token_info.price,
+                quantity: BalanceQuantity {
+                    decimals: token_info.decimals.to_string(),
+                    numeric: crypto::format_token_amount(rpc_balance, token_info.decimals),
+                },
+                icon_url: token_info.icon_url.clone(),
+            });
         }
     }
 

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -142,6 +142,7 @@ async fn handler_internal(
     // Check for the cache invalidation for the certain token contract addresses and
     // update/override balance results for the token from the RPC call
     if let Some(force_update) = &query.force_update {
+        const H160_EMPTY_ADDRESS: H160 = H160::repeat_byte(0xee);
         let rpc_project_id = state
             .config
             .server
@@ -190,7 +191,7 @@ async fn handler_internal(
                 ));
                 continue;
             }
-            if contract_address == H160::repeat_byte(0xee) {
+            if contract_address == H160_EMPTY_ADDRESS {
                 if let Some(balance) = response
                     .balances
                     .iter_mut()
@@ -235,7 +236,7 @@ async fn handler_internal(
                 name: token_info.name.clone(),
                 symbol: token_info.symbol.clone(),
                 chain_id: Some(caip2_chain_id.clone()),
-                address: if contract_address == H160::repeat_byte(0xee) {
+                address: if contract_address == H160_EMPTY_ADDRESS {
                     None
                 } else {
                     Some(caip_contract_address.to_string())

--- a/src/handlers/convert/tokens.rs
+++ b/src/handlers/convert/tokens.rs
@@ -18,6 +18,8 @@ use {
 pub struct TokensListQueryParams {
     pub project_id: String,
     pub chain_id: String,
+    /// Filter tokens by the implementation address
+    pub address: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -32,7 +34,7 @@ pub struct TokenItem {
     pub name: String,
     pub symbol: String,
     pub address: String,
-    pub decimals: u8,
+    pub decimals: u32,
     pub logo_uri: Option<String>,
     pub eip2612: Option<bool>,
 }

--- a/src/handlers/fungible_price.rs
+++ b/src/handlers/fungible_price.rs
@@ -1,5 +1,5 @@
 use {
-    super::HANDLER_TASK_METRICS,
+    super::{SupportedCurrencies, HANDLER_TASK_METRICS},
     crate::{error::RpcError, state::AppState, utils::crypto},
     axum::{
         extract::State,
@@ -7,51 +7,17 @@ use {
         Json,
     },
     serde::{Deserialize, Serialize},
-    std::{fmt::Display, sync::Arc},
+    std::sync::Arc,
     tap::TapFallible,
     tracing::log::error,
     wc::future::FutureExt,
 };
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum PriceCurrencies {
-    BTC,
-    ETH,
-    USD,
-    EUR,
-    GBP,
-    AUD,
-    CAD,
-    INR,
-    JPY,
-}
-
-impl Display for PriceCurrencies {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                PriceCurrencies::BTC => "btc",
-                PriceCurrencies::ETH => "eth",
-                PriceCurrencies::USD => "usd",
-                PriceCurrencies::EUR => "eur",
-                PriceCurrencies::GBP => "gbp",
-                PriceCurrencies::AUD => "aud",
-                PriceCurrencies::CAD => "cad",
-                PriceCurrencies::INR => "inr",
-                PriceCurrencies::JPY => "jpy",
-            }
-        )
-    }
-}
-
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PriceQueryParams {
     pub project_id: String,
-    pub currency: PriceCurrencies,
+    pub currency: SupportedCurrencies,
     pub addresses: Vec<String>,
 }
 
@@ -68,6 +34,7 @@ pub struct FungiblePriceItem {
     pub symbol: String,
     pub icon_url: String,
     pub price: f64,
+    pub decimals: u32,
 }
 
 pub async fn handler(

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -7,7 +7,7 @@ use {
         response::{IntoResponse, Response},
     },
     serde::{Deserialize, Serialize},
-    std::sync::Arc,
+    std::{fmt::Display, sync::Arc},
     tracing::error,
     wc::metrics::TaskMetrics,
 };
@@ -41,6 +41,40 @@ pub struct RpcQueryParams {
 #[derive(Serialize)]
 pub struct SuccessResponse {
     status: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum SupportedCurrencies {
+    BTC,
+    ETH,
+    USD,
+    EUR,
+    GBP,
+    AUD,
+    CAD,
+    INR,
+    JPY,
+}
+
+impl Display for SupportedCurrencies {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                SupportedCurrencies::BTC => "btc",
+                SupportedCurrencies::ETH => "eth",
+                SupportedCurrencies::USD => "usd",
+                SupportedCurrencies::EUR => "eur",
+                SupportedCurrencies::GBP => "gbp",
+                SupportedCurrencies::AUD => "aud",
+                SupportedCurrencies::CAD => "cad",
+                SupportedCurrencies::INR => "inr",
+                SupportedCurrencies::JPY => "jpy",
+            }
+        )
+    }
 }
 
 /// Rate limit middleware that uses `rate_limiting`` token bucket sub crate

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -13,14 +13,14 @@ use {
                 tokens::{TokensListQueryParams, TokensListResponseBody},
                 transaction::{ConvertTransactionQueryParams, ConvertTransactionResponseBody},
             },
-            fungible_price::{PriceCurrencies, PriceResponseBody},
+            fungible_price::PriceResponseBody,
             history::{HistoryQueryParams, HistoryResponseBody},
             onramp::{
                 options::{OnRampBuyOptionsParams, OnRampBuyOptionsResponse},
                 quotes::{OnRampBuyQuotesParams, OnRampBuyQuotesResponse},
             },
             portfolio::{PortfolioQueryParams, PortfolioResponseBody},
-            RpcQueryParams,
+            RpcQueryParams, SupportedCurrencies,
         },
     },
     async_trait::async_trait,
@@ -613,7 +613,7 @@ pub trait FungiblePriceProvider: Send + Sync + Debug {
         &self,
         chain_id: &str,
         address: &str,
-        currency: &PriceCurrencies,
+        currency: &SupportedCurrencies,
     ) -> RpcResult<PriceResponseBody>;
 }
 


### PR DESCRIPTION
# Description

This PR fixes the bug where a forced balance update is invoked, but no updated balance in response due to the absence of the token in the balance object due to zero balance. 
As a fix, we are injecting the token balance item if there are no token item found in the current Zerion response that overrides the recent balance update from JSON-RPC or contract response.

[Slack conversation.](https://walletconnect.slack.com/archives/C03RVH94K5K/p1716557794631039?thread_ts=1713176741.098649&cid=C03RVH94K5K)

## How Has This Been Tested?

* [A new integration test was implemented](https://github.com/WalletConnect/blockchain-api/pull/661/files#diff-13d7369ef8e242470eace4b6a7039baf1685c66f865763226588f2c6bc652dccR93).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
