### PR TITLE
fix(providers): temporary disabling Publicnode for the Base

### DIFF
--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -51,7 +51,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Base mainnet
         (
             "eip155:8453".into(),
-            ("base".into(), Weight::new(Priority::Normal).unwrap()),
+            ("base".into(), Weight::new(Priority::Disabled).unwrap()),
         ),
         // Binance Smart Chain mainnet
         (


### PR DESCRIPTION
# Description

This PR temporarily disabled the Publicnode provider for the Base chain because of the `missing trie node ...` errors on requests.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
