### PR TITLE
feat(grafana): adding handlers execution time, rps chart and alert

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -62,6 +62,7 @@ dashboard.new(
     panels.proxy.errors_non_provider(ds, vars)       { gridPos: pos._4 },
     panels.lb.error_5xx_logs(ds, vars)               { gridPos: pos._4 },
     panels.app.handlers_latency(ds, vars)            { gridPos: pos._2 },
+    panels.app.handlers_rate(ds, vars)               { gridPos: pos._2 },
 
   row.new('ECS'),
     panels.ecs.memory(ds, vars)                      { gridPos: pos._3 },

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -57,12 +57,11 @@ dashboard.new(
 
 .addPanels(layout.generate_grid([
   row.new('Application'),
-    // panels.app.http_request_rate(ds, vars)          { gridPos: pos._4 },
-    // panels.app.http_request_latency(ds, vars)       { gridPos: pos._4 },
     panels.ecs.availability(ds, vars)                { gridPos: pos._4 },
     panels.lb.error_5xx(ds, vars)                    { gridPos: pos._4 },
     panels.proxy.errors_non_provider(ds, vars)       { gridPos: pos._4 },
     panels.lb.error_5xx_logs(ds, vars)               { gridPos: pos._4 },
+    panels.app.handlers_latency(ds, vars)            { gridPos: pos._2 },
 
   row.new('ECS'),
     panels.ecs.memory(ds, vars)                      { gridPos: pos._3 },

--- a/terraform/monitoring/panels/app/handlers_latency.libsonnet
+++ b/terraform/monitoring/panels/app/handlers_latency.libsonnet
@@ -1,0 +1,47 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+local _configuration = defaults.configuration.timeseries
+  .withUnit('ms');
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Handlers execution duration',
+      datasource  = ds.prometheus,
+    )
+    .configure(_configuration)
+
+    .setAlert(vars.environment, alert.new(
+      namespace     = 'Blockchain API',
+      name          = "%s - High handlers execution duration" % vars.environment,
+      message       = "%s - High handlers execution duration" % vars.environment,
+      period        = '5m',
+      frequency     = '1m',
+      noDataState   = 'no_data',
+      notifications = vars.notifications,
+      alertRuleTags = {
+        'og_priority': 'P3',
+      },
+      conditions  = [
+        alertCondition.new(
+          evaluatorParams = [ 3000 ],
+          evaluatorType   = 'gt',
+          operatorType    = 'or',
+          queryRefId      = 'Rate_limited_count',
+          queryTimeStart  = '5m',
+          reducerType     = 'avg',
+        ),
+      ]
+    ))
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum by(task_name) (rate(handler_task_duration_sum[$__rate_interval])) / sum by(task_name) (rate(handler_task_duration_count[$__rate_interval]))',
+      exemplar      = false,
+      legendFormat  = '__auto',
+    ))
+}

--- a/terraform/monitoring/panels/app/handlers_latency.libsonnet
+++ b/terraform/monitoring/panels/app/handlers_latency.libsonnet
@@ -1,8 +1,10 @@
 local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
 local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
 
-local panels    = grafana.panels;
-local targets   = grafana.targets;
+local panels          = grafana.panels;
+local targets         = grafana.targets;
+local alert           = grafana.alert;
+local alertCondition  = grafana.alertCondition;
 
 local _configuration = defaults.configuration.timeseries
   .withUnit('ms');
@@ -31,7 +33,7 @@ local _configuration = defaults.configuration.timeseries
           evaluatorParams = [ 3000 ],
           evaluatorType   = 'gt',
           operatorType    = 'or',
-          queryRefId      = 'Rate_limited_count',
+          queryRefId      = 'HandlersLatency',
           queryTimeStart  = '5m',
           reducerType     = 'avg',
         ),
@@ -43,5 +45,6 @@ local _configuration = defaults.configuration.timeseries
       expr          = 'sum by(task_name) (rate(handler_task_duration_sum[$__rate_interval])) / sum by(task_name) (rate(handler_task_duration_count[$__rate_interval]))',
       exemplar      = false,
       legendFormat  = '__auto',
+      refId         = 'HandlersLatency',
     ))
 }

--- a/terraform/monitoring/panels/app/handlers_rate.libsonnet
+++ b/terraform/monitoring/panels/app/handlers_rate.libsonnet
@@ -1,0 +1,20 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Handlers rate',
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries.withUnit('reqps'))
+
+    .addTarget(targets.prometheus(
+      datasource    = ds.prometheus,
+      expr          = 'sum by(task_name) (rate(handler_task_duration_count[$__rate_interval]))',
+      legendFormat  = "{{task_name}}"
+    ))
+}

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -3,9 +3,10 @@ local redis  = panels.aws.redis;
 
 {
   app: {
-    handlers_latency:     (import 'app/handlers_latency.libsonnet'        ).new, 
+    handlers_latency:     (import 'app/handlers_latency.libsonnet'        ).new,
+    handlers_rate:        (import 'app/handlers_rate.libsonnet'           ).new,
   },
-  
+
   ecs: {
     availability:         (import 'ecs/availability.libsonnet'            ).new,
     cpu:                  (import 'ecs/cpu.libsonnet'                     ).new,

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -2,6 +2,10 @@ local panels = (import '../grafonnet-lib/defaults.libsonnet').panels;
 local redis  = panels.aws.redis;
 
 {
+  app: {
+    handlers_latency:     (import 'app/handlers_latency.libsonnet'        ).new, 
+  },
+  
   ecs: {
     availability:         (import 'ecs/availability.libsonnet'            ).new,
     cpu:                  (import 'ecs/cpu.libsonnet'                     ).new,


### PR DESCRIPTION
# Description

This PR adds a Grafana chart for the handler's execution time. The alert was added for more than 3 seconds of execution time for 5 minutes on average. This alert will help to catch possible blocking and long execution times that can affect the user's experience.

The panel for `Handlers requests per second` was also added.

Resolves #750

## How Has This Been Tested?

* Tested by placing the query into Grafana.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
