### PR TITLE
feat(analytics): adding `same_sender` field to the identity lookup analytics

### DIFF
--- a/src/analytics/identity_lookup_info.rs
+++ b/src/analytics/identity_lookup_info.rs
@@ -28,6 +28,8 @@ pub struct IdentityLookupInfo {
     pub continent: Option<Arc<str>>,
 
     pub client_id: Option<String>,
+    /// Whether the sender of the request is the same as the address being looked up
+    pub same_sender: Option<bool>,
 }
 
 impl IdentityLookupInfo {
@@ -44,6 +46,7 @@ impl IdentityLookupInfo {
         country: Option<Arc<str>>,
         continent: Option<Arc<str>>,
         client_id: Option<String>,
+        same_sender: Option<bool>,
     ) -> Self {
         Self {
             timestamp: wc::analytics::time::now(),
@@ -65,6 +68,7 @@ impl IdentityLookupInfo {
             continent,
 
             client_id,
+            same_sender,
         }
     }
 }

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -116,6 +116,11 @@ async fn handler_internal(
             .map(|geo| (geo.country, geo.continent, geo.region))
             .unwrap_or((None, None, None));
 
+        let same_sender = query
+            .sender
+            .as_ref()
+            .map(|sender| sender == &address.to_string());
+
         state.analytics.identity_lookup(IdentityLookupInfo::new(
             &query.0,
             address,
@@ -128,6 +133,7 @@ async fn handler_internal(
             country,
             continent,
             query.client_id.clone(),
+            same_sender,
         ));
     }
 
@@ -176,6 +182,8 @@ pub struct IdentityQueryParams {
     pub use_cache: Option<bool>,
     /// Client ID for analytics
     pub client_id: Option<String>,
+    /// Request sender address for analytics
+    pub sender: Option<String>,
 }
 
 #[tracing::instrument(skip_all, level = "debug")]

--- a/src/handlers/profile/mod.rs
+++ b/src/handlers/profile/mod.rs
@@ -87,4 +87,6 @@ pub struct RegisterRequest {
 pub struct LookupQueryParams {
     /// Optional version parameter to support version-dependent responses
     pub api_version: Option<usize>,
+    /// Request sender address for analytics
+    pub sender: Option<String>,
 }


### PR DESCRIPTION
# Description

This PR adds `same_sender` boolean field to the identity analytics to reflect was the name lookup request was made for the same address (`true`) as the owner or not (`false`). The field is optional to support backward compatibility.

Web3Modal related PR: [#2649](https://github.com/WalletConnect/web3modal/pull/2649)

## How Has This Been Tested?

* Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
