### PR TITLE
feat(providers): adding Solana fungible price support

### DIFF
--- a/integration/fungible_price.test.ts
+++ b/integration/fungible_price.test.ts
@@ -6,7 +6,9 @@ describe('Fungible price', () => {
   const currency = 'usd'
   const native_token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 
-  it('get erc20 mainnet token price', async () => {
+  const solana_mainnet_chain_id = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+
+  it('get Ethereum ERC20 token price', async () => {
     const shib_token_address = 'eip155:1:0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce';
     let request_data = {
       projectId: projectId,
@@ -29,7 +31,30 @@ describe('Fungible price', () => {
     }
   })
 
-  it('get native tokens price', async () => {
+  it('get Solana SPL token price', async () => {
+    const wsol_token_address = `${solana_mainnet_chain_id}:So11111111111111111111111111111111111111112`;
+    let request_data = {
+      projectId: projectId,
+      currency: currency,
+      addresses: [wsol_token_address]
+    }
+    let resp: any = await httpClient.post(
+      `${endpoint}`,
+      request_data
+    )
+    expect(resp.status).toBe(200)
+    expect(typeof resp.data.fungibles).toBe('object')
+    expect(resp.data.fungibles.length).toBe(1)
+
+    for (const item of resp.data.fungibles) {
+      expect(item.name).toBe('Wrapped SOL')
+      expect(item.symbol).toBe('SOL')
+      expect(typeof item.iconUrl).toBe('string')
+      expect(typeof item.price).toBe('number')
+    }
+  })
+
+  it('get ETH chains native tokens price', async () => {
     const native_tokens = [
       { chainId: 1, symbol: 'ETH' },
       { chainId: 56, symbol: 'BNB' },

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,9 @@ pub enum RpcError {
     #[error("Specified chain is not supported by any of the providers: {0}")]
     UnsupportedChain(String),
 
+    #[error("Specified currency is not supported: {0}")]
+    UnsupportedCurrency(String),
+
     #[error("Requested chain provider is temporarily unavailable: {0}")]
     ChainTemporarilyUnavailable(String),
 
@@ -70,8 +73,8 @@ pub enum RpcError {
     #[error("Failed to reach the balance provider")]
     BalanceProviderError,
 
-    #[error("Failed to reach the fungible price provider")]
-    FungiblePriceProviderError,
+    #[error("Failed to reach the fungible price provider: {0}")]
+    FungiblePriceProviderError(String),
 
     #[error("Failed to parse balance provider url")]
     BalanceParseURLError,
@@ -223,6 +226,14 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response(),
+            Self::UnsupportedCurrency(error_message) => (
+                    StatusCode::BAD_REQUEST,
+                    Json(new_error_response(
+                        "currency".to_string(),
+                        format!("Unsupported currency: {error_message}."),
+                    )),
+                )
+                    .into_response(),
             Self::CryptoUitlsError(e) => (
                 StatusCode::BAD_REQUEST,
                 Json(new_error_response(

--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -235,9 +235,13 @@ async fn handler_internal(
             }
             // Appending the token item to the response if it's not in
             // the balance response due to the zero balance
-            let get_price_info = state
+            let get_price_info_provider = state
                 .providers
-                .fungible_price_provider
+                .fungible_price_providers
+                .get(&namespace)
+                .ok_or_else(|| RpcError::UnsupportedNamespace(namespace))?;
+
+            let get_price_info = get_price_info_provider
                 .get_price(
                     &chain_id.clone(),
                     format!("{:#x}", contract_address).as_str(),

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -44,7 +44,7 @@ pub struct RpcQueryParams {
     pub source: Option<MessageSource>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum SupportedCurrencies {
     BTC,

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -128,7 +128,7 @@ pub struct ProviderRepository {
     pub onramp_provider: Arc<dyn OnRampProvider>,
     pub balance_providers: HashMap<CaipNamespaces, Arc<dyn BalanceProvider>>,
     pub conversion_provider: Arc<dyn ConversionProvider>,
-    pub fungible_price_provider: Arc<dyn FungiblePriceProvider>,
+    pub fungible_price_providers: HashMap<CaipNamespaces, Arc<dyn FungiblePriceProvider>>,
     pub bundler_ops_provider: Arc<dyn BundlerOpsProvider>,
 }
 
@@ -208,6 +208,11 @@ impl ProviderRepository {
 
         let bundler_ops_provider = Arc::new(PimlicoProvider::new(config.pimlico_api_key.clone()));
 
+        let mut fungible_price_providers: HashMap<CaipNamespaces, Arc<dyn FungiblePriceProvider>> =
+            HashMap::new();
+        fungible_price_providers.insert(CaipNamespaces::Eip155, one_inch_provider.clone());
+        fungible_price_providers.insert(CaipNamespaces::Solana, solscan_provider.clone());
+
         Self {
             supported_chains: SupportedChains {
                 http: HashSet::new(),
@@ -225,7 +230,7 @@ impl ProviderRepository {
             onramp_provider: coinbase_pay_provider,
             balance_providers,
             conversion_provider: one_inch_provider.clone(),
-            fungible_price_provider: one_inch_provider.clone(),
+            fungible_price_providers,
             bundler_ops_provider,
         }
     }

--- a/src/storage/redis/mod.rs
+++ b/src/storage/redis/mod.rs
@@ -89,6 +89,7 @@ impl Redis {
         })
     }
 
+    #[allow(dependency_on_unit_never_type_fallback)]
     async fn set_internal(
         &self,
         key: &str,

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -38,6 +38,8 @@ static CAIP_SOLANA_ADDRESS_REGEX: Lazy<Regex> = Lazy::new(|| {
         .expect("Failed to initialize regexp for the solana address format")
 });
 
+pub const SOLANA_NATIVE_TOKEN_ADDRESS: &str = "So11111111111111111111111111111111111111111";
+
 pub const JSON_RPC_VERSION_STR: &str = "2.0";
 pub static JSON_RPC_VERSION: once_cell::sync::Lazy<Arc<str>> =
     once_cell::sync::Lazy::new(|| Arc::from(JSON_RPC_VERSION_STR));
@@ -653,9 +655,10 @@ pub fn disassemble_caip10(
         .ok_or(CryptoUitlsError::WrongChainIdFormat(chain_id.clone()))?;
 
     let address = parts[2].to_string();
-    CAIP_ETH_ADDRESS_REGEX
-        .captures(&address)
-        .ok_or(CryptoUitlsError::WrongAddressFormat(address.clone()))?;
+    if !is_address_valid(&address, &namespace) {
+        return Err(CryptoUitlsError::WrongAddressFormat(address.clone()));
+    };
+
     Ok((namespace, chain_id, address))
 }
 


### PR DESCRIPTION
# Description

This PR adds Solana support for the [fungibles pricing endpoint](https://specs.walletconnect.com/2.0/specs/servers/blockchain/blockchain-api#price) by using the [SolScan Token price](https://pro-api.solscan.io/pro-api-docs/v2.0/reference/v2-token-price) API endpoint for the SOL native token and [SolScan Token Metadata](https://pro-api.solscan.io/pro-api-docs/v2.0/reference/v2-token-meta) endpoint for the SPL tokens.

## How Has This Been Tested?

* A new [integration test was implemented](https://github.com/WalletConnect/blockchain-api/pull/765/files#diff-4493ff1a59d5bf63fc4e0b226e9908932f9c2ef71dafddf6ecf99f00c5739487).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
