### PR TITLE
fix(rpc): passing through a `bad request` error from the RPC provider

### DIFF
--- a/integration/proxy.test.ts
+++ b/integration/proxy.test.ts
@@ -30,4 +30,21 @@ describe('Proxy', () => {
     )
     expect(resp.status).toBe(401)
   })
+
+  it('Bad JSON-RPC request', async () => {
+    // Missing the id field
+    const payload = {
+      jsonrpc: "2.0",
+      method: "eth_chainId",
+      params: [],
+    };
+    const chainId = "eip155:11155111";
+
+    let resp: any = await httpClient.post(
+      `${baseUrl}/v1?chainId=${chainId}&projectId=${projectId}`,
+      payload
+    )
+    expect(resp.status).toBe(400)
+    expect(typeof resp.data).toBe('object')
+  })
 })

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -109,12 +109,7 @@ pub async fn rpc_call(
         .await;
 
         match response {
-            // Passing the response through to the user if it's a bad request
-            // to preserve the JSON-RPC error message
-            Ok(response)
-                if response.status() == http::StatusCode::BAD_REQUEST
-                    || !response.status().is_server_error() =>
-            {
+            Ok(response) if !response.status().is_server_error() => {
                 return Ok(response);
             }
             e => {

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -109,7 +109,12 @@ pub async fn rpc_call(
         .await;
 
         match response {
-            Ok(response) if !response.status().is_server_error() => {
+            // Passing the response through to the user if it's a bad request
+            // to preserve the JSON-RPC error message
+            Ok(response)
+                if response.status() == http::StatusCode::BAD_REQUEST
+                    || !response.status().is_server_error() =>
+            {
                 return Ok(response);
             }
             e => {
@@ -207,7 +212,7 @@ pub async fn rpc_provider_call(
     );
 
     match response.status() {
-        http::StatusCode::OK => {
+        http::StatusCode::OK | http::StatusCode::BAD_REQUEST => {
             state.metrics.add_finished_provider_call(provider.borrow());
         }
         _ => {


### PR DESCRIPTION
# Description

This PR adds proper handling of the `HTTP 400 Bad Request` RPC provider response.
Currently, if the user sends a bad JSON-RPC request, the provider responds with `HTTP 400` which is considered a provider error, and we try the next provider in the retry list. Every provider fails and that results in `HTTP 503 Provider x unavailable` error instead of stopping retrying and passing the `HTTP 400 Bad request` error to the user with the error details.

Resolves #740

## How Has This Been Tested?

* A new integration test was created.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
