### PR TITLE
feat(names): adding `apiVersion=2` query parameter to fix not-found responses

### DIFF
--- a/integration/names.test.ts
+++ b/integration/names.test.ts
@@ -272,7 +272,7 @@ describe('Account profile names', () => {
     expect(resp.status).toBe(400)
   })
 
-  it('name forward lookup', async () => {
+  it('name forward lookup (name found)', async () => {
     let resp: any = await httpClient.get(
       `${baseUrl}/v1/profile/account/${name}`
     )
@@ -285,7 +285,27 @@ describe('Account profile names', () => {
     expect(first.address).toBe(address)
   })
 
-  it('name reverse lookup', async () => {
+  it('name forward lookup (name not found)', async () => {
+    const randomString = Array.from({ length: 10 }, 
+      () => (Math.random().toString(36)[2] || '0')).join('')
+    const name = `integration-test-${randomString}.${zone}`;
+    
+    // Test v=1 where 404 is returned
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/profile/account/${name}`
+    )
+    expect(resp.status).toBe(404)
+    
+    // Test v=2 where 200 and empty array is returned
+    resp = await httpClient.get(
+      `${baseUrl}/v1/profile/account/${name}?v=2`
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data).toBe('object')
+    expect(resp.data.length).toBe(0)
+  })
+
+  it('name reverse lookup (name found)', async () => {
     let resp: any = await httpClient.get(
       `${baseUrl}/v1/profile/reverse/${address}`
     )
@@ -297,6 +317,26 @@ describe('Account profile names', () => {
     // ENSIP-11 using the 60 for the Ethereum mainnet
     const first_address = first_name.addresses[coin_type]
     expect(first_address.address).toBe(address)
+  })
+
+  it('name reverse lookup (name not found)', async () => {
+    // Generate a new eth wallet that have no name registered
+    const wallet = ethers.Wallet.createRandom();
+    const address = wallet.address;
+
+    // Test v=1 where 404 is returned
+    let resp: any = await httpClient.get(
+      `${baseUrl}/v1/profile/reverse/${address}`
+    )
+    expect(resp.status).toBe(404)
+    
+    // Test v=2 where 200 and empty array is returned
+    resp = await httpClient.get(
+      `${baseUrl}/v1/profile/reverse/${address}?v=2`
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data).toBe('object')
+    expect(resp.data.length).toBe(0)
   })
 
   it('name reverse lookup (identity endpoint)', async () => {

--- a/integration/names.test.ts
+++ b/integration/names.test.ts
@@ -290,15 +290,15 @@ describe('Account profile names', () => {
       () => (Math.random().toString(36)[2] || '0')).join('')
     const name = `integration-test-${randomString}.${zone}`;
     
-    // Test v=1 where 404 is returned
+    // Test default behavior where 404 is returned
     let resp: any = await httpClient.get(
       `${baseUrl}/v1/profile/account/${name}`
     )
     expect(resp.status).toBe(404)
     
-    // Test v=2 where 200 and empty array is returned
+    // Test apiVersion=2 where 200 and empty array is returned
     resp = await httpClient.get(
-      `${baseUrl}/v1/profile/account/${name}?v=2`
+      `${baseUrl}/v1/profile/account/${name}?apiVersion=2`
     )
     expect(resp.status).toBe(200)
     expect(typeof resp.data).toBe('object')
@@ -324,15 +324,15 @@ describe('Account profile names', () => {
     const wallet = ethers.Wallet.createRandom();
     const address = wallet.address;
 
-    // Test v=1 where 404 is returned
+    // Test default behavior where 404 is returned
     let resp: any = await httpClient.get(
       `${baseUrl}/v1/profile/reverse/${address}`
     )
     expect(resp.status).toBe(404)
     
-    // Test v=2 where 200 and empty array is returned
+    // Test apiVersion=2 where 200 and empty array is returned
     resp = await httpClient.get(
-      `${baseUrl}/v1/profile/reverse/${address}?v=2`
+      `${baseUrl}/v1/profile/reverse/${address}?apiVersion=2`
     )
     expect(resp.status).toBe(200)
     expect(typeof resp.data).toBe('object')

--- a/src/error.rs
+++ b/src/error.rs
@@ -135,6 +135,9 @@ pub enum RpcError {
     #[error("Name is not registered: {0}")]
     NameNotRegistered(String),
 
+    #[error("Name registeration error: {0}")]
+    NameRegistrationError(String),
+
     #[error("Name is not found: {0}")]
     NameNotFound(String),
 

--- a/src/handlers/profile/lookup.rs
+++ b/src/handlers/profile/lookup.rs
@@ -52,8 +52,7 @@ async fn handler_internal(
         Ok(response) => Ok(Json(response).into_response()),
         Err(e) => match e {
             SqlxError::RowNotFound => {
-                // Return an empty response when there are no results when `v=2` query
-                // parameter is set to fix the console errors and for the future v2 support
+                // Return `HTTP 404` by default and an empty array for the future v2 support
                 return {
                     if query.api_version == Some(2) {
                         Ok(Json(EMPTY_RESPONSE).into_response())

--- a/src/handlers/profile/lookup.rs
+++ b/src/handlers/profile/lookup.rs
@@ -55,7 +55,7 @@ async fn handler_internal(
                 // Return an empty response when there are no results when `v=2` query
                 // parameter is set to fix the console errors and for the future v2 support
                 return {
-                    if query.v == Some(2) {
+                    if query.api_version == Some(2) {
                         Ok(Json(EMPTY_RESPONSE).into_response())
                     } else {
                         Err(RpcError::NameNotFound(name))

--- a/src/handlers/profile/mod.rs
+++ b/src/handlers/profile/mod.rs
@@ -31,6 +31,10 @@ static SUPPORTED_ATTRIBUTES: Lazy<HashMap<String, Regex>> = Lazy::new(|| {
     map
 });
 
+/// Empty vector as an empty response
+/// This is used to return an empty response when there are no results
+pub const EMPTY_RESPONSE: Vec<String> = Vec::new();
+
 /// Payload to register domain name that should be serialized to JSON
 /// and passed to the RegisterRequest.message
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -75,4 +79,12 @@ pub struct RegisterRequest {
     pub coin_type: u32,
     /// Address
     pub address: String,
+}
+
+/// Forward and reverse lookup query parameters
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LookupQueryParams {
+    /// Optional version parameter to support version-dependent responses
+    pub v: Option<usize>,
 }

--- a/src/handlers/profile/mod.rs
+++ b/src/handlers/profile/mod.rs
@@ -86,5 +86,5 @@ pub struct RegisterRequest {
 #[serde(rename_all = "camelCase")]
 pub struct LookupQueryParams {
     /// Optional version parameter to support version-dependent responses
-    pub v: Option<usize>,
+    pub api_version: Option<usize>,
 }

--- a/src/handlers/profile/register.rs
+++ b/src/handlers/profile/register.rs
@@ -200,7 +200,9 @@ pub async fn handler_internal(
     match get_name_and_addresses_by_name(payload.name.clone(), &state.postgres.clone()).await {
         Ok(response) => Ok(Json(response).into_response()),
         Err(e) => match e {
-            SqlxError::RowNotFound => Err(RpcError::NameNotFound(payload.name.clone())),
+            SqlxError::RowNotFound => Err(RpcError::NameRegistrationError(
+                "Name was not found in the database after the registration".into(),
+            )),
             _ => {
                 // Handle other types of errors
                 error!("Failed to lookup name: {}", e);

--- a/src/handlers/profile/reverse.rs
+++ b/src/handlers/profile/reverse.rs
@@ -41,8 +41,7 @@ async fn handler_internal(
     };
 
     if names.is_empty() {
-        // Return an empty response when there are no results when `v=2` query
-        // parameter is set to fix the console errors and for the future v2 support
+        // Return `HTTP 404` by default and an empty array for the future v2 support
         if query.api_version == Some(2) {
             return Ok(Json(EMPTY_RESPONSE).into_response());
         } else {

--- a/src/handlers/profile/reverse.rs
+++ b/src/handlers/profile/reverse.rs
@@ -43,7 +43,7 @@ async fn handler_internal(
     if names.is_empty() {
         // Return an empty response when there are no results when `v=2` query
         // parameter is set to fix the console errors and for the future v2 support
-        if query.v == Some(2) {
+        if query.api_version == Some(2) {
             return Ok(Json(EMPTY_RESPONSE).into_response());
         } else {
             return Err(RpcError::NameByAddressNotFound);

--- a/src/handlers/profile/reverse.rs
+++ b/src/handlers/profile/reverse.rs
@@ -1,12 +1,12 @@
 use {
-    super::super::HANDLER_TASK_METRICS,
+    super::{super::HANDLER_TASK_METRICS, LookupQueryParams, EMPTY_RESPONSE},
     crate::{
         database::helpers::{get_name_and_addresses_by_name, get_names_by_address},
         error::RpcError,
         state::AppState,
     },
     axum::{
-        extract::{Path, State},
+        extract::{Path, Query, State},
         response::{IntoResponse, Response},
         Json,
     },
@@ -19,8 +19,9 @@ use {
 pub async fn handler(
     state: State<Arc<AppState>>,
     address: Path<String>,
+    query: Query<LookupQueryParams>,
 ) -> Result<Response, RpcError> {
-    handler_internal(state, address)
+    handler_internal(state, address, query)
         .with_metrics(HANDLER_TASK_METRICS.with_name("reverse_lookup"))
         .await
 }
@@ -29,6 +30,7 @@ pub async fn handler(
 async fn handler_internal(
     state: State<Arc<AppState>>,
     Path(address): Path<String>,
+    query: Query<LookupQueryParams>,
 ) -> Result<Response, RpcError> {
     let names = match get_names_by_address(address, &state.postgres).await {
         Ok(names) => names,
@@ -39,7 +41,13 @@ async fn handler_internal(
     };
 
     if names.is_empty() {
-        return Err(RpcError::NameByAddressNotFound);
+        // Return an empty response when there are no results when `v=2` query
+        // parameter is set to fix the console errors and for the future v2 support
+        if query.v == Some(2) {
+            return Ok(Json(EMPTY_RESPONSE).into_response());
+        } else {
+            return Err(RpcError::NameByAddressNotFound);
+        }
     }
 
     let mut result = Vec::new();


### PR DESCRIPTION
# Description

This PR adds `apiVersion=2` query parameter to the forward `/v1/profile/account/{name}` and reverse `/v1/profile/reverse/{address}` name lookup endpoints to fix the condition where `HTTP 404` was returned when no name registered was found. 
Adding the query parameter should fix the response to the new versions, but preserve the backward compatibility support for the current ones.

Resolves #700

[API Spec update.](https://github.com/WalletConnect/walletconnect-specs/pull/247)

## How Has This Been Tested?

* [New integration tests were added and current ones were updated.](https://github.com/WalletConnect/blockchain-api/pull/719/files#diff-28b661942cfc4edae43683709afac7c88cdd3d5bdcc47e602ee9ea4c876dbaf1)

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
