### PR TITLE
feat: rpc source analytics

### DIFF
--- a/justfile
+++ b/justfile
@@ -159,7 +159,7 @@ cargo-test-default: _check-cmd-cargo
 # Run project tests with all features activated
 cargo-test-all: _check-cmd-cargo
   @printf '==> Testing project ({{ light-green }}all features{{ nocolor }})\n'
-  cargo +nightly test --all-features
+  cargo test --all-features
 
 # Run tests from project documentation
 cargo-test-doc: _check-cmd-cargo
@@ -179,7 +179,7 @@ cargo-check: _check-cmd-cargo
 # Check rust project with clippy
 cargo-clippy: _check-cmd-cargo-clippy
   @printf '==> Running {{ color-cmd }}clippy{{ nocolor }}\n'
-  cargo +nightly clippy --all-features --tests -- -D clippy::all
+  cargo clippy --all-features --tests -- -D clippy::all
 
 # Check unused dependencies
 cargo-udeps: _check-cmd-cargo-udeps
@@ -242,14 +242,30 @@ tf target='': (_check-string-in-set target "fmt,checkfmt,validate,tfsec,tflint,i
   cd {{ tf-dir }}; terraform validate
 
 # Check Terraform configuration for potential security issues
-@tf-tfsec: _check-cmd-tfsec
-  printf '==> Running {{ color-cmd }}tfsec{{ nocolor }}\n'
-  cd {{ tf-dir }}; tfsec
+@tf-tfsec:
+  #!/bin/bash
+  set -euo pipefail
+  
+  if command -v tfsec >/dev/null; then
+    echo '==> Running tfsec'
+    cd terraform
+    tfsec
+  else
+    echo '==> tfsec not found in PATH, skipping'
+  fi
 
 # Run Terraform linter
-@tf-tflint: _check-cmd-tflint
-  printf '==> Running {{ color-cmd }}tflint{{ nocolor }}\n'
-  cd {{ tf-dir }}; tflint --recursive
+@tf-tflint:
+  #!/bin/bash
+  set -euo pipefail
+
+  if command -v tflint >/dev/null; then
+    echo '==> Running tflint'
+    cd terraform; tflint --recursive
+
+  else
+    echo '==> tflint not found in PATH, skipping'
+  fi
 
 # Init Terraform project
 @tf-init: _check-cmd-terraform

--- a/src/analytics/message_info.rs
+++ b/src/analytics/message_info.rs
@@ -13,6 +13,7 @@ pub struct MessageInfo {
     pub project_id: String,
     pub chain_id: String,
     pub method: Arc<str>,
+    pub source: String,
 
     pub origin: Option<String>,
     pub provider: String,
@@ -38,6 +39,10 @@ impl MessageInfo {
             project_id: query_params.project_id.to_owned(),
             chain_id: query_params.chain_id.to_lowercase(),
             method: request.method.clone(),
+            source: query_params
+                .source
+                .clone()
+                .unwrap_or_else(|| "rpc".to_owned()),
 
             origin,
             provider: provider.to_string(),

--- a/src/analytics/message_info.rs
+++ b/src/analytics/message_info.rs
@@ -1,8 +1,9 @@
 use {
     crate::{handlers::RpcQueryParams, json_rpc::JsonRpcRequest, providers::ProviderKind},
     parquet_derive::ParquetRecordWriter,
-    serde::Serialize,
+    serde::{Deserialize, Serialize},
     std::sync::Arc,
+    strum::{Display, EnumString},
 };
 
 #[derive(Debug, Clone, Serialize, ParquetRecordWriter)]
@@ -41,8 +42,9 @@ impl MessageInfo {
             method: request.method.clone(),
             source: query_params
                 .source
-                .clone()
-                .unwrap_or_else(|| "rpc".to_owned()),
+                .as_ref()
+                .unwrap_or(&MessageSource::Rpc)
+                .to_string(),
 
             origin,
             provider: provider.to_string(),
@@ -51,5 +53,52 @@ impl MessageInfo {
             country,
             continent,
         }
+    }
+}
+
+#[derive(Debug, Clone, EnumString, Display, Deserialize, PartialEq)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum MessageSource {
+    Rpc,
+    Identity,
+    Balance,
+    ProfileAddressSigValidate,
+    ProfileAttributesSigValidate,
+    ProfileRegisterSigValidate,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_message_source() {
+        let source = MessageSource::Rpc;
+        assert_eq!(source.to_string(), "rpc");
+
+        let source = MessageSource::Identity;
+        assert_eq!(source.to_string(), "identity");
+
+        let source = MessageSource::Balance;
+        assert_eq!(source.to_string(), "balance");
+
+        let source = MessageSource::ProfileAddressSigValidate;
+        assert_eq!(source.to_string(), "profile_address_sig_validate");
+
+        let source = MessageSource::ProfileAttributesSigValidate;
+        assert_eq!(source.to_string(), "profile_attributes_sig_validate");
+
+        let source = MessageSource::ProfileRegisterSigValidate;
+        assert_eq!(source.to_string(), "profile_register_sig_validate");
+    }
+
+    #[test]
+    fn deserialize_message_source() {
+        let source = serde_json::json!("rpc");
+        assert_eq!(
+            serde_json::from_value::<MessageSource>(source).unwrap(),
+            MessageSource::Rpc
+        );
     }
 }

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -15,7 +15,7 @@ use {
 };
 pub use {
     balance_lookup_info::BalanceLookupInfo, config::Config, history_lookup_info::HistoryLookupInfo,
-    identity_lookup_info::IdentityLookupInfo, message_info::MessageInfo,
+    identity_lookup_info::IdentityLookupInfo, message_info::*,
     onramp_history_lookup_info::OnrampHistoryLookupInfo,
 };
 

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -1,7 +1,7 @@
 use {
     super::HANDLER_TASK_METRICS,
     crate::{
-        analytics::BalanceLookupInfo,
+        analytics::{BalanceLookupInfo, MessageSource},
         error::RpcError,
         state::AppState,
         utils::{crypto, network},
@@ -206,7 +206,7 @@ async fn handler_internal(
                 contract_address,
                 parsed_address,
                 rpc_project_id,
-                "balance",
+                MessageSource::Balance,
             )
             .await?;
             if let Some(balance) = response

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -206,6 +206,7 @@ async fn handler_internal(
                 contract_address,
                 parsed_address,
                 rpc_project_id,
+                "balance",
             )
             .await?;
             if let Some(balance) = response

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -276,7 +276,7 @@ async fn lookup_identity_rpc(
             // ENS registry contract is only deployed on mainnet
             chain_id: ETHEREUM_MAINNET.to_owned(),
             provider_id: None,
-            source: Some("identity".to_owned()),
+            source: Some(crate::analytics::MessageSource::Identity),
         },
         headers,
     });

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -276,6 +276,7 @@ async fn lookup_identity_rpc(
             // ENS registry contract is only deployed on mainnet
             chain_id: ETHEREUM_MAINNET.to_owned(),
             provider_id: None,
+            source: Some("identity".to_owned()),
         },
         headers,
     });

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -36,6 +36,10 @@ pub struct RpcQueryParams {
     pub project_id: String,
     /// Optional provider ID for the exact provider request
     pub provider_id: Option<String>,
+
+    // TODO remove this param, as it can be set by actual rpc users but it shouldn't be
+    /// Optional "source" field to indicate an internal request
+    pub source: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{error::RpcError, state::AppState, utils::network},
+    crate::{analytics::MessageSource, error::RpcError, state::AppState, utils::network},
     axum::{
         extract::{MatchedPath, State},
         http::Request,
@@ -39,7 +39,7 @@ pub struct RpcQueryParams {
 
     // TODO remove this param, as it can be set by actual rpc users but it shouldn't be
     /// Optional "source" field to indicate an internal request
-    pub source: Option<String>,
+    pub source: Option<MessageSource>,
 }
 
 #[derive(Serialize)]

--- a/src/handlers/profile/address.rs
+++ b/src/handlers/profile/address.rs
@@ -113,6 +113,7 @@ pub async fn handler_internal(
         &request_payload.address,
         &chain_id_caip2,
         rpc_project_id,
+        "profile_address_sig_validate",
     )
     .await
     {

--- a/src/handlers/profile/address.rs
+++ b/src/handlers/profile/address.rs
@@ -4,6 +4,7 @@ use {
         UpdateAddressPayload, UNIXTIMESTAMP_SYNC_THRESHOLD,
     },
     crate::{
+        analytics::MessageSource,
         database::{
             helpers::{get_name_and_addresses_by_name, insert_or_update_address},
             types::SupportedNamespaces,
@@ -113,7 +114,7 @@ pub async fn handler_internal(
         &request_payload.address,
         &chain_id_caip2,
         rpc_project_id,
-        "profile_address_sig_validate",
+        MessageSource::ProfileAddressSigValidate,
     )
     .await
     {

--- a/src/handlers/profile/attributes.rs
+++ b/src/handlers/profile/attributes.rs
@@ -5,6 +5,7 @@ use {
         RegisterRequest, UpdateAttributesPayload, UNIXTIMESTAMP_SYNC_THRESHOLD,
     },
     crate::{
+        analytics::MessageSource,
         database::helpers::{get_name_and_addresses_by_name, update_name_attributes},
         error::RpcError,
         state::AppState,
@@ -89,7 +90,7 @@ pub async fn handler_internal(
         &request_payload.address,
         &chain_id_caip2,
         rpc_project_id,
-        "profile_attributes_sig_validate",
+        MessageSource::ProfileAttributesSigValidate,
     )
     .await
     {

--- a/src/handlers/profile/attributes.rs
+++ b/src/handlers/profile/attributes.rs
@@ -89,6 +89,7 @@ pub async fn handler_internal(
         &request_payload.address,
         &chain_id_caip2,
         rpc_project_id,
+        "profile_attributes_sig_validate",
     )
     .await
     {

--- a/src/handlers/profile/register.rs
+++ b/src/handlers/profile/register.rs
@@ -8,6 +8,7 @@ use {
         RegisterPayload, RegisterRequest, ALLOWED_ZONES, UNIXTIMESTAMP_SYNC_THRESHOLD,
     },
     crate::{
+        analytics::MessageSource,
         database::{
             helpers::{get_name_and_addresses_by_name, insert_name},
             types::{Address, ENSIP11AddressesMap, SupportedNamespaces},
@@ -115,7 +116,7 @@ pub async fn handler_internal(
         &register_request.address,
         &chain_id_caip2,
         rpc_project_id,
-        "profile_register_sig_validate",
+        MessageSource::ProfileRegisterSigValidate,
     )
     .await
     {

--- a/src/handlers/profile/register.rs
+++ b/src/handlers/profile/register.rs
@@ -115,6 +115,7 @@ pub async fn handler_internal(
         &register_request.address,
         &chain_id_caip2,
         rpc_project_id,
+        "profile_register_sig_validate",
     )
     .await
     {

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -66,8 +66,17 @@ pub async fn verify_message_signature(
     address: &str,
     chain_id: &str,
     rpc_project_id: &str,
+    source: &str,
 ) -> Result<bool, CryptoUitlsError> {
-    verify_eip6492_message_signature(message, signature, chain_id, address, rpc_project_id).await
+    verify_eip6492_message_signature(
+        message,
+        signature,
+        chain_id,
+        address,
+        rpc_project_id,
+        source,
+    )
+    .await
 }
 
 /// Veryfy message signature for eip6492 contract
@@ -78,6 +87,7 @@ pub async fn verify_eip6492_message_signature(
     chain_id: &str,
     address: &str,
     rpc_project_id: &str,
+    source: &str,
 ) -> Result<bool, CryptoUitlsError> {
     let message_hash: [u8; 32] = get_message_hash(message).into();
     let address = Address::parse_checksummed(address, None)
@@ -96,6 +106,7 @@ pub async fn verify_eip6492_message_signature(
     provider
         .query_pairs_mut()
         .append_pair("projectId", rpc_project_id);
+    provider.query_pairs_mut().append_pair("source", source);
 
     let hexed_signature = hex::decode(&signature[2..])
         .map_err(|e| CryptoUitlsError::SignatureFormat(format!("Wrong signature format: {}", e)))?;
@@ -117,13 +128,14 @@ pub async fn get_erc20_balance(
     contract: H160,
     wallet: H160,
     rpc_project_id: &str,
+    source: &str,
 ) -> Result<U256, CryptoUitlsError> {
     // Use JSON-RPC call for the balance of the native ERC20 tokens
     // or call the contract for the custom ERC20 tokens
     let balance = if contract == H160::repeat_byte(0xee) {
-        get_erc20_jsonrpc_balance(chain_id, wallet, rpc_project_id).await?
+        get_balance(chain_id, wallet, rpc_project_id, source).await?
     } else {
-        get_erc20_contract_balance(chain_id, contract, wallet, rpc_project_id).await?
+        get_erc20_contract_balance(chain_id, contract, wallet, rpc_project_id, source).await?
     };
 
     Ok(balance)
@@ -136,6 +148,7 @@ async fn get_erc20_contract_balance(
     contract: H160,
     wallet: H160,
     rpc_project_id: &str,
+    source: &str,
 ) -> Result<U256, CryptoUitlsError> {
     abigen!(
         ERC20Contract,
@@ -145,8 +158,8 @@ async fn get_erc20_contract_balance(
     );
 
     let provider = Provider::<Http>::try_from(format!(
-        "https://rpc.walletconnect.com/v1?chainId={}&projectId={}",
-        chain_id, rpc_project_id
+        "https://rpc.walletconnect.com/v1?chainId={}&projectId={}&source={}",
+        chain_id, rpc_project_id, source
     ))
     .map_err(|e| CryptoUitlsError::RpcUrlParseError(format!("Failed to parse RPC url: {}", e)))?;
     let provider = Arc::new(provider);
@@ -161,16 +174,17 @@ async fn get_erc20_contract_balance(
     Ok(balance)
 }
 
-/// Get the balance of ERC20 token using JSON-RPC call
+/// Get the balance of the native coin
 #[tracing::instrument]
-async fn get_erc20_jsonrpc_balance(
+async fn get_balance(
     chain_id: &str,
     wallet: H160,
     rpc_project_id: &str,
+    source: &str,
 ) -> Result<U256, CryptoUitlsError> {
     let provider = Provider::<Http>::try_from(format!(
-        "https://rpc.walletconnect.com/v1?chainId={}&projectId={}",
-        chain_id, rpc_project_id
+        "https://rpc.walletconnect.com/v1?chainId={}&projectId={}&source={}",
+        chain_id, rpc_project_id, source
     ))
     .map_err(|e| CryptoUitlsError::RpcUrlParseError(format!("Failed to parse RPC url: {}", e)))?;
     let provider = Arc::new(provider);


### PR DESCRIPTION
# Description

Adds the source of the RPC call to the analytics export. [Slack conversation](https://walletconnect.slack.com/archives/C04HK47TNBB/p1717082696327969?thread_ts=1717064623.738729&cid=C04HK47TNBB)

Also fixes `devloop` so that it works w/o tflint and tfsec. Also runs checks under stable Rust as this is what CI uses.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
