### PR TITLE
fix(ci): temporary ignoring integration sessions tests for staging

### DIFF
--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -98,7 +98,15 @@ jobs:
       - name: Yarn Install
         run: yarn install
 
+      # Temporary ignoring `Sessions tests` for staging until IRN peering for staging is ready
+      - name: Run Yarn Integration Tests (no IRN tests)
+        if: ${{ inputs.stage == 'staging' }}
+        run: yarn integration --testPathIgnorePatterns='sessions.test.ts'
+        env:
+          PROJECT_ID: ${{ secrets.PROJECT_ID }}
+          RPC_URL: ${{ inputs.stage-url }}
       - name: Yarn Integration Tests
+        if: ${{ inputs.stage == 'prod' }}
         run: yarn integration
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}


### PR DESCRIPTION
# Description

This PR making the change to the `TS Integration tests` CI step to ignore Sessions-related integration tests in `sessions.test.ts` for the `staging` environment. 
At the moment we have collisions that need to be resolved to peer to the IRN from the `staging` environment (we have tests enabled in `prod`). 
This change will unblock our CI/CD until resolution. The Sessions API is alpha/mvp testing only at the moment.

## How Has This Been Tested?

* Running `PROJECT_ID=xxx RPC_URL=https://rpc.walletconnect.com yarn integration --testPathIgnorePatterns='sessions.test.ts'` successfully skipped the sessions test suite.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
