### PR TITLE
feat(SolScan): implementing tokens metadata and price caching

### DIFF
--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -146,6 +146,10 @@ mod test {
             ("RPC_PROXY_ANALYTICS_S3_ENDPOINT", "s3://127.0.0.1"),
             ("RPC_PROXY_ANALYTICS_EXPORT_BUCKET", "EXPORT_BUCKET"),
             // Providers config
+            (
+                "RPC_PROXY_PROVIDER_CACHE_REDIS_ADDR",
+                "redis://127.0.0.1/providers_cache",
+            ),
             ("RPC_PROXY_PROVIDER_INFURA_PROJECT_ID", "INFURA_PROJECT_ID"),
             ("RPC_PROXY_PROVIDER_POKT_PROJECT_ID", "POKT_PROJECT_ID"),
             ("RPC_PROXY_PROVIDER_ZERION_API_KEY", "ZERION_API_KEY"),
@@ -255,6 +259,7 @@ mod test {
                 providers: ProvidersConfig {
                     prometheus_query_url: Some("PROMETHEUS_QUERY_URL".to_owned()),
                     prometheus_workspace_header: Some("PROMETHEUS_WORKSPACE_HEADER".to_owned()),
+                    cache_redis_addr: Some("redis://127.0.0.1/providers_cache".to_owned()),
                     infura_project_id: "INFURA_PROJECT_ID".to_string(),
                     pokt_project_id: "POKT_PROJECT_ID".to_string(),
                     quicknode_api_tokens: "QUICKNODE_API_TOKENS".to_string(),

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -112,6 +112,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_STORAGE_IDENTITY_CACHE_REDIS_ADDR_WRITE", value = "redis://${var.identity_cache_endpoint_write}/1" },
         { name = "RPC_PROXY_STORAGE_RATE_LIMITING_CACHE_REDIS_ADDR_READ", value = "redis://${var.rate_limiting_cache_endpoint_read}/2" },
         { name = "RPC_PROXY_STORAGE_RATE_LIMITING_CACHE_REDIS_ADDR_WRITE", value = "redis://${var.rate_limiting_cache_endpoint_write}/2" },
+        { name = "RPC_PROXY_PROVIDER_CACHE_REDIS_ADDR", value = "redis://${var.provider_cache_endpoint}/3" },
 
         { name = "RPC_PROXY_RATE_LIMITING_MAX_TOKENS", value = tostring(var.rate_limiting_max_tokens) },
         { name = "RPC_PROXY_RATE_LIMITING_REFILL_INTERVAL_SEC", value = tostring(var.rate_limiting_refill_interval) },

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -146,6 +146,11 @@ variable "rate_limiting_cache_endpoint_write" {
   type        = string
 }
 
+variable "provider_cache_endpoint" {
+  description = "Non-RPC providers responses caching endpoint"
+  type        = string
+}
+
 variable "ofac_blocked_countries" {
   description = "The list of countries under OFAC sanctions"
   type        = string

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -58,6 +58,7 @@ module "ecs" {
   identity_cache_endpoint_write      = module.redis.endpoint
   rate_limiting_cache_endpoint_read  = module.redis.endpoint
   rate_limiting_cache_endpoint_write = module.redis.endpoint
+  provider_cache_endpoint            = module.redis.endpoint
   ofac_blocked_countries             = var.ofac_blocked_countries
   postgres_url                       = module.postgres.database_url
 


### PR DESCRIPTION
# Description

This PR implements the local caching for tokens metadata and price.
We are requesting tokens metadata and price on each balance and transaction history request. Since the token's metadata doesn't change often we can cache it in Redis and reuse the cached data instead of querying the provider every time. 
Also, the token's price can be cached to reuse in balance, history, and fungible price endpoints without querying the provider on every request.
This will significantly decrease the latency of our balance, history, and fungible price endpoints and decrease provider request count.

The different TTL for the metadata and pricing cache was applied, since metadata changes are rare and token price changes more often:
* Metadata cache TTL: 1 hour,
* Token price cache TTL: 5 minutes.

The cache response latency metric is also added.

## How Has This Been Tested?

* These changes are covered by the current integration tests for Solana.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
