### PR TITLE
feat(providers): adding Polygon Amoy testnet support to the Publicnode provider

### DIFF
--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -84,6 +84,14 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:137".into(),
             ("polygon-bor".into(), Weight::new(Priority::Normal).unwrap()),
         ),
+        // Polygon bor amoy testnet
+        (
+            "eip155:80002".into(),
+            (
+                "polygon-amoy-bor-rpc".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
+        ),
         // Mantle mainnet
         (
             "eip155:5000".into(),

--- a/tests/functional/http/publicnode.rs
+++ b/tests/functional/http/publicnode.rs
@@ -79,6 +79,15 @@ async fn publicnode_provider(ctx: &mut ServerContext) {
     )
     .await;
 
+    // Polygon amoy testnet
+    check_if_rpc_is_responding_correctly_for_supported_chain(
+        ctx,
+        &ProviderKind::Publicnode,
+        "eip155:80002",
+        "0x13882",
+    )
+    .await;
+
     // Mantle mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(
         ctx,


### PR DESCRIPTION
# Description

This PR adds Polygon Amoy (eip155:80002) support to the Publicnode provider to distribute the load since we have just one provider for that chain ID at the moment.

## How Has This Been Tested?

* Updated provider integration test.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
