### PR TITLE
feat(grafana): adding ELB target response time panel and alert

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -145,6 +145,7 @@ dashboard.new(
 
     panels.lb.healthy_hosts(ds, vars)             { gridPos: pos._3 },
     panels.lb.error_4xx(ds, vars)                 { gridPos: pos._3 },
+    panels.lb.response_time(ds, vars)             { gridPos: pos._3 },
 
   row.new('IRN Client'),
     panels.irn.latency(ds, vars)        { gridPos: pos._2 },

--- a/terraform/monitoring/panels/lb/latency.libsonnet
+++ b/terraform/monitoring/panels/lb/latency.libsonnet
@@ -1,0 +1,50 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels         = grafana.panels;
+local targets        = grafana.targets;
+local alert          = grafana.alert;
+local alertCondition = grafana.alertCondition;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Target response time',
+      datasource  = ds.cloudwatch,
+    )
+    .configure(defaults.configuration.timeseries.withUnit('s'))
+
+    .setAlert(vars.environment, alert.new(
+      namespace     = 'Blockchain API',
+      name          = "%s - ELB High target response time" % vars.environment,
+      message       = "%s - ELB High target response time" % vars.environment,
+      period        = '5m',
+      frequency     = '1m',
+      noDataState   = 'no_data',
+      notifications = vars.notifications,
+      alertRuleTags = {
+        'og_priority': 'P3',
+      },
+      conditions  = [
+        alertCondition.new(
+          evaluatorParams = [ 3 ],
+          evaluatorType   = 'gt',
+          operatorType    = 'or',
+          queryRefId      = 'ELBTargetLatency',
+          queryTimeStart  = '5m',
+          reducerType     = 'avg',
+        ),
+      ]
+    ))
+
+    .addTarget(targets.cloudwatch(
+      datasource      = ds.cloudwatch,
+      namespace     = 'AWS/ApplicationELB',
+      metricName    = 'TargetResponseTime',
+      dimensions    = {
+        LoadBalancer: vars.load_balancer
+      },
+      statistic     = 'Average',
+      refId         = 'ELBTargetLatency',
+    ))
+}

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -62,6 +62,7 @@ local redis  = panels.aws.redis;
     error_5xx_logs:           (import 'lb/error_5xx_logs.libsonnet'             ).new,
     healthy_hosts:            (import 'lb/healthy_hosts.libsonnet'              ).new,
     requests:                 (import 'lb/requests.libsonnet'                   ).new,
+    response_time:            (import 'lb/latency.libsonnet'                    ).new, 
   },
 
   irn: {


### PR DESCRIPTION
# Description

This PR adds a new Grafana panel to monitor ELB Target (app) response time and alert in case the average response time for 5 minutes is more than 3 seconds.

Resolves #748 

## How Has This Been Tested?

* Manually applied to the Grafana dashboard.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
