### PR TITLE
feat(monitoring): adding proper metrics for all external requests to non-proxy providers

### DIFF
--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -116,7 +116,7 @@ async fn handler_internal(
 
     let start = SystemTime::now();
     let mut response = provider
-        .get_balance(address.clone(), query.clone().0, state.http_client.clone())
+        .get_balance(address.clone(), query.clone().0, state.metrics.clone())
         .await
         .tap_err(|e| {
             error!("Failed to call balance with {}", e);
@@ -246,6 +246,7 @@ async fn handler_internal(
                     &chain_id.clone(),
                     format!("{:#x}", contract_address).as_str(),
                     &query.currency,
+                    state.metrics.clone(),
                 )
                 .await
                 .tap_err(|e| {

--- a/src/handlers/convert/allowance.rs
+++ b/src/handlers/convert/allowance.rs
@@ -48,7 +48,7 @@ async fn handler_internal(
     let response = state
         .providers
         .conversion_provider
-        .get_allowance(query.0)
+        .get_allowance(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
             error!("Failed to call get allownce with {}", e);

--- a/src/handlers/convert/approve.rs
+++ b/src/handlers/convert/approve.rs
@@ -63,7 +63,7 @@ async fn handler_internal(
     let response = state
         .providers
         .conversion_provider
-        .build_approve_tx(query.0)
+        .build_approve_tx(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
             error!("Failed to call build approve tx for conversion with {}", e);

--- a/src/handlers/convert/gas_price.rs
+++ b/src/handlers/convert/gas_price.rs
@@ -49,7 +49,7 @@ async fn handler_internal(
     let response = state
         .providers
         .conversion_provider
-        .get_gas_price(query.0)
+        .get_gas_price(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
             error!("Failed to call get gas price with {}", e);

--- a/src/handlers/convert/quotes.rs
+++ b/src/handlers/convert/quotes.rs
@@ -60,7 +60,7 @@ async fn handler_internal(
     let response = state
         .providers
         .conversion_provider
-        .get_convert_quote(query.0)
+        .get_convert_quote(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
             error!("Failed to call get conversion quotes with {}", e);

--- a/src/handlers/convert/tokens.rs
+++ b/src/handlers/convert/tokens.rs
@@ -60,7 +60,7 @@ async fn handler_internal(
     let response = state
         .providers
         .conversion_provider
-        .get_tokens_list(query.0)
+        .get_tokens_list(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
             error!("Failed to call get tokens list for conversion with {}", e);

--- a/src/handlers/convert/transaction.rs
+++ b/src/handlers/convert/transaction.rs
@@ -75,7 +75,7 @@ async fn handler_internal(
     let response = state
         .providers
         .conversion_provider
-        .build_convert_tx(request_payload)
+        .build_convert_tx(request_payload, state.metrics.clone())
         .await
         .tap_err(|e| {
             error!("Failed to call build conversion transaction with {}", e);

--- a/src/handlers/fungible_price.rs
+++ b/src/handlers/fungible_price.rs
@@ -75,7 +75,7 @@ async fn handler_internal(
         .ok_or_else(|| RpcError::UnsupportedNamespace(namespace))?;
 
     let response = provider
-        .get_price(&chain_id, &address, &query.currency)
+        .get_price(&chain_id, &address, &query.currency, state.metrics.clone())
         .await
         .tap_err(|e| {
             error!("Failed to call fungible price with {}", e);

--- a/src/handlers/history.rs
+++ b/src/handlers/history.rs
@@ -166,7 +166,7 @@ async fn handler_internal(
             state
                 .providers
                 .coinbase_pay_provider
-                .get_transactions(address.clone(), query.clone().0, state.http_client.clone())
+                .get_transactions(address.clone(), query.clone().0, state.metrics.clone())
                 .await
                 .tap_err(|e| {
                     error!("Failed to call coinbase transactions history with {}", e);
@@ -183,7 +183,7 @@ async fn handler_internal(
             .get(&namespace)
             .ok_or_else(|| RpcError::UnsupportedNamespace(namespace))?;
         provider
-            .get_transactions(address.clone(), query.0.clone(), state.http_client.clone())
+            .get_transactions(address.clone(), query.0.clone(), state.metrics.clone())
             .await
             .tap_err(|e| {
                 error!("Failed to call transactions history with {}", e);

--- a/src/handlers/onramp/options.rs
+++ b/src/handlers/onramp/options.rs
@@ -89,7 +89,7 @@ async fn handler_internal(
     let buy_options = state
         .providers
         .onramp_provider
-        .get_buy_options(query.0, state.http_client.clone())
+        .get_buy_options(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
             error!("Failed to call coinbase buy options with {}", e);

--- a/src/handlers/onramp/quotes.rs
+++ b/src/handlers/onramp/quotes.rs
@@ -85,7 +85,7 @@ async fn handler_internal(
     let buy_quotes = state
         .providers
         .onramp_provider
-        .get_buy_quotes(query.0, state.http_client.clone())
+        .get_buy_quotes(query.0, state.metrics.clone())
         .await
         .tap_err(|e| {
             error!("Failed to call coinbase buy quotes with {}", e);

--- a/src/providers/coinbase.rs
+++ b/src/providers/coinbase.rs
@@ -13,28 +13,61 @@ use {
                 quotes::{OnRampBuyQuotesParams, OnRampBuyQuotesResponse},
             },
         },
+        providers::ProviderKind,
         utils::crypto::ChainId,
+        Metrics,
     },
     async_trait::async_trait,
     serde::{Deserialize, Serialize},
+    std::{sync::Arc, time::SystemTime},
     tracing::log::error,
     url::Url,
 };
 
 #[derive(Debug)]
 pub struct CoinbaseProvider {
+    pub provider_kind: ProviderKind,
     pub api_key: String,
     pub app_id: String,
     pub base_api_url: String,
+    pub http_client: reqwest::Client,
 }
 
 impl CoinbaseProvider {
     pub fn new(api_key: String, app_id: String, base_api_url: String) -> Self {
         Self {
+            provider_kind: ProviderKind::Coinbase,
             api_key,
             app_id,
             base_api_url,
+            http_client: reqwest::Client::new(),
         }
+    }
+
+    async fn send_post_request<T>(
+        &self,
+        url: Url,
+        params: &T,
+    ) -> Result<reqwest::Response, reqwest::Error>
+    where
+        T: Serialize,
+    {
+        self.http_client
+            .post(url)
+            .json(&params)
+            .header("CBPAY-APP-ID", self.app_id.clone())
+            .header("CBPAY-API-KEY", self.api_key.clone())
+            .send()
+            .await
+    }
+
+    async fn send_get_request(&self, url: Url) -> Result<reqwest::Response, reqwest::Error> {
+        self.http_client
+            .get(url)
+            .header("CBPAY-APP-ID", self.app_id.clone())
+            .header("CBPAY-API-KEY", self.api_key.clone())
+            .send()
+            .await
     }
 }
 
@@ -68,7 +101,7 @@ impl HistoryProvider for CoinbaseProvider {
         &self,
         address: String,
         params: HistoryQueryParams,
-        http_client: reqwest::Client,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<HistoryResponseBody> {
         let base = format!("{}/buy/user/{}/transactions", &self.base_api_url, &address);
 
@@ -79,13 +112,15 @@ impl HistoryProvider for CoinbaseProvider {
             url.query_pairs_mut().append_pair("page_key", &cursor);
         }
 
-        let response = http_client
-            .get(url)
-            .header("Content-Type", "application/json")
-            .header("CBPAY-APP-ID", self.app_id.clone())
-            .header("CBPAY-API-KEY", self.api_key.clone())
-            .send()
-            .await?;
+        let latency_start = SystemTime::now();
+        let response = self.send_get_request(url).await?;
+        metrics.add_latency_and_status_code_for_provider(
+            self.provider_kind,
+            response.status().into(),
+            latency_start,
+            None,
+            Some("transactions".to_string()),
+        );
 
         if response.status() != reqwest::StatusCode::OK {
             error!(
@@ -143,7 +178,7 @@ impl OnRampProvider for CoinbaseProvider {
     async fn get_buy_options(
         &self,
         params: OnRampBuyOptionsParams,
-        http_client: reqwest::Client,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<OnRampBuyOptionsResponse> {
         let base = format!("{}/buy/options", &self.base_api_url);
         let mut url = Url::parse(&base).map_err(|_| RpcError::OnRampParseURLError)?;
@@ -154,13 +189,15 @@ impl OnRampProvider for CoinbaseProvider {
                 .append_pair("subdivision", &subdivision);
         }
 
-        let response = http_client
-            .get(url)
-            .header("Content-Type", "application/json")
-            .header("CBPAY-APP-ID", self.app_id.clone())
-            .header("CBPAY-API-KEY", self.api_key.clone())
-            .send()
-            .await?;
+        let latency_start = SystemTime::now();
+        let response = self.send_get_request(url).await?;
+        metrics.add_latency_and_status_code_for_provider(
+            self.provider_kind,
+            response.status().into(),
+            latency_start,
+            None,
+            Some("buy_options".to_string()),
+        );
 
         if response.status() != reqwest::StatusCode::OK {
             error!(
@@ -176,18 +213,20 @@ impl OnRampProvider for CoinbaseProvider {
     async fn get_buy_quotes(
         &self,
         params: OnRampBuyQuotesParams,
-        http_client: reqwest::Client,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<OnRampBuyQuotesResponse> {
         let base = format!("{}/buy/quote", &self.base_api_url);
         let url = Url::parse(&base).map_err(|_| RpcError::OnRampParseURLError)?;
 
-        let response = http_client
-            .post(url)
-            .json(&params)
-            .header("CBPAY-APP-ID", self.app_id.clone())
-            .header("CBPAY-API-KEY", self.api_key.clone())
-            .send()
-            .await?;
+        let latency_start = SystemTime::now();
+        let response = self.send_post_request(url, &params).await?;
+        metrics.add_latency_and_status_code_for_provider(
+            self.provider_kind,
+            response.status().into(),
+            latency_start,
+            None,
+            Some("buy_quote".to_string()),
+        );
 
         if response.status() != reqwest::StatusCode::OK {
             error!(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -23,6 +23,7 @@ use {
             RpcQueryParams, SupportedCurrencies,
         },
         utils::crypto::CaipNamespaces,
+        Metrics,
     },
     async_trait::async_trait,
     axum::response::Response,
@@ -428,10 +429,12 @@ pub enum ProviderKind {
     Zora,
     Zerion,
     Coinbase,
+    OneInch,
     Quicknode,
     Near,
     Mantle,
     GetBlock,
+    SolScan,
 }
 
 impl Display for ProviderKind {
@@ -450,10 +453,12 @@ impl Display for ProviderKind {
                 ProviderKind::Zora => "Zora",
                 ProviderKind::Zerion => "Zerion",
                 ProviderKind::Coinbase => "Coinbase",
+                ProviderKind::OneInch => "OneInch",
                 ProviderKind::Quicknode => "Quicknode",
                 ProviderKind::Near => "Near",
                 ProviderKind::Mantle => "Mantle",
                 ProviderKind::GetBlock => "GetBlock",
+                ProviderKind::SolScan => "SolScan",
             }
         )
     }
@@ -473,10 +478,12 @@ impl ProviderKind {
             "Zora" => Some(Self::Zora),
             "Zerion" => Some(Self::Zerion),
             "Coinbase" => Some(Self::Coinbase),
+            "OneInch" => Some(Self::OneInch),
             "Quicknode" => Some(Self::Quicknode),
             "Near" => Some(Self::Near),
             "Mantle" => Some(Self::Mantle),
             "GetBlock" => Some(Self::GetBlock),
+            "SolScan" => Some(Self::SolScan),
             _ => None,
         }
     }
@@ -603,7 +610,7 @@ pub trait HistoryProvider: Send + Sync + Debug {
         &self,
         address: String,
         params: HistoryQueryParams,
-        http_client: reqwest::Client,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<HistoryResponseBody>;
 }
 
@@ -612,8 +619,8 @@ pub trait PortfolioProvider: Send + Sync + Debug {
     async fn get_portfolio(
         &self,
         address: String,
-        body: hyper::body::Bytes,
         params: PortfolioQueryParams,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<PortfolioResponseBody>;
 }
 
@@ -622,13 +629,13 @@ pub trait OnRampProvider: Send + Sync + Debug {
     async fn get_buy_options(
         &self,
         params: OnRampBuyOptionsParams,
-        http_client: reqwest::Client,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<OnRampBuyOptionsResponse>;
 
     async fn get_buy_quotes(
         &self,
         params: OnRampBuyQuotesParams,
-        http_client: reqwest::Client,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<OnRampBuyQuotesResponse>;
 }
 
@@ -638,7 +645,7 @@ pub trait BalanceProvider: Send + Sync + Debug {
         &self,
         address: String,
         params: BalanceQueryParams,
-        http_client: reqwest::Client,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<BalanceResponseBody>;
 }
 
@@ -649,6 +656,7 @@ pub trait FungiblePriceProvider: Send + Sync + Debug {
         chain_id: &str,
         address: &str,
         currency: &SupportedCurrencies,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<PriceResponseBody>;
 }
 
@@ -657,30 +665,38 @@ pub trait ConversionProvider: Send + Sync + Debug {
     async fn get_tokens_list(
         &self,
         params: TokensListQueryParams,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<TokensListResponseBody>;
 
     async fn get_convert_quote(
         &self,
         params: ConvertQuoteQueryParams,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<ConvertQuoteResponseBody>;
 
     async fn build_approve_tx(
         &self,
         params: ConvertApproveQueryParams,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<ConvertApproveResponseBody>;
 
     async fn build_convert_tx(
         &self,
         params: ConvertTransactionQueryParams,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<ConvertTransactionResponseBody>;
 
     async fn get_gas_price(
         &self,
         params: GasPriceQueryParams,
+        metrics: Arc<Metrics>,
     ) -> RpcResult<GasPriceQueryResponseBody>;
 
-    async fn get_allowance(&self, params: AllowanceQueryParams)
-        -> RpcResult<AllowanceResponseBody>;
+    async fn get_allowance(
+        &self,
+        params: AllowanceQueryParams,
+        metrics: Arc<Metrics>,
+    ) -> RpcResult<AllowanceResponseBody>;
 }
 
 /// List of supported bundler operations


### PR DESCRIPTION
# Description

This PR adds proper monitoring metrics for all external requests to non-proxy providers.
At the moment we are just monitoring latency and status codes for the Proxy providers and only monitoring handlers execution latency for non-proxy providers and don't monitor response codes from non-proxy providers at all. Some handlers use different non-proxy providers and execute not only one request to the provider. We need to implement proper monitoring for the non-proxy provider's endpoints.

This PR adds the following changes:
* Refactoring: aggregating repeated code parts into private methods,
* Adding request latency and response status codes by invoking the [add_latency_and_status_code](https://github.com/WalletConnect/blockchain-api/pull/773/files#diff-9f90e93b5696724fd8e4407c9db0bfd381d5468bcfbf2f09c17ac8510a85e104R414) metrics function for each of the following provider's external calls:
  * Zerion,
  * OneInch,
  * SolScan.

By adding the metrics for each request we can monitor the health of each of the non-proxy provider's endpoints and make an alert if it's not available or has a high latency.

Grafana panels for these providers was added in the follow-up https://github.com/WalletConnect/blockchain-api/pull/774

## How Has This Been Tested?

* Current integration tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [x] Add Grafana panels for each non-proxy provider
* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
