### PR TITLE
fix(sessions): change numbers to strings in the `userOperation`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         .route("/v1/sessions/:address/:pci", get(handlers::sessions::get::handler))
         .route("/v1/sessions/:address/context", post(handlers::sessions::context::handler))
         .route("/v1/sessions/:address/revoke", post(handlers::sessions::revoke::handler))
+        .route("/v1/sessions/:address/sign", post(handlers::sessions::cosign::handler))
         // Health
         .route("/health", get(handlers::health::handler))
         .route_layer(tracing_and_metrics_layer)

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -99,14 +99,14 @@ struct BundlerSimulationType {
 #[serde(rename_all = "camelCase")]
 pub struct UserOperation {
     pub sender: String,
-    pub nonce: usize,
+    pub nonce: String,
     pub init_code: String,
     pub call_data: String,
-    pub call_gas_limit: usize,
-    pub verification_gas_limit: usize,
-    pub pre_verification_gas: usize,
-    pub max_fee_per_gas: usize,
-    pub max_priority_fee_per_gas: usize,
+    pub call_gas_limit: String,
+    pub verification_gas_limit: String,
+    pub pre_verification_gas: String,
+    pub max_fee_per_gas: String,
+    pub max_priority_fee_per_gas: String,
     pub paymaster_and_data: String,
     pub signature: String,
 }


### PR DESCRIPTION
# Description

This PR changes numbers to strings in the `userOperation` to support bigint at the JS side which should be the string.

## How Has This Been Tested?

* Manually tested by calling the pre-created cosign request.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
