### PR TITLE
feat(sessions): implementing session create, list and get handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.8.0",
+ "uuid 1.9.1",
 ]
 
 [[package]]
@@ -1071,7 +1071,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "once_cell",
- "p256",
+ "p256 0.11.1",
  "percent-encoding",
  "ring 0.17.8",
  "sha2",
@@ -2378,6 +2378,7 @@ dependencies = [
  "ff 0.13.0",
  "generic-array",
  "group 0.13.0",
+ "pem-rfc7468",
  "pkcs8 0.10.2",
  "rand_core",
  "sec1 0.7.3",
@@ -4620,7 +4621,7 @@ dependencies = [
  "tagptr",
  "thiserror",
  "triomphe",
- "uuid 1.8.0",
+ "uuid 1.9.1",
 ]
 
 [[package]]
@@ -5175,6 +5176,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5578,6 +5591,15 @@ checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2 1.0.86",
  "syn 2.0.67",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -6312,6 +6334,7 @@ dependencies = [
  "aws-sdk-s3",
  "axum",
  "axum-tungstenite",
+ "base64 0.22.1",
  "bytes",
  "cerberus",
  "chrono",
@@ -6331,11 +6354,13 @@ dependencies = [
  "network",
  "num_enum",
  "once_cell",
+ "p256 0.13.2",
  "parquet",
  "parquet_derive",
  "pnet_datalink",
  "prometheus-http-query",
  "rand",
+ "rand_core",
  "regex",
  "relay_rpc",
  "reqwest 0.11.27",
@@ -6359,6 +6384,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid 1.9.1",
  "validator",
  "vergen",
  "wc 0.1.0 (git+https://github.com/WalletConnect/utils-rs.git?tag=v0.9.0)",
@@ -7898,7 +7924,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "uuid 1.8.0",
+ "uuid 1.9.1",
 ]
 
 [[package]]
@@ -8208,9 +8234,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,13 +74,17 @@ tokio-stream = "0.1.12"
 axum-tungstenite = "0.2.0"
 
 rand = "0.8.4"
+rand_core = "0.6"
 prometheus-http-query = "0.6.6"
 ethers = { version = "2.0.11", git = "https://github.com/gakonst/ethers-rs" } # using Git version because crates.io version fails clippy
 alloy-primitives = "0.7"
 
 bytes = "1.4.0"
+base64 = "0.22"
 regex = "1.10"
 sha256 = "1.2.2"
+p256 = "0.13"
+uuid = "1.9"
 
 # System CPU and Memory metrics
 sysinfo = "0.30"

--- a/integration/sessions.test.ts
+++ b/integration/sessions.test.ts
@@ -3,10 +3,10 @@ import { ethers } from "ethers"
 
 describe('Sessions/Permissions', () => {
   const { baseUrl, projectId, httpClient } = getTestSetup();
-  const address = ethers.Wallet.createRandom().address;
+  const address = `eip155:1:${ethers.Wallet.createRandom().address}`;
   // Session payload
   const payload = {
-    permissions: {
+    permission: {
       permissionType: "exampleType",
       data: "exampleData",
       required: true,
@@ -42,9 +42,9 @@ describe('Sessions/Permissions', () => {
       `${baseUrl}/v1/sessions/${address}/${new_pci}`
     )
     expect(resp.status).toBe(200)
-    expect(resp.data.permissionType).toBe(payload.permissions.permissionType)
-    expect(resp.data.data).toBe(payload.permissions.data)
-    expect(resp.data.required).toBe(payload.permissions.required)
-    expect(resp.data.onChainValidated).toBe(payload.permissions.onChainValidated)
+    expect(resp.data.permissionType).toBe(payload.permission.permissionType)
+    expect(resp.data.data).toBe(payload.permission.data)
+    expect(resp.data.required).toBe(payload.permission.required)
+    expect(resp.data.onChainValidated).toBe(payload.permission.onChainValidated)
   })
 })

--- a/integration/sessions.test.ts
+++ b/integration/sessions.test.ts
@@ -1,0 +1,50 @@
+import { getTestSetup } from './init';
+import { ethers } from "ethers"
+
+describe('Sessions/Permissions', () => {
+  const { baseUrl, projectId, httpClient } = getTestSetup();
+  const address = ethers.Wallet.createRandom().address;
+  // Session payload
+  const payload = {
+    permissions: {
+      permissionType: "exampleType",
+      data: "exampleData",
+      required: true,
+      onChainValidated: false
+    }
+  }
+  let new_pci: string;
+  
+  it('create new session', async () => {
+    let resp: any = await httpClient.post(
+      `${baseUrl}/v1/sessions/${address}`,
+      payload
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.pci).toBe('string')
+    new_pci = resp.data.pci
+    expect(typeof resp.data.key).toBe('string')
+    // check key is base64 encoded
+    expect(Buffer.from(resp.data.key, 'base64').toString('base64')).toBe(resp.data.key)
+  })
+
+  it('list PCIs for address', async () => {
+    let resp = await httpClient.get(
+      `${baseUrl}/v1/sessions/${address}`
+    )
+    expect(resp.status).toBe(200)
+    expect(resp.data.pci.length).toBe(1)
+    expect(resp.data.pci[0]).toBe(new_pci)
+  })
+
+  it('get session by PCI', async () => {
+    let resp = await httpClient.get(
+      `${baseUrl}/v1/sessions/${address}/${new_pci}`
+    )
+    expect(resp.status).toBe(200)
+    expect(resp.data.permissionType).toBe(payload.permissions.permissionType)
+    expect(resp.data.data).toBe(payload.permissions.data)
+    expect(resp.data.required).toBe(payload.permissions.required)
+    expect(resp.data.onChainValidated).toBe(payload.permissions.onChainValidated)
+  })
+})

--- a/src/error.rs
+++ b/src/error.rs
@@ -169,6 +169,12 @@ pub enum RpcError {
 
     #[error("Weighted providers index error: {0}")]
     WeightedProvidersIndex(String),
+
+    #[error("IRN client is not configured")]
+    IrnNotConfigured,
+
+    #[error("Permission for PCI is not found: {0}")]
+    PermissionNotFound(String),
 }
 
 impl IntoResponse for RpcError {
@@ -382,6 +388,14 @@ impl IntoResponse for RpcError {
                 Json(new_error_response(
                     "rate_limit".to_string(),
                     format!("Rate limited: {}", e),
+                )),
+            )
+                .into_response(),
+            Self::PermissionNotFound(e) => (
+                StatusCode::BAD_REQUEST,
+                Json(new_error_response(
+                    "pci".to_string(),
+                    format!("Permission for PCI is not found: {}", e),
                 )),
             )
                 .into_response(),

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -24,6 +24,7 @@ pub mod onramp;
 pub mod portfolio;
 pub mod profile;
 pub mod proxy;
+pub mod sessions;
 pub mod supported_chains;
 pub mod ws_proxy;
 

--- a/src/handlers/sessions/create.rs
+++ b/src/handlers/sessions/create.rs
@@ -1,6 +1,6 @@
 use {
     super::{super::HANDLER_TASK_METRICS, NewPermissionPayload, StoragePermissionsItem},
-    crate::{error::RpcError, state::AppState},
+    crate::{error::RpcError, state::AppState, utils::crypto::disassemble_caip10},
     axum::{
         extract::{Path, State},
         response::{IntoResponse, Response},
@@ -38,6 +38,9 @@ async fn handler_internal(
 ) -> Result<Response, RpcError> {
     let irn_client = state.irn.as_ref().ok_or(RpcError::IrnNotConfigured)?;
 
+    // Checking the CAIP-10 address format
+    disassemble_caip10(&address)?;
+
     // generate a unique permission control identifier
     let pci = uuid::Uuid::new_v4().to_string();
 
@@ -49,7 +52,7 @@ async fn handler_internal(
 
     // store the permission item in the IRN database
     let storage_permissions_item = StoragePermissionsItem {
-        permissions: request_payload.permissions,
+        permissions: request_payload.permission,
         verification_key: verifying_key_base64,
     };
     irn_client

--- a/src/handlers/sessions/create.rs
+++ b/src/handlers/sessions/create.rs
@@ -1,0 +1,69 @@
+use {
+    super::{super::HANDLER_TASK_METRICS, NewPermissionPayload, StoragePermissionsItem},
+    crate::{error::RpcError, state::AppState},
+    axum::{
+        extract::{Path, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    base64::prelude::*,
+    p256::ecdsa::{SigningKey, VerifyingKey},
+    rand_core::OsRng,
+    serde::{Deserialize, Serialize},
+    std::sync::Arc,
+    wc::future::FutureExt,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NewPermissionResponse {
+    pci: String,
+    key: String,
+}
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    address: Path<String>,
+    Json(request_payload): Json<NewPermissionPayload>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, address, request_payload)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("sessions_create"))
+        .await
+}
+
+#[tracing::instrument(skip(state), level = "debug")]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    Path(address): Path<String>,
+    request_payload: NewPermissionPayload,
+) -> Result<Response, RpcError> {
+    let irn_client = state.irn.as_ref().ok_or(RpcError::IrnNotConfigured)?;
+
+    // generate a unique permission control identifier
+    let pci = uuid::Uuid::new_v4().to_string();
+
+    // generate ECDSA key pair
+    let signing_key = SigningKey::random(&mut OsRng);
+    let verifying_key = VerifyingKey::from(&signing_key);
+    let signing_key_base64 = BASE64_STANDARD.encode(signing_key.to_bytes());
+    let verifying_key_base64 = BASE64_STANDARD.encode(verifying_key.to_sec1_bytes());
+
+    // store the permission item in the IRN database
+    let storage_permissions_item = StoragePermissionsItem {
+        permissions: request_payload.permissions,
+        verification_key: verifying_key_base64,
+    };
+    irn_client
+        .hset(
+            address.clone(),
+            pci.clone(),
+            serde_json::to_string(&storage_permissions_item)?.into(),
+        )
+        .await?;
+
+    let response = NewPermissionResponse {
+        pci,
+        key: signing_key_base64,
+    };
+
+    Ok(Json(response).into_response())
+}

--- a/src/handlers/sessions/get.rs
+++ b/src/handlers/sessions/get.rs
@@ -1,0 +1,49 @@
+use {
+    super::{
+        super::HANDLER_TASK_METRICS, GetPermissionsRequest, PermissionItem, StoragePermissionsItem,
+    },
+    crate::{error::RpcError, state::AppState},
+    axum::{
+        extract::{Path, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    std::sync::Arc,
+    wc::future::FutureExt,
+};
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    request: Path<GetPermissionsRequest>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, request)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("sessions_create"))
+        .await
+}
+
+#[tracing::instrument(skip(state), level = "debug")]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    Path(request): Path<GetPermissionsRequest>,
+) -> Result<Response, RpcError> {
+    let irn_client = state.irn.as_ref().ok_or(RpcError::IrnNotConfigured)?;
+
+    let storage_permissions_item = match irn_client
+        .hget(request.address.clone(), request.pci.clone())
+        .await?
+    {
+        Some(storage_permissions_item) => storage_permissions_item,
+        None => return Err(RpcError::PermissionNotFound(request.pci)),
+    };
+    let storage_permissions_item: StoragePermissionsItem =
+        serde_json::from_str(&storage_permissions_item)?;
+
+    let response = PermissionItem {
+        permission_type: storage_permissions_item.permissions.permission_type,
+        data: storage_permissions_item.permissions.data,
+        required: storage_permissions_item.permissions.required,
+        on_chain_validated: storage_permissions_item.permissions.on_chain_validated,
+    };
+
+    Ok(Json(response).into_response())
+}

--- a/src/handlers/sessions/list.rs
+++ b/src/handlers/sessions/list.rs
@@ -1,6 +1,6 @@
 use {
     super::super::HANDLER_TASK_METRICS,
-    crate::{error::RpcError, state::AppState},
+    crate::{error::RpcError, state::AppState, utils::crypto::disassemble_caip10},
     axum::{
         extract::{Path, State},
         response::{IntoResponse, Response},
@@ -32,8 +32,11 @@ async fn handler_internal(
 ) -> Result<Response, RpcError> {
     let irn_client = state.irn.as_ref().ok_or(RpcError::IrnNotConfigured)?;
 
+    // Checking the CAIP-10 address format
+    disassemble_caip10(&address)?;
+
     // get all permission control identifiers for the address
-    let pci = irn_client.hfields(address.clone()).await?;
+    let pci = irn_client.hfields(address).await?;
     let response = ListPermissionResponse { pci };
 
     Ok(Json(response).into_response())

--- a/src/handlers/sessions/list.rs
+++ b/src/handlers/sessions/list.rs
@@ -1,0 +1,40 @@
+use {
+    super::super::HANDLER_TASK_METRICS,
+    crate::{error::RpcError, state::AppState},
+    axum::{
+        extract::{Path, State},
+        response::{IntoResponse, Response},
+        Json,
+    },
+    serde::{Deserialize, Serialize},
+    std::sync::Arc,
+    wc::future::FutureExt,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ListPermissionResponse {
+    pci: Vec<String>,
+}
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    address: Path<String>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, address)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("sessions_list"))
+        .await
+}
+
+#[tracing::instrument(skip(state), level = "debug")]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    Path(address): Path<String>,
+) -> Result<Response, RpcError> {
+    let irn_client = state.irn.as_ref().ok_or(RpcError::IrnNotConfigured)?;
+
+    // get all permission control identifiers for the address
+    let pci = irn_client.hfields(address.clone()).await?;
+    let response = ListPermissionResponse { pci };
+
+    Ok(Json(response).into_response())
+}

--- a/src/handlers/sessions/mod.rs
+++ b/src/handlers/sessions/mod.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+pub mod create;
+pub mod get;
+pub mod list;
+
+/// Payload to create a new permission
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NewPermissionPayload {
+    pub permissions: PermissionItem,
+}
+
+// Payload to get permission by PCI
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GetPermissionsRequest {
+    address: String,
+    pci: String,
+}
+
+/// Permission item schema
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionItem {
+    permission_type: String,
+    data: String,
+    required: bool,
+    on_chain_validated: bool,
+}
+
+/// Serialized permission item schema to store it in the IRN database
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoragePermissionsItem {
+    permissions: PermissionItem,
+    verification_key: String,
+}

--- a/src/handlers/sessions/mod.rs
+++ b/src/handlers/sessions/mod.rs
@@ -7,7 +7,7 @@ pub mod list;
 /// Payload to create a new permission
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NewPermissionPayload {
-    pub permissions: PermissionItem,
+    pub permission: PermissionItem,
 }
 
 // Payload to get permission by PCI

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,11 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
             "/v1/fungible/price",
             post(handlers::fungible_price::handler),
         )
+        // Sessions
+        .route("/v1/sessions/:address", post(handlers::sessions::create::handler))
+        .route("/v1/sessions/:address", get(handlers::sessions::list::handler))
+        .route("/v1/sessions/:address/:pci", get(handlers::sessions::get::handler))
+        // Health
         .route("/health", get(handlers::health::handler))
         .route_layer(tracing_and_metrics_layer)
         .layer(cors);


### PR DESCRIPTION
# Description

This PR implements the following handlers according to the [sessions API spec](https://github.com/WalletConnect/walletconnect-specs/pull/242/files):

* Session/permission creating at `POST /v1/sessions/:address`,
  * Generating the ECDSA keypair, storing the verification key (for further owner verification), and returning the signing key.
  * Generating the unique PCI (permission identifier) by using the UUIDv4 format.
  * Storing the permission object in the IRN.
* List of session/permissions PCI (permission identifiers) for the certain address at `GET /v1/sessions/:address`,
* Get session/permission by the address and PCI (permission identifier) at `GET /v1/sessions/:address/:pci`.

## How Has This Been Tested?

* [Integration tests](https://github.com/WalletConnect/blockchain-api/pull/686/files#diff-d2b6bfa16ff410867b43a05eebec7cf74f434e26320f85fdf4681537ebb32372) for creation, list, and get were implemented.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
