### PR TITLE
fix(Dockerfile): moving copy before the `chef cook`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,10 @@ ARG                 BUILD_PROFILE="--profile ${PROFILE}"
 WORKDIR             /app
 # Cache dependancies
 COPY --from=plan    /app/recipe.json recipe.json
-COPY                . .
+COPY                irn ./irn
 RUN                 cargo chef cook ${BUILD_PROFILE} --recipe-path recipe.json 
 # Build the local binary
+COPY                . .
 RUN                 cargo build --bin rpc-proxy ${RELEASE}
 
 ################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,9 @@ ARG                 BUILD_PROFILE="--profile ${PROFILE}"
 WORKDIR             /app
 # Cache dependancies
 COPY --from=plan    /app/recipe.json recipe.json
+COPY                . .
 RUN                 cargo chef cook ${BUILD_PROFILE} --recipe-path recipe.json 
 # Build the local binary
-COPY                . .
 RUN                 cargo build --bin rpc-proxy ${RELEASE}
 
 ################################################################################


### PR DESCRIPTION
# Description

This PR moves files copying *before* the `chef cook` to copy the `irn` submodule files and fix [the build error](https://github.com/WalletConnect/blockchain-api/actions/runs/9669791859/job/26677120309#step:8:372).

## How Has This Been Tested?

Tested by running `docker build --no-cache -t test_app .` locally and successfully built the image with the change from this PR.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
