### PR TITLE
fix(sessions): changing to use secp256k1, removing signatures from context update and revoking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "once_cell",
- "p256 0.11.1",
+ "p256",
  "percent-encoding",
  "ring 0.17.8",
  "sha2",
@@ -2380,7 +2380,6 @@ dependencies = [
  "ff 0.13.0",
  "generic-array",
  "group 0.13.0",
- "pem-rfc7468",
  "pkcs8 0.10.2",
  "rand_core",
  "sec1 0.7.3",
@@ -5006,17 +5005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "olpc-cjson"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d637c9c15b639ccff597da8f4fa968300651ad2f1e968aefc3b4927a6fb2027a"
-dependencies = [
- "serde",
- "serde_json",
- "unicode-normalization",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5185,18 +5173,6 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
- "sha2",
-]
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
- "primeorder",
  "sha2",
 ]
 
@@ -5604,15 +5580,6 @@ checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2 1.0.86",
  "syn 2.0.70",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -6366,9 +6333,7 @@ dependencies = [
  "moka",
  "network",
  "num_enum",
- "olpc-cjson",
  "once_cell",
- "p256 0.13.2",
  "parquet",
  "parquet_derive",
  "pnet_datalink",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_piecewise_default = "0.2"
 serde-aux = "3.1"
-olpc-cjson = "0.1"
 validator = { version = "0.16", features = ["derive"] }
 num_enum = "0.7"
 strum = "0.26"
@@ -84,7 +83,6 @@ bytes = "1.4.0"
 base64 = "0.22"
 regex = "1.10"
 sha256 = "1.2.2"
-p256 = "0.13"
 uuid = "1.9"
 
 # System CPU and Memory metrics

--- a/integration/sessions.test.ts
+++ b/integration/sessions.test.ts
@@ -71,23 +71,8 @@ describe('Sessions/Permissions', () => {
       }
     }
     
-    // Canonicalize context JSON object
-    let json_canonicalize = canonicalize(context);
-    const privateKey = createPrivateKey({
-      key: Buffer.from(signing_key, 'base64'),
-      format: 'der',
-      type: 'sec1',
-    });
-
-    // Create a signature
-    const sign = createSign('SHA256');
-    sign.update(json_canonicalize);
-    sign.end();
-    const signature = sign.sign(privateKey, 'base64');
-
     const payload = {
       pci: new_pci,
-      signature: signature,
       context
     }
     
@@ -107,36 +92,8 @@ describe('Sessions/Permissions', () => {
     expect(resp.data.pci.length).toBe(1)
     expect(resp.data.pci[0]).toBe(new_pci)
 
-    // Create a signature
-    const privateKey = createPrivateKey({
-      key: Buffer.from(signing_key, 'base64'),
-      format: 'der',
-      type: 'sec1',
-    });
-
-    // Create a bad signature and try to revoke PCI
-    let bad_signature = createSign('SHA256');
-    bad_signature.update('bad_pci');
-    bad_signature.end();
-    let signature = bad_signature.sign(privateKey, 'base64');
     let payload = {
       pci: new_pci,
-      signature,
-    }
-    resp = await httpClient.post(
-      `${baseUrl}/v1/sessions/${address}/revoke`,
-      payload
-    )
-    expect(resp.status).toBe(401)
-
-    // Create a good signature and try to revoke PCI
-    const good_signature = createSign('SHA256');
-    good_signature.update(new_pci);
-    good_signature.end();
-    signature = good_signature.sign(privateKey, 'base64');
-    payload = {
-      pci: new_pci,
-      signature,
     }
     
     // Revoke PCI

--- a/src/handlers/sessions/context.rs
+++ b/src/handlers/sessions/context.rs
@@ -1,10 +1,8 @@
 use {
     super::{super::HANDLER_TASK_METRICS, PermissionContextItem, StoragePermissionsItem},
     crate::{
-        error::RpcError,
-        state::AppState,
-        storage::irn::OperationType,
-        utils::crypto::{disassemble_caip10, json_canonicalize, verify_ecdsa_signature},
+        error::RpcError, state::AppState, storage::irn::OperationType,
+        utils::crypto::disassemble_caip10,
     },
     axum::{
         extract::{Path, State},
@@ -47,15 +45,6 @@ async fn handler_internal(
         .add_irn_latency(irn_call_start, OperationType::Hget);
     let mut storage_permissions_item =
         serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
-
-    // Check the signature
-    let json_canonicalized = json_canonicalize(serde_json::to_value(&request_payload.context)?)?;
-    verify_ecdsa_signature(
-        &String::from_utf8(json_canonicalized.clone())
-            .map_err(|e| RpcError::InvalidParameter(e.to_string()))?,
-        &request_payload.signature,
-        &storage_permissions_item.verification_key,
-    )?;
 
     // Update the context
     storage_permissions_item.context = Some(request_payload.clone());

--- a/src/handlers/sessions/mod.rs
+++ b/src/handlers/sessions/mod.rs
@@ -34,7 +34,6 @@ pub struct PermissionItem {
 #[serde(rename_all = "camelCase")]
 pub struct PermissionContextItem {
     pci: String,
-    signature: String,
     context: PermissionSubContext,
 }
 
@@ -83,5 +82,4 @@ pub struct StoragePermissionsItem {
 #[serde(rename_all = "camelCase")]
 pub struct PermissionRevokeRequest {
     pci: String,
-    signature: String,
 }

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -3,17 +3,15 @@ use {
     alloy_primitives::Address,
     base64::prelude::*,
     ethers::{
+        core::k256::ecdsa::{signature::Verifier, Signature, VerifyingKey},
         prelude::abigen,
         providers::{Http, Middleware, Provider},
         types::{H160, H256, U256},
+        utils::keccak256,
     },
-    olpc_cjson::CanonicalFormatter,
     once_cell::sync::Lazy,
-    p256::ecdsa::{signature::Verifier, DerSignature, VerifyingKey},
     regex::Regex,
     relay_rpc::auth::cacao::{signature::eip6492::verify_eip6492, CacaoError},
-    serde::Serialize,
-    serde_json::Value,
     std::{str::FromStr, sync::Arc},
     strum::IntoEnumIterator,
     strum_macros::{Display, EnumIter, EnumString},
@@ -64,14 +62,6 @@ pub fn get_message_hash(message: &str) -> H256 {
     let prefixed_message = add_eip191(message);
     let message_hash = ethers::core::utils::keccak256(prefixed_message.clone());
     ethers::types::H256::from_slice(&message_hash)
-}
-
-/// Serialize JSON to canonical format
-pub fn json_canonicalize(json: Value) -> Result<Vec<u8>, serde_json::Error> {
-    let mut buf = Vec::new();
-    let mut ser = serde_json::Serializer::with_formatter(&mut buf, CanonicalFormatter::new());
-    json.serialize(&mut ser)?;
-    Ok(buf)
 }
 
 pub async fn verify_message_signature(
@@ -137,9 +127,10 @@ pub async fn verify_eip6492_message_signature(
     }
 }
 
-/// Verify ECDSA message signature using the verification key
+/// Verify secp256k1 message signature using the verification key
+/// Verification key is expected to be in DER format and Base64 encoded same as signature
 #[tracing::instrument(level = "debug")]
-pub fn verify_ecdsa_signature(
+pub fn verify_secp256k1_signature(
     message: &str,
     signature: &str,
     verification_key: &str,
@@ -151,15 +142,16 @@ pub fn verify_ecdsa_signature(
     )
     .map_err(|e| RpcError::KeyFormatError(e.to_string()))?;
 
-    let signature = DerSignature::from_bytes(
-        &BASE64_STANDARD
-            .decode(signature)
-            .map_err(|_| RpcError::WrongBase64Format(signature.to_string()))?,
-    )
-    .map_err(|e| RpcError::SignatureFormatError(e.to_string()))?;
+    let signature_bytes = &BASE64_STANDARD
+        .decode(signature)
+        .map_err(|_| RpcError::WrongBase64Format(signature.to_string()))?;
+    let signature = Signature::from_der(signature_bytes)
+        .map_err(|e| RpcError::SignatureFormatError(e.to_string()))?;
+
+    let message_hash = keccak256(message.as_bytes());
 
     verifying_key
-        .verify(message.as_bytes(), &signature)
+        .verify(&message_hash, &signature)
         .map_err(|e| RpcError::SignatureValidationError(e.to_string()))?;
 
     Ok(())
@@ -454,9 +446,11 @@ pub fn convert_token_amount_to_value(balance: U256, price: f64, decimals: u32) -
 mod tests {
     use {
         super::*,
-        p256::ecdsa::{signature::Signer, SigningKey, VerifyingKey},
+        ethers::{
+            core::k256::ecdsa::{signature::Signer, Signature, SigningKey, VerifyingKey},
+            utils::keccak256,
+        },
         rand_core::OsRng,
-        serde_json::json,
         std::collections::HashMap,
     };
 
@@ -590,36 +584,32 @@ mod tests {
     }
 
     #[test]
-    fn test_json_canonicalize() {
-        let json = json!({
-            "key1": "value1",
-            "key2": "value2"
-        });
-
-        let result = json_canonicalize(json).unwrap();
-        assert_eq!(result, b"{\"key1\":\"value1\",\"key2\":\"value2\"}");
-    }
-
-    #[test]
-    fn test_verify_ecdsa_signature() {
+    fn test_verify_secp256k1_signature() {
         let message = "test message";
-        // Generate ECDSA key pair
+
+        // Generate secp256k1 key pair
         let signing_key = SigningKey::random(&mut OsRng);
         let verifying_key = VerifyingKey::from(&signing_key);
-        let verifying_key_base64 = BASE64_STANDARD.encode(verifying_key.to_sec1_bytes());
+        let public_key_der = verifying_key.to_encoded_point(false).as_bytes().to_vec();
+        let public_key_der_base64 = BASE64_STANDARD.encode(public_key_der);
 
-        // Sign the message
-        let signature: DerSignature = signing_key.sign(message.as_bytes());
-        let signature_base64 = BASE64_STANDARD.encode(signature.to_bytes());
+        // Hash the message using Keccak-256
+        let message_hash = keccak256(message.as_bytes());
+
+        // Sign the hashed message
+        let signature: Signature = signing_key.sign(&message_hash);
+        let signature_base64 = BASE64_STANDARD.encode(signature.to_der().as_bytes());
 
         // Correct signature and message
-        assert!(verify_ecdsa_signature(message, &signature_base64, &verifying_key_base64).is_ok());
+        assert!(
+            verify_secp256k1_signature(message, &signature_base64, &public_key_der_base64).is_ok()
+        );
 
         // Incorrect message
-        assert!(verify_ecdsa_signature(
+        assert!(verify_secp256k1_signature(
             "wrong message signature",
             &signature_base64,
-            &verifying_key_base64
+            &public_key_der_base64
         )
         .is_err());
     }

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -138,13 +138,13 @@ pub fn verify_secp256k1_signature(
     let verifying_key = VerifyingKey::from_sec1_bytes(
         &BASE64_STANDARD
             .decode(verification_key)
-            .map_err(|_| RpcError::WrongBase64Format(verification_key.to_string()))?,
+            .map_err(|e| RpcError::WrongBase64Format(e.to_string()))?,
     )
     .map_err(|e| RpcError::KeyFormatError(e.to_string()))?;
 
     let signature_bytes = &BASE64_STANDARD
         .decode(signature)
-        .map_err(|_| RpcError::WrongBase64Format(signature.to_string()))?;
+        .map_err(|e| RpcError::WrongBase64Format(e.to_string()))?;
     let signature = Signature::from_der(signature_bytes)
         .map_err(|e| RpcError::SignatureFormatError(e.to_string()))?;
 


### PR DESCRIPTION
# Description

This PR makes the following changes based on [this Slack thread](https://walletconnect.slack.com/archives/C0760BM9AHH/p1721110736693969):

* Removing the signature authorization from the context update and revoking endpoints.
* Using the secp256k1 instead of P256 (secp256r1) during the PCI creation and returns the public, not a private key.
* Using keccak256 for message hashing.
* Removing unused dependencies.

## How Has This Been Tested?

* Updated integration and unit tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
