### PR TITLE
feat(sessions): implementing additional cosigner steps

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -183,6 +183,9 @@ pub enum RpcError {
     #[error("Wrong Base64 format: {0}")]
     WrongBase64Format(String),
 
+    #[error("Wrong Hex format: {0}")]
+    WrongHexFormat(String),
+
     #[error("Key format error: {0}")]
     KeyFormatError(String),
 
@@ -191,6 +194,9 @@ pub enum RpcError {
 
     #[error("Pkcs8 error: {0}")]
     Pkcs8Error(#[from] ethers::core::k256::pkcs8::Error),
+
+    #[error("Permission context was not updated yet: {0}")]
+    PermissionContextNotUpdated(String),
 }
 
 impl IntoResponse for RpcError {

--- a/src/handlers/sessions/cosign.rs
+++ b/src/handlers/sessions/cosign.rs
@@ -27,6 +27,8 @@ use {
     wc::future::FutureExt,
 };
 
+const ENTRY_POINT_V07_CONTRACT_ADDRESS: &str = "0x0000000071727De22E5E9d8BAf0edAc6f37da032";
+
 /// Co-sign response schema
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CoSignResponse {
@@ -68,14 +70,13 @@ async fn handler_internal(
         .as_ref()
         .ok_or_else(|| {
             RpcError::InvalidConfiguration(
-                "Missing testing project id in the configuration for the balance RPC lookups"
+                "Missing testing project id in the configuration for the cosigner RPC calls"
                     .to_string(),
             )
         })?;
 
     // Get the userOp hash
-    // Entrypoint v07 contract address
-    let contract_address = "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+    let contract_address = ENTRY_POINT_V07_CONTRACT_ADDRESS
         .parse::<H160>()
         .map_err(|_| RpcError::InvalidAddress)?;
     let user_op_hash = call_get_user_op_hash(

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -893,6 +893,8 @@ mod tests {
         .is_err());
     }
 
+    // Ignoring this test until the RPC project ID is provided by the CI workflow
+    // The test can be run manually by providing the project ID
     #[ignore]
     #[tokio::test]
     async fn test_call_get_user_op_hash() {
@@ -948,6 +950,8 @@ mod tests {
         Bytes::from(context)
     }
 
+    // Ignoring this test until the RPC project ID is provided by the CI workflow
+    // The test can be run manually by providing the project ID
     #[ignore]
     #[tokio::test]
     async fn test_call_get_signature() {


### PR DESCRIPTION
# Description

This PR modifying co-signing steps according to the recent changes ([Slack thread](https://walletconnect.slack.com/archives/C0760BM9AHH/p1721314692128899)).

The updated flow:
* Get the `userOperation` hash by calling `getUserOpHash(userOps)` on the v07 entrypoint.
* Sign the resulting hash value with the PCI private key.
* ABI-encode two signatures (co-signer and `userOperation` signature) into one.
* Set the above-encoded signature to the updated `userOperation` and call `getSignature` method on the userOpBuilder contract.
* Set the returned signature from userOpBuilder call to `userOperation`.
* Send the resulting `userOperation` to the bundler.

## How Has This Been Tested?

Tested manually step by step.
Contracts call unit tests that can be [run manually](https://github.com/WalletConnect/blockchain-api/pull/713#discussion_r1684516876) at the moment.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
