### PR TITLE
fix(redis): increasing the node type and max connections

### DIFF
--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -113,7 +113,7 @@ variable "log_level" {
 variable "redis_max_connections" {
   description = "The maximum number of connections to the Redis server"
   type        = number
-  default     = 128
+  default     = 512
 }
 
 variable "project_cache_endpoint_read" {

--- a/terraform/redis/variables.tf
+++ b/terraform/redis/variables.tf
@@ -4,7 +4,7 @@
 variable "node_type" {
   description = "The instance type to use for the database nodes"
   type        = string
-  default     = "cache.t4g.micro" # https://aws.amazon.com/elasticache/pricing/?nc=sn&loc=5#On-demand_nodes
+  default     = "cache.t4g.small" # https://aws.amazon.com/elasticache/pricing/?nc=sn&loc=5#On-demand_nodes
 }
 
 variable "num_cache_nodes" {


### PR DESCRIPTION
# Description

This PR increases the Redis node type to `cache.t4g.small` and Redis pool maximum connections to `512`.
This change fixes the Redis bottleneck issue on connection spikes when using the rate-limiting middleware which depends on the Redis connections.

## How Has This Been Tested?

* Tested by applying manually.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
