### PR TITLE
fix(identity): properly handling of the avatar NFT absence

### DIFF
--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -531,7 +531,7 @@ impl JsonRpcClient for SelfProvider {
         };
         let result = serde_json::from_value(result).map_err(|e| {
             SelfProviderError::GenericParameterError(format!(
-                "Result should always provide generic parameter which is deserializable: {}",
+                "Caller should always provide generic parameter R=Bytes: {}",
                 e
             ))
         })?;


### PR DESCRIPTION
# Description

This PR adds properly handling exceptional cases where the ENS name avatar pointing to the ERC721 NFT which is absent or the contract address is wrong.
Currently, when ENS name have an `avatar record` that points to the wrong contract address we are returning `HTTP 500` error (because the contract call result is `0x`), which is wrong since the name was resolved and we should just return `avatar: null` in such cases instead of the server error.

## How Has This Been Tested?

* The following identity request triggers `HTTP 500`: `/v1/identity/0x08D3a14b98D1E15B197bb86545d119E1C769Df45`.
* This Pr changes fixing the response to became `{"name":"bubnov.eth", "avatar":null }`.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
