### PR TITLE
feat(bundlerops): extending supported bundler operations list

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -689,6 +689,10 @@ pub enum SupportedBundlerOps {
     EthGetUserOperationReceipt,
     #[serde(rename = "eth_sendUserOperation")]
     EthSendUserOperation,
+    #[serde(rename = "eth_estimateUserOperationGas")]
+    EthEstimateUserOperationGas,
+    #[serde(rename = "pm_sponsorUserOperation")]
+    PmSponsorUserOperation,
 }
 
 /// Provider for the bundler operations

--- a/src/providers/pimlico.rs
+++ b/src/providers/pimlico.rs
@@ -68,8 +68,12 @@ impl BundlerOpsProvider for PimlicoProvider {
         match op {
             SupportedBundlerOps::EthSendUserOperation => "eth_sendUserOperation".into(),
             SupportedBundlerOps::EthGetUserOperationReceipt => "eth_getUserOperationReceipt".into(),
+            SupportedBundlerOps::EthEstimateUserOperationGas => {
+                "eth_estimateUserOperationGas".into()
+            }
             SupportedBundlerOps::WalletGetCallsStatus => "wallet_getCallsStatus".into(),
             SupportedBundlerOps::WalletShowCallsStatus => "wallet_showCallsStatus".into(),
+            SupportedBundlerOps::PmSponsorUserOperation => "pm_sponsorUserOperation".into(),
         }
     }
 }


### PR DESCRIPTION
# Description

This PR extending supported bundler operations list with the following new operations:
* `eth_estimateUserOperationGas`
* `pm_sponsorUserOperation`

New operations are required for the shared library to use the bundler ops API endpoint.

The API SPEC updating PR: https://github.com/WalletConnect/walletconnect-specs/pull/254

## How Has This Been Tested?

* Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
