### PR TITLE
fix: add proxy timeout

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,9 @@ pub enum RpcError {
     #[error("Transport error: {0}")]
     TransportError(#[from] hyper::Error),
 
+    #[error("Proxy timeout error: {0}")]
+    ProxyTimeoutError(tokio::time::error::Elapsed),
+
     #[error("Request::builder() failed: {0}")]
     RequestBuilderError(#[from] hyper::http::Error),
 

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -112,12 +112,12 @@ pub async fn rpc_call(
             Ok(response) if !response.status().is_server_error() => {
                 return Ok(response);
             }
-            _ => {
+            e => {
                 state
                     .metrics
                     .add_rpc_call_retries(i as u64, chain_id.clone());
                 debug!(
-                    "Provider '{}' returned an error, trying the next provider",
+                    "Provider '{}' returned an error {e:?}, trying the next provider",
                     provider.provider_kind()
                 );
             }


### PR DESCRIPTION
# Description

This adds a 10s timeout to call providers. Metrics show that sometimes endpoints can sometimes take a long time to respond and this could lead to 504 errors.

<img width="1150" alt="Screenshot 2024-08-16 at 13 53 22" src="https://github.com/user-attachments/assets/1975be1e-40d6-4247-b126-dcb9fb13fe9a">

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
