### PR TITLE
feat(readme): adding manual integration tests run description

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The following environment variables are expected to be passed:
 If you want to run certain test from the suite you can pass `-t` with the name of the
 test or test suite to run.
 
+For passing `Exact provider request` and disabled cache tests you need to provide a valid `RPC_PROXY_TESTING_PROJECT_ID`.
+
 ### Docker
 
 ```console

--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ curl -X POST "http://localhost:3000/v1?chainId=eip155:1&projectId=someid" --data
 just devloop
 ```
 
+### Manual integrations test run
+
+You can run manual integration tests by invoking the `yarn integration` command. 
+The following environment variables are expected to be passed:
+
+* `RPC_URL` - URL of the server to test. Use `http://localhost:3000` for the local testing.
+* `PROJECT_ID` - Unique project identifier.
+
+If you want to run certain test from the suite you can pass `-t` with the name of the
+test or test suite to run.
+
 ### Docker
 
 ```console


### PR DESCRIPTION
# Description

This PR adds a description to the `README.md` file on how to run manual integration tests.

## How Has This Been Tested?

* Command in the description was tested locally.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
