### PR TITLE
fix(network): using the last forwarded IP from the list

### DIFF
--- a/src/utils/network.rs
+++ b/src/utils/network.rs
@@ -73,3 +73,30 @@ pub fn get_forwarded_ip(headers: HeaderMap) -> Option<IpAddr> {
         .and_then(|header| header.split(',').last())
         .and_then(|client_ip| client_ip.trim().parse::<IpAddr>().ok())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_forwarded_ip() {
+        // Singe IP
+        let mut headers_single = HeaderMap::new();
+        headers_single.insert("X-Forwarded-For", "10.128.128.1".parse().unwrap());
+        assert_eq!(
+            get_forwarded_ip(headers_single).unwrap(),
+            "10.128.128.1".parse::<IpAddr>().unwrap()
+        );
+
+        // Muplitple IPs appended by ALB
+        let mut headers_multiple = HeaderMap::new();
+        headers_multiple.insert(
+            "X-Forwarded-For",
+            "10.128.128.1, 10.128.128.2".parse().unwrap(),
+        );
+        assert_eq!(
+            get_forwarded_ip(headers_multiple).unwrap(),
+            "10.128.128.2".parse::<IpAddr>().unwrap()
+        );
+    }
+}

--- a/src/utils/network.rs
+++ b/src/utils/network.rs
@@ -70,6 +70,6 @@ pub fn get_forwarded_ip(headers: HeaderMap) -> Option<IpAddr> {
     headers
         .get("X-Forwarded-For")
         .and_then(|header| header.to_str().ok())
-        .and_then(|header| header.split(',').next())
+        .and_then(|header| header.split(',').last())
         .and_then(|client_ip| client_ip.trim().parse::<IpAddr>().ok())
 }


### PR DESCRIPTION
# Description

This PR changes the user IP to get the last IP from the list in `X-Forwarded-For` instead of the first since the AWS Load Balancer appends the IP to the end.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
