### PR TITLE
feat(sessions): implementing permission revoking

### DIFF
--- a/src/handlers/sessions/context.rs
+++ b/src/handlers/sessions/context.rs
@@ -3,6 +3,7 @@ use {
     crate::{
         error::RpcError,
         state::AppState,
+        storage::irn::OperationType,
         utils::crypto::{disassemble_caip10, json_canonicalize, verify_ecdsa_signature},
     },
     axum::{
@@ -41,7 +42,9 @@ async fn handler_internal(
         .hget(address.clone(), request_payload.pci.clone())
         .await?
         .ok_or_else(|| RpcError::PermissionNotFound(request_payload.pci.clone()))?;
-    state.metrics.add_irn_latency(irn_call_start, "hget".into());
+    state
+        .metrics
+        .add_irn_latency(irn_call_start, OperationType::Hget.into());
     let mut storage_permissions_item =
         serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
 
@@ -66,7 +69,9 @@ async fn handler_internal(
             serde_json::to_string(&storage_permissions_item)?.into(),
         )
         .await?;
-    state.metrics.add_irn_latency(irn_call_start, "hset".into());
+    state
+        .metrics
+        .add_irn_latency(irn_call_start, OperationType::Hset.into());
 
     Ok(Json(storage_permissions_item).into_response())
 }

--- a/src/handlers/sessions/context.rs
+++ b/src/handlers/sessions/context.rs
@@ -44,7 +44,7 @@ async fn handler_internal(
         .ok_or_else(|| RpcError::PermissionNotFound(request_payload.pci.clone()))?;
     state
         .metrics
-        .add_irn_latency(irn_call_start, OperationType::Hget.into());
+        .add_irn_latency(irn_call_start, OperationType::Hget);
     let mut storage_permissions_item =
         serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
 
@@ -71,7 +71,7 @@ async fn handler_internal(
         .await?;
     state
         .metrics
-        .add_irn_latency(irn_call_start, OperationType::Hset.into());
+        .add_irn_latency(irn_call_start, OperationType::Hset);
 
     Ok(Json(storage_permissions_item).into_response())
 }

--- a/src/handlers/sessions/create.rs
+++ b/src/handlers/sessions/create.rs
@@ -1,6 +1,9 @@
 use {
     super::{super::HANDLER_TASK_METRICS, NewPermissionPayload, StoragePermissionsItem},
-    crate::{error::RpcError, state::AppState, utils::crypto::disassemble_caip10},
+    crate::{
+        error::RpcError, state::AppState, storage::irn::OperationType,
+        utils::crypto::disassemble_caip10,
+    },
     axum::{
         extract::{Path, State},
         response::{IntoResponse, Response},
@@ -81,7 +84,9 @@ async fn handler_internal(
             serde_json::to_string(&storage_permissions_item)?.into(),
         )
         .await?;
-    state.metrics.add_irn_latency(irn_call_start, "hset".into());
+    state
+        .metrics
+        .add_irn_latency(irn_call_start, OperationType::Hset.into());
 
     let response = NewPermissionResponse {
         pci,

--- a/src/handlers/sessions/create.rs
+++ b/src/handlers/sessions/create.rs
@@ -86,7 +86,7 @@ async fn handler_internal(
         .await?;
     state
         .metrics
-        .add_irn_latency(irn_call_start, OperationType::Hset.into());
+        .add_irn_latency(irn_call_start, OperationType::Hset);
 
     let response = NewPermissionResponse {
         pci,

--- a/src/handlers/sessions/get.rs
+++ b/src/handlers/sessions/get.rs
@@ -1,6 +1,9 @@
 use {
     super::{super::HANDLER_TASK_METRICS, GetPermissionsRequest, StoragePermissionsItem},
-    crate::{error::RpcError, state::AppState, utils::crypto::disassemble_caip10},
+    crate::{
+        error::RpcError, state::AppState, storage::irn::OperationType,
+        utils::crypto::disassemble_caip10,
+    },
     axum::{
         extract::{Path, State},
         response::{IntoResponse, Response},
@@ -34,7 +37,9 @@ async fn handler_internal(
         .hget(request.address.clone(), request.pci.clone())
         .await?
         .ok_or_else(|| RpcError::PermissionNotFound(request.pci))?;
-    state.metrics.add_irn_latency(irn_call_start, "hget".into());
+    state
+        .metrics
+        .add_irn_latency(irn_call_start, OperationType::Hget.into());
     let storage_permissions_item =
         serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
 

--- a/src/handlers/sessions/get.rs
+++ b/src/handlers/sessions/get.rs
@@ -39,7 +39,7 @@ async fn handler_internal(
         .ok_or_else(|| RpcError::PermissionNotFound(request.pci))?;
     state
         .metrics
-        .add_irn_latency(irn_call_start, OperationType::Hget.into());
+        .add_irn_latency(irn_call_start, OperationType::Hget);
     let storage_permissions_item =
         serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
 

--- a/src/handlers/sessions/list.rs
+++ b/src/handlers/sessions/list.rs
@@ -1,6 +1,9 @@
 use {
     super::super::HANDLER_TASK_METRICS,
-    crate::{error::RpcError, state::AppState, utils::crypto::disassemble_caip10},
+    crate::{
+        error::RpcError, state::AppState, storage::irn::OperationType,
+        utils::crypto::disassemble_caip10,
+    },
     axum::{
         extract::{Path, State},
         response::{IntoResponse, Response},
@@ -40,7 +43,7 @@ async fn handler_internal(
     let pci = irn_client.hfields(address).await?;
     state
         .metrics
-        .add_irn_latency(irn_call_start, "hfields".into());
+        .add_irn_latency(irn_call_start, OperationType::Hfields.into());
     let response = ListPermissionResponse { pci };
 
     Ok(Json(response).into_response())

--- a/src/handlers/sessions/list.rs
+++ b/src/handlers/sessions/list.rs
@@ -43,7 +43,7 @@ async fn handler_internal(
     let pci = irn_client.hfields(address).await?;
     state
         .metrics
-        .add_irn_latency(irn_call_start, OperationType::Hfields.into());
+        .add_irn_latency(irn_call_start, OperationType::Hfields);
     let response = ListPermissionResponse { pci };
 
     Ok(Json(response).into_response())

--- a/src/handlers/sessions/mod.rs
+++ b/src/handlers/sessions/mod.rs
@@ -4,6 +4,7 @@ pub mod context;
 pub mod create;
 pub mod get;
 pub mod list;
+pub mod revoke;
 
 /// Payload to create a new permission
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -74,4 +75,12 @@ pub struct StoragePermissionsItem {
     permissions: PermissionItem,
     context: Option<PermissionContextItem>,
     verification_key: String,
+}
+
+/// Permission revoke request schema
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionRevokeRequest {
+    pci: String,
+    signature: String,
 }

--- a/src/handlers/sessions/revoke.rs
+++ b/src/handlers/sessions/revoke.rs
@@ -1,0 +1,61 @@
+use {
+    super::{super::HANDLER_TASK_METRICS, PermissionRevokeRequest, StoragePermissionsItem},
+    crate::{
+        error::RpcError,
+        state::AppState,
+        utils::crypto::{disassemble_caip10, verify_ecdsa_signature},
+    },
+    axum::{
+        extract::{Path, State},
+        response::Response,
+        Json,
+    },
+    std::{sync::Arc, time::SystemTime},
+    wc::future::FutureExt,
+};
+
+pub async fn handler(
+    state: State<Arc<AppState>>,
+    address: Path<String>,
+    Json(request_payload): Json<PermissionRevokeRequest>,
+) -> Result<Response, RpcError> {
+    handler_internal(state, address, request_payload)
+        .with_metrics(HANDLER_TASK_METRICS.with_name("sessions_revoke"))
+        .await
+}
+
+#[tracing::instrument(skip(state), level = "debug")]
+async fn handler_internal(
+    state: State<Arc<AppState>>,
+    Path(address): Path<String>,
+    request_payload: PermissionRevokeRequest,
+) -> Result<Response, RpcError> {
+    let irn_client = state.irn.as_ref().ok_or(RpcError::IrnNotConfigured)?;
+
+    // Checking the CAIP-10 address format
+    disassemble_caip10(&address)?;
+
+    // Get the PCI object from the IRN
+    let irn_call_start = SystemTime::now();
+    let storage_permissions_item = irn_client
+        .hget(address.clone(), request_payload.pci.clone())
+        .await?
+        .ok_or_else(|| RpcError::PermissionNotFound(request_payload.pci.clone()))?;
+    state.metrics.add_irn_latency(irn_call_start, "hget".into());
+    let storage_permissions_item =
+        serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
+
+    // Check the signature
+    verify_ecdsa_signature(
+        &request_payload.pci,
+        &request_payload.signature,
+        &storage_permissions_item.verification_key,
+    )?;
+
+    // Remove the session/permission item from the IRN
+    let irn_call_start = SystemTime::now();
+    irn_client.hdel(address, request_payload.pci).await?;
+    state.metrics.add_irn_latency(irn_call_start, "hdel".into());
+
+    Ok(Response::default())
+}

--- a/src/handlers/sessions/revoke.rs
+++ b/src/handlers/sessions/revoke.rs
@@ -3,6 +3,7 @@ use {
     crate::{
         error::RpcError,
         state::AppState,
+        storage::irn::OperationType,
         utils::crypto::{disassemble_caip10, verify_ecdsa_signature},
     },
     axum::{
@@ -41,7 +42,9 @@ async fn handler_internal(
         .hget(address.clone(), request_payload.pci.clone())
         .await?
         .ok_or_else(|| RpcError::PermissionNotFound(request_payload.pci.clone()))?;
-    state.metrics.add_irn_latency(irn_call_start, "hget".into());
+    state
+        .metrics
+        .add_irn_latency(irn_call_start, OperationType::Hget.into());
     let storage_permissions_item =
         serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
 
@@ -55,7 +58,9 @@ async fn handler_internal(
     // Remove the session/permission item from the IRN
     let irn_call_start = SystemTime::now();
     irn_client.hdel(address, request_payload.pci).await?;
-    state.metrics.add_irn_latency(irn_call_start, "hdel".into());
+    state
+        .metrics
+        .add_irn_latency(irn_call_start, OperationType::Hdel.into());
 
     Ok(Response::default())
 }

--- a/src/handlers/sessions/revoke.rs
+++ b/src/handlers/sessions/revoke.rs
@@ -44,7 +44,7 @@ async fn handler_internal(
         .await?;
     state
         .metrics
-        .add_irn_latency(irn_call_start, OperationType::Hget.into());
+        .add_irn_latency(irn_call_start, OperationType::Hget);
     let storage_permissions_item = match irn_client_result {
         Some(item) => item,
         // Return Success if the item is not found for idempotency
@@ -71,7 +71,7 @@ async fn handler_internal(
     irn_client.hdel(address, request_payload.pci).await?;
     state
         .metrics
-        .add_irn_latency(irn_call_start, OperationType::Hdel.into());
+        .add_irn_latency(irn_call_start, OperationType::Hdel);
 
     Ok(Response::default())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,6 +339,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         .route("/v1/sessions/:address", get(handlers::sessions::list::handler))
         .route("/v1/sessions/:address/:pci", get(handlers::sessions::get::handler))
         .route("/v1/sessions/:address/context", post(handlers::sessions::context::handler))
+        .route("/v1/sessions/:address/revoke", post(handlers::sessions::revoke::handler))
         // Health
         .route("/health", get(handlers::health::handler))
         .route_layer(tracing_and_metrics_layer)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,6 +3,7 @@ use {
         database::helpers::get_account_names_stats,
         handlers::identity::IdentityLookupSource,
         providers::{ProviderKind, RpcProvider},
+        storage::irn::OperationType,
     },
     hyper::http,
     sqlx::PgPool,
@@ -537,14 +538,14 @@ impl Metrics {
             .record(&otel::Context::new(), entry, &[]);
     }
 
-    pub fn add_irn_latency(&self, start: SystemTime, operation: String) {
+    pub fn add_irn_latency(&self, start: SystemTime, operation: OperationType) {
         self.irn_latency_tracker.record(
             &otel::Context::new(),
             start
                 .elapsed()
                 .unwrap_or(Duration::from_secs(0))
                 .as_secs_f64(),
-            &[otel::KeyValue::new("operation", operation)],
+            &[otel::KeyValue::new("operation", operation.as_str())],
         );
     }
 

--- a/src/storage/irn/mod.rs
+++ b/src/storage/irn/mod.rs
@@ -25,7 +25,7 @@ pub enum OperationType {
 }
 
 impl OperationType {
-    fn as_str(&self) -> &'static str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             OperationType::Hset => "hset",
             OperationType::Hget => "hget",

--- a/src/storage/irn/mod.rs
+++ b/src/storage/irn/mod.rs
@@ -15,6 +15,32 @@ const CONNECTION_TIMEOUT: Duration = Duration::from_secs(3);
 const RECORDS_TTL: Duration = Duration::from_secs(60 * 60 * 24 * 30); // 30 days
 const UDP_SOCKET_COUNT: usize = 1;
 
+/// IRN storage operation type
+#[derive(Debug)]
+pub enum OperationType {
+    Hset,
+    Hget,
+    Hfields,
+    Hdel,
+}
+
+impl OperationType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            OperationType::Hset => "hset",
+            OperationType::Hget => "hget",
+            OperationType::Hfields => "hfields",
+            OperationType::Hdel => "hdel",
+        }
+    }
+}
+
+impl From<OperationType> for String {
+    fn from(value: OperationType) -> Self {
+        value.as_str().to_string()
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Eq, PartialEq)]
 pub struct Config {
     pub node: Option<String>,


### PR DESCRIPTION
# Description

This PR implements the permission context revoking endpoint `/v1/sessions/{address}/revoke` according to the [API SPEC draft](https://github.com/WalletConnect/walletconnect-specs/pull/242).

For the request authentication, the signature (signed message) is used. 
As a signing message, the permission controller unique identifier is used (PCI) and signed by the signing key (created during the session creation request). 
Then the signature is verified at the server by the verification key which is stored during the [session creation](https://github.com/WalletConnect/walletconnect-specs/pull/242/files#diff-585df27a5f0c0b1216c7296d8bbe3c30877bc469bcbdad4c905c6803c1e441dcR53) in the permission session object.

## How Has This Been Tested?

* [A new integration test was implemented](https://github.com/WalletConnect/blockchain-api/pull/699/files#diff-d2b6bfa16ff410867b43a05eebec7cf74f434e26320f85fdf4681537ebb32372).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
