### PR TITLE
fix(ratelimiting): tuning token bucket settings

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -174,7 +174,7 @@ variable "webhook_prometheus_p2" {
 variable "rate_limiting_max_tokens" {
   description = "The maximum number of tokens in the bucket"
   type        = number
-  default     = 100
+  default     = 30
 }
 
 variable "rate_limiting_refill_interval" {
@@ -186,5 +186,5 @@ variable "rate_limiting_refill_interval" {
 variable "rate_limiting_refill_rate" {
   description = "The number of tokens to refill the bucket with"
   type        = number
-  default     = 2
+  default     = 3
 }


### PR DESCRIPTION
# Description

This PR tunes the rate-limiting token bucket settings:
* Decreasing the maximum token bucket size to 30.
* Increasing refill rate to 3 per second.

The full context of the reason for this change: [Slack](https://walletconnect.slack.com/archives/C03SCF66K2T/p1718608552397669)

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
