### PR TITLE
feat(grafana): adding non-rpc providers Grafana panels for status codes and endpoints latency

### DIFF
--- a/integration/fungible_price.test.ts
+++ b/integration/fungible_price.test.ts
@@ -59,7 +59,7 @@ describe('Fungible price', () => {
       { chainId: 1, symbol: 'ETH' },
       { chainId: 56, symbol: 'BNB' },
       { chainId: 100, symbol: 'xDAI' },
-      { chainId: 137, symbol: 'MATIC' },
+      { chainId: 137, symbol: 'POL' },
       { chainId: 250, symbol: 'FTM' },
       { chainId: 43114, symbol: 'AVAX' },
     ];

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -203,7 +203,7 @@ pub async fn rpc_provider_call(
 
     state
         .metrics
-        .add_external_http_latency(provider.provider_kind(), external_call_start);
+        .add_external_http_latency(provider.provider_kind(), external_call_start, None);
 
     match response.status() {
         http::StatusCode::OK | http::StatusCode::BAD_REQUEST => {

--- a/src/providers/zerion.rs
+++ b/src/providers/zerion.rs
@@ -493,7 +493,7 @@ impl BalanceProvider for ZerionProvider {
                         .and_then(|f| f.address.clone());
                     let chain_id = crypto::ChainId::to_caip2(&chain_id_human);
                     if let Some(chain_address) = chain_address {
-                        // For Polygon native token (Matic)
+                        // For Polygon native token (POL)
                         // address is returned, but address should be null
                         // for native tokens
                         // https://specs.walletconnect.com/2.0/specs/servers/blockchain/blockchain-server-api#success-response-body-4

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -68,7 +68,7 @@ dashboard.new(
     panels.ecs.memory(ds, vars)                      { gridPos: pos._3 },
     panels.ecs.cpu(ds, vars)                         { gridPos: pos._3 },
 
-  row.new('Chain Usage'),
+  row.new('RPC Proxy Chain Usage'),
     panels.usage.provider(ds, vars, 'Aurora')        { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Base')          { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'Binance')       { gridPos: pos._4 },
@@ -82,7 +82,7 @@ dashboard.new(
     panels.usage.provider(ds, vars, 'Mantle')        { gridPos: pos._4 },
     panels.usage.provider(ds, vars, 'GetBlock')      { gridPos: pos._4 },
 
-  row.new('Provider Weights'),
+  row.new('RPC Proxy provider Weights'),
     panels.weights.provider(ds, vars, 'Aurora')      { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Base')        { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'Binance')     { gridPos: pos._4 },
@@ -96,7 +96,7 @@ dashboard.new(
     panels.weights.provider(ds, vars, 'Mantle')      { gridPos: pos._4 },
     panels.weights.provider(ds, vars, 'GetBlock')    { gridPos: pos._4 },
 
-  row.new('Status Codes'),
+  row.new('RPC Proxy providers Status Codes'),
     panels.status.provider(ds, vars, 'Aurora')       { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Base')         { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'Binance')      { gridPos: pos._4 },
@@ -110,12 +110,24 @@ dashboard.new(
     panels.status.provider(ds, vars, 'Mantle')       { gridPos: pos._4 },
     panels.status.provider(ds, vars, 'GetBlock')     { gridPos: pos._4 },
 
-  row.new('Proxy Metrics'),
+  row.new('RPC Proxy Metrics'),
     panels.proxy.calls(ds, vars)                     { gridPos: pos._2 },
     panels.proxy.latency(ds, vars)                   { gridPos: pos._2 },
     panels.proxy.errors_provider(ds, vars)           { gridPos: pos._3 },
     panels.proxy.provider_retries(ds, vars)          { gridPos: pos._3 },
     panels.proxy.http_codes(ds, vars)                { gridPos: pos._3 },
+
+  row.new('Non-RPC providers Status Codes'),
+    panels.status.provider(ds, vars, 'Zerion')       { gridPos: pos._4 },
+    panels.status.provider(ds, vars, 'SolScan')      { gridPos: pos._4 },
+    panels.status.provider(ds, vars, 'OneInch')      { gridPos: pos._4 },
+    panels.status.provider(ds, vars, 'Coinbase')     { gridPos: pos._4 },
+  
+  row.new('Non-RPC providers Latency'),
+    panels.non_rpc.endpoints_latency(ds, vars, 'Zerion')       { gridPos: pos._4 },
+    panels.non_rpc.endpoints_latency(ds, vars, 'SolScan')      { gridPos: pos._4 },
+    panels.non_rpc.endpoints_latency(ds, vars, 'OneInch')      { gridPos: pos._4 },
+    panels.non_rpc.endpoints_latency(ds, vars, 'Coinbase')     { gridPos: pos._4 },
 
   row.new('Projects registry'),
     panels.projects.rejected_projects(ds, vars)         { gridPos: pos._4 },

--- a/terraform/monitoring/panels/non_rpc/endpoints_latency.libsonnet
+++ b/terraform/monitoring/panels/non_rpc/endpoints_latency.libsonnet
@@ -1,0 +1,20 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars, provider)::
+    panels.timeseries(
+      title       = provider,
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+
+    .addTarget(targets.prometheus(
+      datasource  = ds.prometheus,
+      expr          = 'sum by(endpoint) (rate(http_external_latency_tracker_sum{provider="%s"}[$__rate_interval])) / sum by(endpoint) (rate(http_external_latency_tracker_count{provider="%s"}[$__rate_interval]))' % [provider, provider],
+      legendFormat  = '__auto',
+    ))
+}

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -84,4 +84,8 @@ local redis  = panels.aws.redis;
   irn: {
     latency: (import 'irn/latency.libsonnet').new,
   },
+
+  non_rpc: {
+    endpoints_latency: (import 'non_rpc/endpoints_latency.libsonnet').new,
+  },
 }


### PR DESCRIPTION
# Description

This PR adds the following new Grafana panel rows:

* Non-RPC Providers Status codes,
* Non-RPC Providers endpoints latency.

Monitoring charts on these panels were added for the following providers:

* Zerion,
* OneInch,
* Coinbase,
* SolScan.

Also, the `endpoint` attribute was added to the `http_external_latency_tracker` metrics.

## How Has This Been Tested?

* Manually tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
