### PR TITLE
feat(providers): respond HTTP 503 instead of 500 on provider non-success request

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -500,6 +500,38 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response(),
+            Self::TransactionProviderError => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(new_error_response(
+                    "".to_string(),
+                    "Transaction provider is temporarily unavailable".to_string(),
+                )),
+            )
+                .into_response(),
+            Self::PortfolioProviderError => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(new_error_response(
+                    "".to_string(),
+                    "Portfolio provider is temporarily unavailable".to_string(),
+                )),
+            )
+                .into_response(),
+            Self::BalanceProviderError => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(new_error_response(
+                    "".to_string(),
+                    "Balance provider is temporarily unavailable".to_string(),
+                )),
+            )
+                .into_response(),
+            Self::FungiblePriceProviderError(e) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(new_error_response(
+                    "".to_string(),
+                    format!("Fungibles price provider is temporarily unavailable: {}", e),
+                )),
+            )
+                .into_response(),
 
             // Any other errors considering as 500
             _ => (


### PR DESCRIPTION
# Description

This PR makes the following change for the Zerion and SolScan provider's error handling: in case the request to the provider was not a successful `!response.status().is_success()` we will respond `HTTP 503` Provider temporary unavailable, instead of responding with HTTP 500 Server error. This makes better sense in case if the provider responds with the 500 or 503s.

## How Has This Been Tested?

* Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
