### PR TITLE
fix: remove special TCP flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,13 +448,7 @@ fn create_server(
     app: Router,
     addr: &SocketAddr,
 ) -> Server<AddrIncoming, IntoMakeServiceWithConnectInfo<Router, SocketAddr>> {
-    axum::Server::bind(addr)
-        .tcp_keepalive(Some(KEEPALIVE_IDLE_DURATION))
-        .tcp_keepalive_interval(Some(KEEPALIVE_INTERVAL))
-        .tcp_keepalive_retries(Some(KEEPALIVE_RETRIES))
-        .tcp_sleep_on_accept_errors(true)
-        .tcp_nodelay(true)
-        .serve(app.into_make_service_with_connect_info::<SocketAddr>())
+    axum::Server::bind(addr).serve(app.into_make_service_with_connect_info::<SocketAddr>())
 }
 
 fn init_providers(config: &ProvidersConfig) -> ProviderRepository {

--- a/terraform/ecs/network.tf
+++ b/terraform/ecs/network.tf
@@ -9,6 +9,11 @@ resource "aws_lb" "load_balancer" {
   load_balancer_type = "application"
   subnets            = var.public_subnets
 
+  // client_keep_alive must be greater (or equal?) than idle_timeout:
+  // https://repost.aws/knowledge-center/elb-alb-troubleshoot-502-errors
+  client_keep_alive = 60
+  idle_timeout      = 60
+
   security_groups = [aws_security_group.lb_ingress.id]
 
   lifecycle {


### PR DESCRIPTION
# Description

Removes special TCP flags... these seem to be leading to TCP resets.

The ALB is responsible for closing client connections, not these flags, so we need to tune on the ALB instead. Looks like we customized these values in the load balancer to 60 and 60 already, but didn't put in Terraform.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
