### PR TITLE
fix: relax paths-ignore

### DIFF
--- a/.github/workflows/event_release.yml
+++ b/.github/workflows/event_release.yml
@@ -7,10 +7,7 @@ on:
       - main
       - master
     paths-ignore:
-      - '.github/**'
       - 'docs/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
       - 'README.md'
       - 'CHANGELOG.md'
       - 'LICENSE'


### PR DESCRIPTION
# Description

Relax paths-ignore so releases get executed if Cargo.toml|lock or workflow files change.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
