### PR TITLE
fix(tests): tuning rate-limiting integration test

### DIFF
--- a/integration/ratelimiting.test.ts
+++ b/integration/ratelimiting.test.ts
@@ -4,8 +4,8 @@ describe('Rate limiting', () => {
   const { baseUrl, projectId, httpClient } = getTestSetup();
 
   it('Simulate flood and check is rate limited', async () => {
-    // Using default max tokens of 100
-    const max_tokens = 100;
+    // Using default max tokens of 30
+    const max_tokens = 30;
 
     // Flooding requests twice then max tokens
     const requests_to_send = max_tokens * 2;
@@ -41,8 +41,8 @@ describe('Rate limiting', () => {
   })
 
   it('Flood below max tokens and check is NOT rate limited', async () => {
-    // Using default max tokens of 100
-    const max_tokens = 100;
+    // Using default max tokens of 30
+    const max_tokens = 30;
    
     // Sending flood requests to the endpoint other then in first test case
     // since the key is composite with the matched endpoint


### PR DESCRIPTION
# Description

This PR tuning max token bucket size variables to `30` for the integration tests as a follow-up from #675. 
This should fix the rate-limiting [integration test error](https://github.com/WalletConnect/blockchain-api/actions/runs/9580015523/job/26420144164#step:5:49).

## How Has This Been Tested?

* Tested by running tests locally.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
