### PR TITLE
fix(grafana): fixing no data irn latency alert and registered names counter

### DIFF
--- a/terraform/monitoring/panels/irn/latency.libsonnet
+++ b/terraform/monitoring/panels/irn/latency.libsonnet
@@ -19,7 +19,7 @@ local error_alert(vars) = alert.new(
   message     = "%s - IRN Client latency" % vars.environment,
   period      = '5m',
   frequency   = '1m',
-  noDataState = 'alerting',
+  noDataState = 'no_data',
   notifications = vars.notifications,
   alertRuleTags = {
     'og_priority': 'P3',

--- a/terraform/monitoring/panels/names/registered.libsonnet
+++ b/terraform/monitoring/panels/names/registered.libsonnet
@@ -14,7 +14,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'rate(account_names_count_total{}[$__rate_interval])',
+      expr        = 'account_names_count',
       refId       = "Names count",
     ))
 }


### PR DESCRIPTION
# Description

This PR consists the following fixes: 
* Fixes IRN latency alert by changing no alerting when there is no data instead of alert.
* Fixes Names counter query.

## How Has This Been Tested?

Tested by putting the query and config to the Grafana UI.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
