### PR TITLE
fix(providers): changing Mantle Testnet endpoint and chain ID to the actual

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -16,7 +16,7 @@ Chain name with associated `chainId` query param to use.
 | zkSync Era                                               | eip155:324           |
 | Polygon Zkevm                                            | eip155:1101          |
 | Mantle <sup>[1](#footnote1)</sup>                        | eip155:5000          |
-| Mantle Testnet <sup>[1](#footnote1)</sup>                | eip155:5001          |
+| Mantle Testnet <sup>[1](#footnote1)</sup>                | eip155:5003          |
 | Klaytn Mainnet                                           | eip155:8217          |
 | Base                                                     | eip155:8453          |
 | Ethereum Holesky                                         | eip155:17000         |

--- a/src/env/mantle.rs
+++ b/src/env/mantle.rs
@@ -43,11 +43,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::High).unwrap(),
             ),
         ),
-        // Mantle testnet
+        // Mantle Sepolia testnet
         (
-            "eip155:5001".into(),
+            "eip155:5003".into(),
             (
-                "https://rpc.testnet.mantle.xyz".into(),
+                "https://rpc.sepolia.mantle.xyz".into(),
                 Weight::new(Priority::High).unwrap(),
             ),
         ),

--- a/tests/functional/http/mantle.rs
+++ b/tests/functional/http/mantle.rs
@@ -19,8 +19,8 @@ async fn mantle_provider(ctx: &mut ServerContext) {
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,
         &ProviderKind::Mantle,
-        "eip155:5001",
-        "0x1389",
+        "eip155:5003",
+        "0x138b",
     )
     .await;
 }


### PR DESCRIPTION
# Description

This PR changes Mantle (MNT) testnet chain ID and RPC endpoint to the actual.
Currently, Mantle deprecated the `https://rpc.testnet.mantle.xyz` endpoint and `5001` Chain ID for the testnet in favor of `5003` and `https://rpc.sepolia.mantle.xyz` RPC endpoint.

## How Has This Been Tested?

* Updated provider integration test.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
