### PR TITLE
feat(metrics): implementing account names count metrics watcher

### DIFF
--- a/src/database/helpers.rs
+++ b/src/database/helpers.rs
@@ -284,7 +284,7 @@ pub async fn insert_or_update_address<'e>(
     Ok(result_map)
 }
 
-#[instrument(skip(postgres))]
+#[instrument(skip(postgres), level = "debug")]
 pub async fn get_account_names_stats(
     postgres: &PgPool,
 ) -> std::result::Result<AccountNamesStats, sqlx::error::Error> {

--- a/src/database/helpers.rs
+++ b/src/database/helpers.rs
@@ -288,7 +288,7 @@ pub async fn insert_or_update_address<'e>(
 pub async fn get_account_names_stats(
     postgres: &PgPool,
 ) -> std::result::Result<AccountNamesStats, sqlx::error::Error> {
-    let query = "SELECT COUNT(name) FROM names AS count";
+    let query = "SELECT COUNT(*) FROM names AS count";
     let stats = sqlx::query_as::<Postgres, AccountNamesStats>(query)
         .fetch_one(postgres)
         .await?;

--- a/src/database/helpers.rs
+++ b/src/database/helpers.rs
@@ -1,7 +1,7 @@
 use {
     crate::database::{error::DatabaseError, types, utils},
     chrono::{DateTime, Utc},
-    sqlx::{PgPool, Postgres, Row},
+    sqlx::{FromRow, PgPool, Postgres, Row},
     std::collections::HashMap,
     tracing::{error, instrument},
 };
@@ -12,6 +12,11 @@ struct RowAddress {
     chain_id: String,
     address: String,
     created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, FromRow)]
+pub struct AccountNamesStats {
+    pub count: i64,
 }
 
 /// Initial name registration insert
@@ -277,4 +282,15 @@ pub async fn insert_or_update_address<'e>(
     );
 
     Ok(result_map)
+}
+
+#[instrument(skip(postgres))]
+pub async fn get_account_names_stats(
+    postgres: &PgPool,
+) -> std::result::Result<AccountNamesStats, sqlx::error::Error> {
+    let query = "SELECT COUNT(name) FROM names AS count";
+    let stats = sqlx::query_as::<Postgres, AccountNamesStats>(query)
+        .fetch_one(postgres)
+        .await?;
+    Ok(stats)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ use {
 const KEEPALIVE_IDLE_DURATION: Duration = Duration::from_secs(60);
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 const KEEPALIVE_RETRIES: u32 = 5;
-const DB_STATS_POLLING_INTERVAL: Duration = Duration::from_secs(60);
+const DB_STATS_POLLING_INTERVAL: Duration = Duration::from_secs(3600);
 
 mod analytics;
 pub mod database;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ use {
 const KEEPALIVE_IDLE_DURATION: Duration = Duration::from_secs(60);
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 const KEEPALIVE_RETRIES: u32 = 5;
+const DB_STATS_POLLING_INTERVAL: Duration = Duration::from_secs(60);
 
 mod analytics;
 pub mod database;
@@ -395,6 +396,17 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         tokio::spawn(weights_updater),
         tokio::spawn(system_metrics_updater),
         tokio::spawn(profiler),
+        // Spawning a new task to observe metrics from the database by interval polling
+        tokio::spawn({
+            let postgres = state_arc.postgres.clone();
+            async move {
+                let mut interval = tokio::time::interval(DB_STATS_POLLING_INTERVAL);
+                loop {
+                    interval.tick().await;
+                    metrics.update_account_names_count(&postgres).await;
+                }
+            }
+        }),
     ];
 
     if let Err(e) = futures_util::future::select_all(services).await.0 {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -551,7 +551,7 @@ impl Metrics {
     }
 
     /// Update the account names count from database
-    #[instrument(skip_all)]
+    #[instrument(skip_all, level = "debug")]
     pub async fn update_account_names_count(&self, postgres: &PgPool) {
         let names_stats = get_account_names_stats(postgres).await;
         match names_stats {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,17 +1,20 @@
 use {
     crate::{
+        database::helpers::get_account_names_stats,
         handlers::identity::IdentityLookupSource,
         providers::{ProviderKind, RpcProvider},
     },
     hyper::http,
+    sqlx::PgPool,
     std::time::{Duration, SystemTime},
     sysinfo::{
         CpuRefreshKind, MemoryRefreshKind, RefreshKind, System, MINIMUM_CPU_UPDATE_INTERVAL,
     },
+    tracing::{error, instrument},
     wc::metrics::{
         otel::{
             self,
-            metrics::{Counter, Histogram},
+            metrics::{Counter, Histogram, ObservableGauge},
         },
         ServiceMetrics,
     },
@@ -55,6 +58,9 @@ pub struct Metrics {
 
     // Rate limiting
     pub rate_limited_entries_counter: Histogram<u64>,
+
+    // Account names
+    pub account_names_count: ObservableGauge<u64>,
 }
 
 impl Metrics {
@@ -222,6 +228,11 @@ impl Metrics {
             .with_description("The rate limited entries counter")
             .init();
 
+        let account_names_count = meter
+            .u64_observable_gauge("account_names_count")
+            .with_description("Registered account names count")
+            .init();
+
         Metrics {
             rpc_call_counter,
             rpc_call_retries,
@@ -255,6 +266,7 @@ impl Metrics {
             memory_total,
             memory_used,
             rate_limited_entries_counter,
+            account_names_count,
         }
     }
 }
@@ -536,5 +548,26 @@ impl Metrics {
 
         self.add_memory_total(system.total_memory() as f64);
         self.add_memory_used(system.used_memory() as f64);
+    }
+
+    /// Update the account names count from database
+    #[instrument(skip_all)]
+    pub async fn update_account_names_count(&self, postgres: &PgPool) {
+        let names_stats = get_account_names_stats(postgres).await;
+        match names_stats {
+            Ok(names_stats) => {
+                self.account_names_count.observe(
+                    &otel::Context::new(),
+                    names_stats.count as u64,
+                    &[],
+                );
+            }
+            Err(e) => {
+                error!(
+                    "Error on getting account names stats from database: {:?}",
+                    e
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
# Description

This PR implements an account names counter metrics watcher that periodically checks the names rows count in the `names` database table and stores the value to the `account_names_count` metrics gauge.

The new Grafana dashboard PR #674 

## How Has This Been Tested?

* New unit test for database helper function,

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
