### PR TITLE
feat(analytics): adding names registrations analytics

### DIFF
--- a/src/analytics/account_names_info.rs
+++ b/src/analytics/account_names_info.rs
@@ -1,0 +1,40 @@
+use {parquet_derive::ParquetRecordWriter, serde::Serialize, std::sync::Arc};
+
+#[derive(Debug, Clone, Serialize, ParquetRecordWriter)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountNameRegistration {
+    pub timestamp: chrono::NaiveDateTime,
+
+    pub name: String,
+    pub owner_address: String,
+    pub chain_id: String,
+
+    pub origin: Option<String>,
+    pub region: Option<String>,
+    pub country: Option<Arc<str>>,
+    pub continent: Option<Arc<str>>,
+}
+
+impl AccountNameRegistration {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        name: String,
+        owner_address: String,
+        chain_id: String,
+        origin: Option<String>,
+        region: Option<Vec<String>>,
+        country: Option<Arc<str>>,
+        continent: Option<Arc<str>>,
+    ) -> Self {
+        Self {
+            timestamp: wc::analytics::time::now(),
+            name,
+            owner_address,
+            chain_id,
+            origin,
+            region: region.map(|r| r.join(", ")),
+            country,
+            continent,
+        }
+    }
+}

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -309,7 +309,7 @@ impl RPCAnalytics {
             },
             ParquetBatchFactory::new(Default::default()).with_observer(observer),
             AwsExporter::new(AwsConfig {
-                export_prefix: "blockchain-api/name-requests".to_owned(),
+                export_prefix: "blockchain-api/name-registrations".to_owned(),
                 export_name: "name_registrations".to_owned(),
                 node_addr,
                 file_extension: "parquet".to_owned(),


### PR DESCRIPTION
# Description

This PR adds name registration analytics with the following data:
* Name,
* Owner's address,
* Registration chain ID (in case the user is not at the mainnet),
* Geo data: origin, region, country, continent.

The analytics data is stored in the `blockchain-api/name-requests/name_registrations` S3 bucket.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
