### PR TITLE
fix: remove service executor

### DIFF
--- a/terraform/monitoring/panels/lb/error_5xx.libsonnet
+++ b/terraform/monitoring/panels/lb/error_5xx.libsonnet
@@ -50,7 +50,7 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
       refId       = 'ELB',
     ))
     .addTarget(targets.cloudwatch(
-      alias       = 'ELB',
+      alias       = 'ELB 500',
       datasource  = ds.cloudwatch,
       namespace   = 'AWS/ApplicationELB',
       metricName  = 'HTTPCode_ELB_500_Count',
@@ -62,7 +62,7 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
       refId       = 'ELB500',
     ))
     .addTarget(targets.cloudwatch(
-      alias       = 'ELB',
+      alias       = 'ELB 502',
       datasource  = ds.cloudwatch,
       namespace   = 'AWS/ApplicationELB',
       metricName  = 'HTTPCode_ELB_502_Count',
@@ -74,7 +74,7 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
       refId       = 'ELB502',
     ))
     .addTarget(targets.cloudwatch(
-      alias       = 'ELB',
+      alias       = 'ELB 503',
       datasource  = ds.cloudwatch,
       namespace   = 'AWS/ApplicationELB',
       metricName  = 'HTTPCode_ELB_503_Count',
@@ -86,7 +86,7 @@ local _alert(namespace, env, notifications) = grafana.alert.new(
       refId       = 'ELB503',
     ))
     .addTarget(targets.cloudwatch(
-      alias       = 'ELB',
+      alias       = 'ELB 504',
       datasource  = ds.cloudwatch,
       namespace   = 'AWS/ApplicationELB',
       metricName  = 'HTTPCode_ELB_504_Count',


### PR DESCRIPTION
# Description

As per [this discussion](https://walletconnect.slack.com/archives/C058RS0MH38/p1718212843263849?thread_ts=1718209220.781689&cid=C058RS0MH38) I don't think we need the service executor anymore. This closes ELB connections and likely results in 502 errors to clients. This existed to reduce memory load but now we use an ALB which decouples client connections from server connections.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
