### PR TITLE
fix(tests): fixing providers integration tests compilation

### DIFF
--- a/tests/context/mod.rs
+++ b/tests/context/mod.rs
@@ -23,8 +23,6 @@ impl AsyncTestContext for ServerContext {
             {
                 let project_id = env::var("PROJECT_ID").expect("PROJECT_ID must be set");
                 RpcProxy {
-                    private_addr: None,
-                    public_port: None,
                     public_addr,
                     project_id,
                 }

--- a/tests/context/server.rs
+++ b/tests/context/server.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "test-localhost")]
 use std::net::SocketAddr;
 
 #[cfg(feature = "test-localhost")]
@@ -10,7 +11,6 @@ use {
     tokio::{runtime::Handle, time::sleep},
 };
 
-#[cfg(feature = "test-localhost")]
 pub struct RpcProxy {
     pub public_addr: String,
     pub project_id: String,


### PR DESCRIPTION
# Description

This PR fixes RPC providers [integration test compilation errors](https://github.com/WalletConnect/blockchain-api/actions/runs/9548607111/job/26317101711#step:4:1099) after removing the rudimental code in #673.

## How Has This Been Tested?

* Passed `cargo test coinbase_provider -- --ignored` locally,
* Passed `cargo clippy --workspace --all-features --all-targets -- -D warnings` locally.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
