### PR TITLE
feat(analytics): adding unhashed address to the identity analytics

### DIFF
--- a/src/analytics/identity_lookup_info.rs
+++ b/src/analytics/identity_lookup_info.rs
@@ -12,6 +12,7 @@ pub struct IdentityLookupInfo {
     pub timestamp: chrono::NaiveDateTime,
 
     pub address_hash: String,
+    pub address: String,
     pub name_present: bool,
     pub avatar_present: bool,
     pub source: String,
@@ -45,6 +46,7 @@ impl IdentityLookupInfo {
             timestamp: wc::analytics::time::now(),
 
             address_hash: sha256::digest(address.as_ref()),
+            address: format!("{:#x}", address),
             name_present,
             avatar_present,
             source: source.as_str().to_string(),


### PR DESCRIPTION
# Description

This PR adds an unhashed address to the identity lookup analytics schema.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
