### PR TITLE
feat(debug): temporary adding debug messages for PCI creation and error when not found in IRN

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -190,7 +190,7 @@ pub enum RpcError {
     IrnNotConfigured,
 
     #[error("Permission for PCI is not found: {0}")]
-    PermissionNotFound(String),
+    PermissionNotFound(String, String),
 
     #[error("Wrong Base64 format: {0}")]
     WrongBase64Format(String),
@@ -449,14 +449,22 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response(),
-            Self::PermissionNotFound(e) => (
+            Self::PermissionNotFound(address, pci) => {
+                // TODO: Remove this debug log
+                print!(
+                    "Permission not found with PCI: {:?} and address: {:?}",
+                    pci,
+                    address
+                );
+                (
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(
                     "pci".to_string(),
-                    format!("Permission for PCI is not found: {}", e),
+                    format!("Permission for PCI is not found: {}", pci),
                 )),
             )
-                .into_response(),
+                .into_response()
+        },
             Self::WrongBase64Format(e) => (
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(

--- a/src/handlers/sessions/context.rs
+++ b/src/handlers/sessions/context.rs
@@ -39,7 +39,9 @@ async fn handler_internal(
     let storage_permissions_item = irn_client
         .hget(address.clone(), request_payload.pci.clone())
         .await?
-        .ok_or_else(|| RpcError::PermissionNotFound(request_payload.pci.clone()))?;
+        .ok_or_else(|| {
+            RpcError::PermissionNotFound(address.clone(), request_payload.pci.clone())
+        })?;
     state
         .metrics
         .add_irn_latency(irn_call_start, OperationType::Hget);

--- a/src/handlers/sessions/cosign.rs
+++ b/src/handlers/sessions/cosign.rs
@@ -119,7 +119,9 @@ async fn handler_internal(
     let storage_permissions_item = irn_client
         .hget(caip10_address.clone(), request_payload.pci.clone())
         .await?
-        .ok_or_else(|| RpcError::PermissionNotFound(request_payload.pci.clone()))?;
+        .ok_or_else(|| {
+            RpcError::PermissionNotFound(caip10_address.clone(), request_payload.pci.clone())
+        })?;
     state
         .metrics
         .add_irn_latency(irn_call_start, OperationType::Hget);

--- a/src/handlers/sessions/create.rs
+++ b/src/handlers/sessions/create.rs
@@ -76,9 +76,15 @@ async fn handler_internal(
         .add_irn_latency(irn_call_start, OperationType::Hset);
 
     let response = NewPermissionResponse {
-        pci,
+        pci: pci.clone(),
         key: public_key_der_base64,
     };
+
+    // TODO: remove this debuging log
+    print!(
+        "New permission created with PCI: {:?} for address: {:?}",
+        pci, address
+    );
 
     Ok(Json(response).into_response())
 }

--- a/src/handlers/sessions/get.rs
+++ b/src/handlers/sessions/get.rs
@@ -36,7 +36,7 @@ async fn handler_internal(
     let storage_permissions_item = irn_client
         .hget(request.address.clone(), request.pci.clone())
         .await?
-        .ok_or_else(|| RpcError::PermissionNotFound(request.pci))?;
+        .ok_or_else(|| RpcError::PermissionNotFound(request.address.clone(), request.pci))?;
     state
         .metrics
         .add_irn_latency(irn_call_start, OperationType::Hget);


### PR DESCRIPTION
# Description

This PR adds an additional temporary debugging for the IRN client record creation and tracking the error when the created record was not found during the `hget` lookup. 
We are having rare errors when the client successfully creates a record in IRN and then has a record not found issue. To track this error and make sure it's not a client error these temporary debug lines were added and will be removed when the issue is fixed.

## How Has This Been Tested?

* No tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
