### PR TITLE
fix(ci): adding submodule secret for providers and integration tests

### DIFF
--- a/.github/workflows/event_pr.yml
+++ b/.github/workflows/event_pr.yml
@@ -36,7 +36,7 @@ jobs:
     name: Paths Filter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: WalletConnect/actions/github/paths-filter/@2.2.1
         id: filter
     outputs:

--- a/.github/workflows/event_release.yml
+++ b/.github/workflows/event_release.yml
@@ -31,7 +31,7 @@ jobs:
     name: Paths Filter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: WalletConnect/actions/github/paths-filter/@2.2.1
         id: filter
     outputs:

--- a/.github/workflows/sub-providers.yml
+++ b/.github/workflows/sub-providers.yml
@@ -73,6 +73,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
+          submodules: recursive
 
       - name: "Install Rust ${{ vars.RUST_VERSION }}"
         uses: WalletConnect/actions-rs/toolchain@1.0.0

--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -50,7 +50,10 @@ jobs:
       url: ${{ inputs.stage-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
+          submodules: recursive
 
       - name: "Install Rust ${{ vars.RUST_VERSION }}"
         uses: WalletConnect/actions-rs/toolchain@1.0.0
@@ -83,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
# Description

This PR adds `PRIVATE_SUBMODULE_ACCESS_TOKEN` to the checkout step to fix the running of the [provider-specific tests and Rust integration tests](https://github.com/WalletConnect/blockchain-api/actions/runs/9751517891/job/26913564466).
Also, bumping the  GitHub action `actions/checkout` version to `4`.

## How Has This Been Tested?

Not tested, just action-lint passed.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
