### PR TITLE
fix(o11y): ENS Metric tracked without aggregate

### DIFF
--- a/terraform/monitoring/panels/names/registered.libsonnet
+++ b/terraform/monitoring/panels/names/registered.libsonnet
@@ -14,7 +14,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'account_names_count',
+      expr        = 'max(account_names_count)',
       refId       = "Names count",
     ))
 }


### PR DESCRIPTION

The ENS metric shows one metric per dimension instead of an aggregate.

## How Has This Been Tested?

Tested manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
