### PR TITLE
fix(tests): increasing integration tests timeout

### DIFF
--- a/integration/jestconfig.integration.json
+++ b/integration/jestconfig.integration.json
@@ -4,5 +4,6 @@
     "^.+\\.(t|j)sx?$": "ts-jest"
   },
   "testRegex": "./.*\\.test\\.ts$",
-  "collectCoverageFrom": ["src/**/*.{ts,js}"]
+  "collectCoverageFrom": ["src/**/*.{ts,js}"],
+  "testTimeout": 10000
 }


### PR DESCRIPTION
# Description

This PR increases the integration tests timeout to 10 seconds. Since we have a bunch of tests and the number of new tests increased sometimes the default 5 seconds is not enough and we get the `thrown: "Exceeded timeout of 5000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test"` error.
This PR increases the `testTimeout` parameter in the jest config file.

## How Has This Been Tested?

* Tested by running `yarn test` on the long-running test.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
