### PR TITLE
fix(providers): enabling Base for Publicnode provider

### DIFF
--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -51,7 +51,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Base mainnet
         (
             "eip155:8453".into(),
-            ("base".into(), Weight::new(Priority::Disabled).unwrap()),
+            ("base".into(), Weight::new(Priority::High).unwrap()),
         ),
         // Binance Smart Chain mainnet
         (


### PR DESCRIPTION
# Description

This PR enabling back the Base chain for the Publicnode provider since the issue was resolved.

## How Has This Been Tested?

* Current integration tet.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
