### PR TITLE
fix(identity): properly handling of the JSON-RPC code `-32000`

### DIFF
--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -355,7 +355,7 @@ pub fn handle_rpc_error(error: ProviderError) -> Result<(), RpcError> {
             // Proceed with Ok() if the error is related to the contract call error
             // since there should be a wrong NFT avatar contract address.
             if error_detail.contains("Contract call error") {
-                warn!(
+                debug!(
                     "Contract call error while looking up identity: {:?}",
                     error_detail
                 );
@@ -363,7 +363,7 @@ pub fn handle_rpc_error(error: ProviderError) -> Result<(), RpcError> {
             }
             // Proceed with Ok() if the error is related to the JSON-RPC -32000 error code.
             if error_detail.contains("code: -32000") {
-                warn!(
+                debug!(
                     "JsonRpcError code -32000 while looking up identity: {:?}",
                     error_detail
                 );

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -361,6 +361,14 @@ pub fn handle_rpc_error(error: ProviderError) -> Result<(), RpcError> {
                 );
                 return Ok(());
             }
+            // Proceed with Ok() if the error is related to the JSON-RPC -32000 error code.
+            if error_detail.contains("code: -32000") {
+                warn!(
+                    "JsonRpcError code -32000 while looking up identity: {:?}",
+                    error_detail
+                );
+                return Ok(());
+            }
 
             Err(RpcError::IdentityLookup(error_detail.to_string()))
         }


### PR DESCRIPTION
# Description

This PR adds proper handling of the JSON-RPC code `-32000` when trying to get the identity avatar.
Currently, if the avatar contains an NFT contract address and the execution was reverted there is a JSON-RPC error `-32000` that results in the `HTTP 500` error response. In such cases, we should return just an empty avatar instead of the server error.

## How Has This Been Tested?

* Identity request `/v1/identity/0x2531Dac8784CC16b0F1047C5FB97A4a629c44566` results in the `HTTP 500` error, because the name `shibun.eth` contains the `eip155:1/erc721:0x373075bab7d668ed2473d8233ebdebcf49eb758e/1` avatar contract record that returns execution reverted.
* Calling the same request in the current PR results to the `{"name":"shibun.eth","avatar":null,"resolvedAt":"2024-08-08T13:15:45.889236Z"}` response, which is the same as at the https://ens.app/shibun.eth

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
