### PR TITLE
fix(rate_limiting): adding terraform IP whitelisting variable

### DIFF
--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -116,6 +116,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_RATE_LIMITING_MAX_TOKENS", value = tostring(var.rate_limiting_max_tokens) },
         { name = "RPC_PROXY_RATE_LIMITING_REFILL_INTERVAL_SEC", value = tostring(var.rate_limiting_refill_interval) },
         { name = "RPC_PROXY_RATE_LIMITING_REFILL_RATE", value = tostring(var.rate_limiting_refill_rate) },
+        { name = "RPC_PROXY_RATE_LIMITING_IP_WHITELIST", value = var.rate_limiting_ip_whitelist },
 
         { name = "RPC_PROXY_POSTGRES_URI", value = var.postgres_url },
 

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -352,6 +352,11 @@ variable "rate_limiting_refill_rate" {
   type        = number
 }
 
+variable "rate_limiting_ip_whitelist" {
+  description = "Comma separated list of whitelisted IPs"
+  type        = string
+}
+
 #-------------------------------------------------------------------------------
 # IRN client configuration
 

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -84,6 +84,7 @@ module "ecs" {
   rate_limiting_max_tokens      = var.rate_limiting_max_tokens
   rate_limiting_refill_interval = var.rate_limiting_refill_interval
   rate_limiting_refill_rate     = var.rate_limiting_refill_rate
+  rate_limiting_ip_whitelist    = var.rate_limiting_ip_whitelist
 
   # IRN Client
   irn_node             = var.irn_node

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -207,6 +207,11 @@ variable "rate_limiting_refill_rate" {
   default     = 3
 }
 
+variable "rate_limiting_ip_whitelist" {
+  description = "Comma separated list of whitelisted IPs"
+  type        = string
+}
+
 #-------------------------------------------------------------------------------
 # IRN VPC peering
 


### PR DESCRIPTION
# Description

This PR is a follow-up for #776, it fixes (adding) the Terraform variable for the IP whitelisting which is missed in the original #776.

## How Has This Been Tested?

* Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
