### PR TITLE
fix(SolScan): using the correct SPL tokens amount in balance

### DIFF
--- a/src/providers/solscan.rs
+++ b/src/providers/solscan.rs
@@ -220,7 +220,7 @@ struct TokensResponseItem {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 struct AmountItem {
-    pub amount: String,
+    pub ui_amount_string: String,
     pub decimals: u8,
 }
 
@@ -316,7 +316,7 @@ impl BalanceProvider for SolScanProvider {
                 price: 0.0,
                 quantity: BalanceQuantity {
                     decimals: f.token_amount.decimals.to_string(),
-                    numeric: f.token_amount.amount,
+                    numeric: f.token_amount.ui_amount_string,
                 },
                 icon_url: f.token_icon.unwrap_or_default(),
             })


### PR DESCRIPTION
# Description

This PR fixes SPL tokens balance amounts by using the amount with decimals applied.
Currently, the amount without applied decimals is returned which caused the wrong amount in the UI.

## How Has This Been Tested?

* Current integration tests and manual querying of the Solana address with SPL tokens.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
