### PR TITLE
feat(CoSign): response depends on the `version` query parameter

### DIFF
--- a/src/handlers/sessions/cosign.rs
+++ b/src/handlers/sessions/cosign.rs
@@ -23,6 +23,7 @@ use {
         utils::keccak256,
     },
     serde::{Deserialize, Serialize},
+    serde_json::json,
     std::{sync::Arc, time::SystemTime},
     wc::future::FutureExt,
 };
@@ -155,21 +156,9 @@ async fn handler_internal(
     // Update the userOp with the signature
     user_op.signature = concatenated_signature;
 
-    // Make a POST request to the sendUserOp endpoint
-    let send_user_op_request = SendUserOpRequest {
-        chain_id: chain_id_uint as usize,
-        user_op: user_op.clone(),
-        permissions_context: Some(permission_context),
-    };
-    let http_client = state.http_client.clone();
-    let send_user_op_call_result = http_client
-        .post(SEND_USER_OP_ENDPOINT)
-        .json(&send_user_op_request)
-        .send()
-        .await?;
-    let result = send_user_op_call_result
-        .json::<SendUserOpResponse>()
-        .await?;
+    let result = json!({
+        "signature": format!("0x{}", hex::encode(user_op.signature)),
+    });
 
     Ok(Json(result).into_response())
 }

--- a/src/handlers/sessions/cosign.rs
+++ b/src/handlers/sessions/cosign.rs
@@ -11,7 +11,7 @@ use {
         },
     },
     axum::{
-        extract::{Path, State},
+        extract::{Path, Query, State},
         response::{IntoResponse, Response},
         Json,
     },
@@ -52,12 +52,20 @@ pub struct SendUserOpResponse {
     pub receipt: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoSignQueryParams {
+    /// CoSigner version for testing purposes
+    pub version: Option<u8>,
+}
+
 pub async fn handler(
     state: State<Arc<AppState>>,
     address: Path<String>,
+    query_payload: Query<CoSignQueryParams>,
     Json(request_payload): Json<CoSignRequest>,
 ) -> Result<Response, RpcError> {
-    handler_internal(state, address, request_payload)
+    handler_internal(state, address, request_payload, query_payload)
         .with_metrics(HANDLER_TASK_METRICS.with_name("sessions_co_sign"))
         .await
 }
@@ -67,6 +75,7 @@ async fn handler_internal(
     state: State<Arc<AppState>>,
     Path(caip10_address): Path<String>,
     request_payload: CoSignRequest,
+    query_payload: Query<CoSignQueryParams>,
 ) -> Result<Response, RpcError> {
     // Checking the CAIP-10 address format
     let (namespace, chain_id, address) = disassemble_caip10(&caip10_address)?;
@@ -156,9 +165,31 @@ async fn handler_internal(
     // Update the userOp with the signature
     user_op.signature = concatenated_signature;
 
-    let result = json!({
-        "signature": format!("0x{}", hex::encode(user_op.signature)),
-    });
-
-    Ok(Json(result).into_response())
+    // Check the call version and make or skip wallet service call
+    // if the version 0 (default) or return the signature
+    // if the version not 0
+    let version = query_payload.version.unwrap_or(0);
+    if version == 0 {
+        // Make a POST request to the sendUserOp endpoint
+        let send_user_op_request = SendUserOpRequest {
+            chain_id: chain_id_uint as usize,
+            user_op: user_op.clone(),
+            permissions_context: Some(permission_context),
+        };
+        let http_client = state.http_client.clone();
+        let send_user_op_call_result = http_client
+            .post(SEND_USER_OP_ENDPOINT)
+            .json(&send_user_op_request)
+            .send()
+            .await?;
+        let result = send_user_op_call_result
+            .json::<SendUserOpResponse>()
+            .await?;
+        Ok(Json(result).into_response())
+    } else {
+        Ok(Json(json!({
+            "signature": format!("0x{}", hex::encode(user_op.signature)),
+        }))
+        .into_response())
+    }
 }

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -526,6 +526,7 @@ pub enum ChainId {
         serialize = "binance_smart_chain",
         serialize = "bsc"
     )]
+    BaseSepoliaTestnet = 84532,
     BinanceSmartChain = 56,
     Blast = 81032,
     Celo = 42220,

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -521,12 +521,13 @@ pub enum ChainId {
     Aurora = 1313161554,
     Avalanche = 43114,
     Base = 8453,
+    #[strum(serialize = "base_sepolia_testnet", serialize = "base-sepolia-testnet")]
+    BaseSepoliaTestnet = 84532,
     #[strum(
         to_string = "binance-smart-chain",
         serialize = "binance_smart_chain",
         serialize = "bsc"
     )]
-    BaseSepoliaTestnet = 84532,
     BinanceSmartChain = 56,
     Blast = 81032,
     Celo = 42220,
@@ -753,6 +754,7 @@ mod tests {
         chains.insert("xdai", "eip155:100");
         chains.insert("polygon", "eip155:137");
         chains.insert("base", "eip155:8453");
+        chains.insert("base_sepolia_testnet", "eip155:84532");
 
         for (chain_name, coin_type) in chains.iter() {
             let result = ChainId::to_caip2(chain_name);
@@ -771,6 +773,7 @@ mod tests {
         chains.insert("eip155:100", "xdai");
         chains.insert("eip155:137", "polygon");
         chains.insert("eip155:8453", "base");
+        chains.insert("eip155:84532", "base-sepolia-testnet");
 
         for (chain_id, chain_name) in chains.iter() {
             let result = ChainId::from_caip2(chain_id);


### PR DESCRIPTION
# Description

This PR adds the response to the CoSign request depending on the `version` query parameter.
The default response is used when no `version` or `version = 0` is provided for backward compatibility. The updated response `version != 0` should be a signature without calling the wallet service.
We are still in the testing/mvp stage so the `version` will reflect the further stages if needed until the stable.

## How Has This Been Tested?

* Only manual testing.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
