### PR TITLE
feat(names): adding mainnet cointype `60` address by default

### DIFF
--- a/integration/names.test.ts
+++ b/integration/names.test.ts
@@ -198,11 +198,24 @@ describe('Account profile names', () => {
       payload
     )
     expect(resp.status).toBe(200)
+    expect(resp.data.name).toBe(name)
+    expect(typeof resp.data.addresses).toBe('object')
+    const mainnet_address = resp.data.addresses[coin_type]
+    expect(mainnet_address.address).toBe(address)
   })
 
   it('register new name with not Mainnet coin type', async () => {
     // If the user registering new name with not Mainnet coin type
     // it should be added automatically to the addresses list
+    const randomString = Array.from({ length: 10 }, 
+      () => (Math.random().toString(36)[2] || '0')).join('')
+    const name = `integration-test-${randomString}.${zone}`;
+    const registerMessageObject = {
+        name,
+        attributes,
+        timestamp: Math.round(Date.now() / 1000)
+    };
+    const registerMessage = JSON.stringify(registerMessageObject);
     const signature = await wallet.signMessage(registerMessage);
 
     const payload = {

--- a/integration/names.test.ts
+++ b/integration/names.test.ts
@@ -200,6 +200,30 @@ describe('Account profile names', () => {
     expect(resp.status).toBe(200)
   })
 
+  it('register new name with not Mainnet coin type', async () => {
+    // If the user registering new name with not Mainnet coin type
+    // it should be added automatically to the addresses list
+    const signature = await wallet.signMessage(registerMessage);
+
+    const payload = {
+      message: registerMessage,
+      signature,
+      coin_type: 2147483748, // ENSIP-11 xdai
+      address,
+    };
+    let resp: any = await httpClient.post(
+      `${baseUrl}/v1/profile/account`,
+      payload
+    )
+    expect(resp.status).toBe(200)
+    expect(resp.data.name).toBe(name)
+    expect(typeof resp.data.addresses).toBe('object')
+    const mainnet_address = resp.data.addresses[60]
+    expect(mainnet_address.address).toBe(address)
+    const xdai_address = resp.data.addresses[2147483748]
+    expect(xdai_address.address).toBe(address)
+  })
+
   it('try register already registered name', async () => {
     // Sign the message
     const signature = await wallet.signMessage(registerMessage);

--- a/src/handlers/profile/register.rs
+++ b/src/handlers/profile/register.rs
@@ -134,13 +134,22 @@ pub async fn handler_internal(
     }
 
     // Register (insert) a new domain with address
-    let addresses: ENSIP11AddressesMap = HashMap::from([(
+    let mut addresses: ENSIP11AddressesMap = HashMap::from([(
         register_request.coin_type,
         Address {
-            address: register_request.address,
+            address: register_request.address.clone(),
             created_at: None,
         },
     )]);
+
+    // Adding address with cointype 60 (Mainnet) by default
+    // if it was not provided during the registration
+    if let std::collections::hash_map::Entry::Vacant(e) = addresses.entry(60) {
+        e.insert(Address {
+            address: register_request.address,
+            created_at: None,
+        });
+    }
 
     let insert_result = insert_name(
         payload.name.clone(),


### PR DESCRIPTION
# Description

This PR adds an address for the mainnet ENSIP-11 cointype `60` if the user is not provided it during the registration.

This should be set by default since we are missing this in the UI when the user is not on the Mainnet chain the name address is only added for the non-mainnet cointype. In this case, ENS.app resolution will not work, since the ENS contracts are on the Mainnet and Sepolia.

The full context: [Slack](https://walletconnect.slack.com/archives/C03RVH94K5K/p1718194512697689?thread_ts=1718179147.968809&cid=C03RVH94K5K)

## How Has This Been Tested?

* New integration test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
