### PR TITLE
fix(sessions): removing getting of the receipt from the co-sign request

### DIFF
--- a/src/database/helpers.rs
+++ b/src/database/helpers.rs
@@ -39,9 +39,9 @@ pub async fn insert_name(
         VALUES ($1, $2::hstore)
     ";
     sqlx::query::<Postgres>(insert_name_query)
-        .bind(&name.clone())
+        .bind(name.clone())
         // Convert JSON to String for hstore update
-        .bind(&utils::hashmap_to_hstore(&attributes))
+        .bind(utils::hashmap_to_hstore(&attributes))
         .execute(&mut *transaction)
         .await?;
 
@@ -85,7 +85,7 @@ pub async fn update_name_attributes(
     ";
     let row = sqlx::query(update_attributes_query)
         .bind(&name)
-        .bind(&utils::hashmap_to_hstore(&attributes))
+        .bind(utils::hashmap_to_hstore(&attributes))
         .fetch_one(postgres)
         .await?;
     let result: serde_json::Value = row.get(0);

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -43,11 +43,6 @@ pub struct RpcQueryParams {
     pub source: Option<MessageSource>,
 }
 
-#[derive(Serialize)]
-pub struct SuccessResponse {
-    status: String,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum SupportedCurrencies {

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -139,7 +139,7 @@ pub async fn rpc_provider_call(
     body: Bytes,
     provider: Arc<dyn crate::providers::RpcProvider>,
 ) -> Result<Response, RpcError> {
-    Span::current().record("provider", &provider.provider_kind().to_string());
+    Span::current().record("provider", provider.provider_kind().to_string());
     let chain_id = query_params.chain_id.clone();
     let origin = headers
         .get("origin")

--- a/src/handlers/sessions/cosign.rs
+++ b/src/handlers/sessions/cosign.rs
@@ -32,8 +32,9 @@ const ENTRY_POINT_V07_CONTRACT_ADDRESS: &str = "0x0000000071727De22E5E9d8BAf0edA
 
 /// Co-sign response schema
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CoSignResponse {
-    receipt: String,
+    user_operation_tx_hash: String,
 }
 
 pub async fn handler(
@@ -183,7 +184,7 @@ async fn handler_internal(
             .ok_or(RpcError::InvalidConfiguration(
                 "Missing bundler API token".to_string(),
             ))?;
-    let receipt = send_user_operation_to_bundler(
+    let user_operation_tx_hash = send_user_operation_to_bundler(
         &user_op,
         &chain_id,
         &bundler_api_token,
@@ -192,5 +193,8 @@ async fn handler_internal(
     )
     .await?;
 
-    Ok(Json(receipt).into_response())
+    Ok(Json(CoSignResponse {
+        user_operation_tx_hash,
+    })
+    .into_response())
 }


### PR DESCRIPTION
# Description

This PR removes the getting receipt step from the co-signer request handler. Getting the receipt should be moved to a separate endpoint. 
The reason is the receipt can be obtained later than the request for user operation was made, so we need to poll for the receipt after the co-sign request from a dedicated endpoint for that operation.
The co-sign endpoint will now return the user operation tx hash instead of the receipt.

## How Has This Been Tested?

* Manually tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [x] Requires a documentation API SPEC update
* [ ] Breaking change
* [ ] Requires a e2e/integration test update
