### PR TITLE
feat(rate_limiting): implementing IP whitelisting

### DIFF
--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -185,6 +185,10 @@ mod test {
             ("RPC_PROXY_RATE_LIMITING_MAX_TOKENS", "100"),
             ("RPC_PROXY_RATE_LIMITING_REFILL_INTERVAL_SEC", "1"),
             ("RPC_PROXY_RATE_LIMITING_REFILL_RATE", "10"),
+            (
+                "RPC_PROXY_RATE_LIMITING_IP_WHITE_LIST",
+                "127.0.0.1,127.0.0.2",
+            ),
             // IRN config.
             ("RPC_PROXY_IRN_NODE", "node"),
             ("RPC_PROXY_IRN_KEY", "key"),
@@ -268,6 +272,7 @@ mod test {
                     max_tokens: Some(100),
                     refill_interval_sec: Some(1),
                     refill_rate: Some(10),
+                    ip_white_list: Some(vec!["127.0.0.1".into(), "127.0.0.2".into()]),
                 },
                 irn: IrnConfig {
                     node: Some("node".to_owned()),

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -186,7 +186,7 @@ mod test {
             ("RPC_PROXY_RATE_LIMITING_REFILL_INTERVAL_SEC", "1"),
             ("RPC_PROXY_RATE_LIMITING_REFILL_RATE", "10"),
             (
-                "RPC_PROXY_RATE_LIMITING_IP_WHITE_LIST",
+                "RPC_PROXY_RATE_LIMITING_IP_WHITELIST",
                 "127.0.0.1,127.0.0.2",
             ),
             // IRN config.
@@ -272,7 +272,7 @@ mod test {
                     max_tokens: Some(100),
                     refill_interval_sec: Some(1),
                     refill_rate: Some(10),
-                    ip_white_list: Some(vec!["127.0.0.1".into(), "127.0.0.2".into()]),
+                    ip_whitelist: Some(vec!["127.0.0.1".into(), "127.0.0.2".into()]),
                 },
                 irn: IrnConfig {
                     node: Some("node".to_owned()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,13 +91,13 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
                 config.rate_limiting.max_tokens,
                 config.rate_limiting.refill_interval_sec,
                 config.rate_limiting.refill_rate,
-                config.rate_limiting.ip_white_list.clone(),
+                config.rate_limiting.ip_whitelist.clone(),
             ) {
-                (Some(max_tokens), Some(refill_interval_sec), Some(refill_rate), ip_white_list) => {
+                (Some(max_tokens), Some(refill_interval_sec), Some(refill_rate), ip_whitelist) => {
                     info!(
                         "Rate limiting is enabled with the following configuration: \
-                         max_tokens={}, refill_interval_sec={}, refill_rate={}, ip_white_list={:?}",
-                        max_tokens, refill_interval_sec, refill_rate, ip_white_list
+                         max_tokens={}, refill_interval_sec={}, refill_rate={}, ip_whitelist={:?}",
+                        max_tokens, refill_interval_sec, refill_rate, ip_whitelist
                     );
                     RateLimit::new(
                         redis_addr.write(),
@@ -106,7 +106,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
                         chrono::Duration::seconds(refill_interval_sec as i64),
                         refill_rate,
                         metrics.clone(),
-                        ip_white_list,
+                        ip_whitelist,
                     )
                 }
                 _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,12 +91,13 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
                 config.rate_limiting.max_tokens,
                 config.rate_limiting.refill_interval_sec,
                 config.rate_limiting.refill_rate,
+                config.rate_limiting.ip_white_list.clone(),
             ) {
-                (Some(max_tokens), Some(refill_interval_sec), Some(refill_rate)) => {
+                (Some(max_tokens), Some(refill_interval_sec), Some(refill_rate), ip_white_list) => {
                     info!(
                         "Rate limiting is enabled with the following configuration: \
-                         max_tokens={}, refill_interval_sec={}, refill_rate={}",
-                        max_tokens, refill_interval_sec, refill_rate
+                         max_tokens={}, refill_interval_sec={}, refill_rate={}, ip_white_list={:?}",
+                        max_tokens, refill_interval_sec, refill_rate, ip_white_list
                     );
                     RateLimit::new(
                         redis_addr.write(),
@@ -105,6 +106,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
                         chrono::Duration::seconds(refill_interval_sec as i64),
                         refill_rate,
                         metrics.clone(),
+                        ip_white_list,
                     )
                 }
                 _ => {

--- a/src/utils/rate_limit.rs
+++ b/src/utils/rate_limit.rs
@@ -14,7 +14,7 @@ pub struct RateLimitingConfig {
     pub max_tokens: Option<u32>,
     pub refill_interval_sec: Option<u32>,
     pub refill_rate: Option<u32>,
-    pub ip_white_list: Option<Vec<String>>,
+    pub ip_whitelist: Option<Vec<String>>,
 }
 
 pub struct RateLimit {
@@ -24,7 +24,7 @@ pub struct RateLimit {
     interval: Duration,
     refill_rate: u32,
     metrics: Arc<Metrics>,
-    ip_white_list: Option<Vec<String>>,
+    ip_whitelist: Option<Vec<String>>,
 }
 
 impl RateLimit {
@@ -35,7 +35,7 @@ impl RateLimit {
         interval: Duration,
         refill_rate: u32,
         metrics: Arc<Metrics>,
-        ip_white_list: Option<Vec<String>>,
+        ip_whitelist: Option<Vec<String>>,
     ) -> Option<Self> {
         let redis_builder = deadpool_redis::Config::from_url(redis_addr)
             .builder()
@@ -71,7 +71,7 @@ impl RateLimit {
             interval,
             refill_rate,
             metrics,
-            ip_white_list,
+            ip_whitelist,
         })
     }
 
@@ -88,8 +88,8 @@ impl RateLimit {
         _project_id: Option<&str>,
     ) -> Result<(), RateLimitExceeded> {
         // Check first if the IP is in the white list
-        if let Some(white_list) = &self.ip_white_list {
-            if white_list.contains(&ip.to_string()) {
+        if let Some(whitelist) = &self.ip_whitelist {
+            if whitelist.contains(&ip.to_string()) {
                 return Ok(());
             }
         }

--- a/src/utils/rate_limit.rs
+++ b/src/utils/rate_limit.rs
@@ -14,6 +14,7 @@ pub struct RateLimitingConfig {
     pub max_tokens: Option<u32>,
     pub refill_interval_sec: Option<u32>,
     pub refill_rate: Option<u32>,
+    pub ip_white_list: Option<Vec<String>>,
 }
 
 pub struct RateLimit {
@@ -23,6 +24,7 @@ pub struct RateLimit {
     interval: Duration,
     refill_rate: u32,
     metrics: Arc<Metrics>,
+    ip_white_list: Option<Vec<String>>,
 }
 
 impl RateLimit {
@@ -33,6 +35,7 @@ impl RateLimit {
         interval: Duration,
         refill_rate: u32,
         metrics: Arc<Metrics>,
+        ip_white_list: Option<Vec<String>>,
     ) -> Option<Self> {
         let redis_builder = deadpool_redis::Config::from_url(redis_addr)
             .builder()
@@ -68,6 +71,7 @@ impl RateLimit {
             interval,
             refill_rate,
             metrics,
+            ip_white_list,
         })
     }
 
@@ -83,6 +87,13 @@ impl RateLimit {
         ip: &str,
         _project_id: Option<&str>,
     ) -> Result<(), RateLimitExceeded> {
+        // Check first if the IP is in the white list
+        if let Some(white_list) = &self.ip_white_list {
+            if white_list.contains(&ip.to_string()) {
+                return Ok(());
+            }
+        }
+
         let call_start_time = SystemTime::now();
         let result = token_bucket(
             &self.mem_cache.clone(),


### PR DESCRIPTION
# Description

This PR implements the IP's whitelisting for the rate-limiting middleware.
The following changes were made:

* New optional config environment variable `RPC_PROXY_RATE_LIMITING_IP_WHITE_LIST` was added for the comma-separated list of whitelisted IPs;
* Check for the IP in the whitelist added to the rate-limiting middleware.

## How Has This Been Tested?

* No tests for the whitelisting yet.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
