### PR TITLE
fix(zerion): adding zksync era mapping name

### DIFF
--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -574,8 +574,12 @@ pub enum ChainId {
         serialize = "gnosischain"
     )]
     GnosisChain = 100,
-    #[strum(serialize = "zksync", serialize = "zksyncera")]
-    ZkSyncEra = 328,
+    #[strum(
+        serialize = "zksync",
+        serialize = "zksyncera",
+        serialize = "zksync-era"
+    )]
+    ZkSyncEra = 324,
     Zora = 7854577,
 }
 


### PR DESCRIPTION
# Description

This PR adds an additional mapping (human-readable name -> chain ID) name to the zkSync Era chain. 
Zerion uses `zksync-era` chain name for the chain ID 324. 
Also, this PR fixes a bug where zkSync Era is mapped to the Chain ID `328` instead of `324`.

## How Has This Been Tested?

* Current integration tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
