### PR TITLE
feat(grafana): adding account names counter dashboard

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -124,12 +124,15 @@ dashboard.new(
     panels.history.latency(ds, vars)                { gridPos: pos_short._3 },
     panels.history.availability(ds, vars)           { gridPos: pos_short._3 },
 
-  row.new('Identity (ENS) Metrics'),
+  row.new('Identity resolver (ENS resolver) Metrics'),
     panels.identity.requests(ds, vars)               { gridPos: pos_short._2 },
     panels.identity.availability(ds, vars)           { gridPos: pos_short._2 },
     panels.identity.latency(ds, vars)                { gridPos: pos_short._2 },
     panels.identity.cache(ds, vars)                  { gridPos: pos_short._2 },
     panels.identity.usage(ds, vars)                  { gridPos: pos_short._2 },
+
+  row.new('Account names (ENS gateway) Metrics'),
+    panels.names.registered(ds, vars)                { gridPos: pos_short._3 },
 
   row.new('Redis'),
     panels.redis.cpu(ds, vars)                    { gridPos: pos._2 },

--- a/terraform/monitoring/panels/names/registered.libsonnet
+++ b/terraform/monitoring/panels/names/registered.libsonnet
@@ -1,0 +1,20 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Names registered',
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+
+    .addTarget(targets.prometheus(
+      datasource  = ds.prometheus,
+      expr        = 'rate(account_names_count_total{}[$__rate_interval])',
+      refId       = "Names count",
+    ))
+}

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -44,6 +44,10 @@ local redis  = panels.aws.redis;
     usage:                (import 'identity/usage.libsonnet'              ).new,
   },
 
+  names: {
+    registered:           (import 'names/registered.libsonnet'            ).new,
+  },
+
   history: {
     availability:         (import 'history/availability.libsonnet'        ).new,
     requests:             (import 'history/requests.libsonnet'            ).new,


### PR DESCRIPTION
# Description

This PR adds a new Grafana dashboard to monitor how many account names were registered.
This is a follow-up of #672.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
