### PR TITLE
feat(grafana): adding provider RPC call retries panel

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -114,6 +114,7 @@ dashboard.new(
     panels.proxy.calls(ds, vars)                     { gridPos: pos._2 },
     panels.proxy.latency(ds, vars)                   { gridPos: pos._2 },
     panels.proxy.errors_provider(ds, vars)           { gridPos: pos._3 },
+    panels.proxy.provider_retries(ds, vars)          { gridPos: pos._3 },
     panels.proxy.rejected_projects(ds, vars)         { gridPos: pos._3 },
     panels.proxy.quota_limited_projects(ds, vars)    { gridPos: pos._3 },
     panels.proxy.rate_limited_counter(ds, vars)      { gridPos: pos._3 },

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -25,6 +25,7 @@ local redis  = panels.aws.redis;
     latency:                (import 'proxy/latency.libsonnet'               ).new,
     errors_non_provider:    (import 'proxy/errors_non_provider.libsonnet'   ).new,
     errors_provider:        (import 'proxy/errors_provider.libsonnet'       ).new,
+    provider_retries:       (import 'proxy/rpc_retries.libsonnet'           ).new,
     rejected_projects:      (import 'proxy/rejected_projects.libsonnet'     ).new,
     quota_limited_projects: (import 'proxy/quota_limited_projects.libsonnet').new,
     rate_limited_counter:   (import 'proxy/rate_limited_counter.libsonnet'  ).new,

--- a/terraform/monitoring/panels/proxy/rpc_retries.libsonnet
+++ b/terraform/monitoring/panels/proxy/rpc_retries.libsonnet
@@ -1,0 +1,24 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+local _configuration = defaults.configuration.timeseries
+  .withUnit('cpm');
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Provider call retries',
+      datasource  = ds.prometheus,
+    )
+    .configure(_configuration)
+
+    .addTarget(targets.prometheus(
+      datasource  = ds.prometheus,
+      expr          = 'sum by (chain_id)(rate(rpc_call_retries_sum{}[$__rate_interval]))',
+      exemplar      = false,
+      legendFormat  = '__auto',
+    ))
+}


### PR DESCRIPTION
# Description

This PR adds a Grafana `Provider call retries` panel to track analytics `rpc_call_retries` histogram. 
The panel will track how many provider retries we have for each of the chain id on RPC calls.

## How Has This Been Tested?

* The query was manually added to the Grafana dashboard and it shows the right chart.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
