### PR TITLE
feat(analytics): adding `clientId` optional identity request field to the analytics

### DIFF
--- a/src/analytics/identity_lookup_info.rs
+++ b/src/analytics/identity_lookup_info.rs
@@ -26,6 +26,8 @@ pub struct IdentityLookupInfo {
     pub region: Option<String>,
     pub country: Option<Arc<str>>,
     pub continent: Option<Arc<str>>,
+
+    pub client_id: Option<String>,
 }
 
 impl IdentityLookupInfo {
@@ -41,6 +43,7 @@ impl IdentityLookupInfo {
         region: Option<Vec<String>>,
         country: Option<Arc<str>>,
         continent: Option<Arc<str>>,
+        client_id: Option<String>,
     ) -> Self {
         Self {
             timestamp: wc::analytics::time::now(),
@@ -60,6 +63,8 @@ impl IdentityLookupInfo {
             region: region.map(|r| r.join(", ")),
             country,
             continent,
+
+            client_id,
         }
     }
 }

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -127,6 +127,7 @@ async fn handler_internal(
             region,
             country,
             continent,
+            query.client_id.clone(),
         ));
     }
 
@@ -173,6 +174,8 @@ pub struct IdentityQueryParams {
     /// Optional flag to control the cache to fetch the data from the provider
     /// or serve from the cache where applicable
     pub use_cache: Option<bool>,
+    /// Client ID for analytics
+    pub client_id: Option<String>,
 }
 
 #[tracing::instrument(skip_all, level = "debug")]


### PR DESCRIPTION
# Description

This PR adds the optional `clientId` request parameter to the analytics.
Some of `/identity` requests now have a `clientId` parameter which is the client ID of the end-user’s dapp instance of the Sign Client. 
We need to use this for analytics. The new optional `client_id` field was added at the end of the analytics structure.

## How Has This Been Tested?

* Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
