### PR TITLE
fix: min 1 weight

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -226,7 +226,11 @@ impl ProviderRepository {
             return Err(RpcError::UnsupportedChain(chain_id.to_string()));
         }
 
-        let weights: Vec<_> = providers.iter().map(|(_, weight)| weight.value()).collect();
+        let weights: Vec<_> = providers
+            .iter()
+            .map(|(_, weight)| weight.value())
+            .map(|w| w.min(1))
+            .collect();
         let non_zero_weight_providers = weights.iter().filter(|&x| *x > 0).count();
         let keys = providers.keys().cloned().collect::<Vec<_>>();
 


### PR DESCRIPTION
# Description

Sets the minimum weight to 1 when selecting a provider so that there's always a little bit of traffic to a provider.

Resolves #737 

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
