### PR TITLE
feat(monitoring): add non-rpc providers cache latency Grafana panel

### DIFF
--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -146,6 +146,10 @@ mod test {
             ("RPC_PROXY_ANALYTICS_S3_ENDPOINT", "s3://127.0.0.1"),
             ("RPC_PROXY_ANALYTICS_EXPORT_BUCKET", "EXPORT_BUCKET"),
             // Providers config
+            (
+                "RPC_PROXY_PROVIDER_CACHE_REDIS_ADDR",
+                "redis://127.0.0.1/providers_cache",
+            ),
             ("RPC_PROXY_PROVIDER_INFURA_PROJECT_ID", "INFURA_PROJECT_ID"),
             ("RPC_PROXY_PROVIDER_POKT_PROJECT_ID", "POKT_PROJECT_ID"),
             ("RPC_PROXY_PROVIDER_ZERION_API_KEY", "ZERION_API_KEY"),
@@ -255,6 +259,7 @@ mod test {
                 providers: ProvidersConfig {
                     prometheus_query_url: Some("PROMETHEUS_QUERY_URL".to_owned()),
                     prometheus_workspace_header: Some("PROMETHEUS_WORKSPACE_HEADER".to_owned()),
+                    cache_redis_addr: Some("redis://127.0.0.1/providers_cache".to_owned()),
                     infura_project_id: "INFURA_PROJECT_ID".to_string(),
                     pokt_project_id: "POKT_PROJECT_ID".to_string(),
                     quicknode_api_tokens: "QUICKNODE_API_TOKENS".to_string(),

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -112,6 +112,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { name = "RPC_PROXY_STORAGE_IDENTITY_CACHE_REDIS_ADDR_WRITE", value = "redis://${var.identity_cache_endpoint_write}/1" },
         { name = "RPC_PROXY_STORAGE_RATE_LIMITING_CACHE_REDIS_ADDR_READ", value = "redis://${var.rate_limiting_cache_endpoint_read}/2" },
         { name = "RPC_PROXY_STORAGE_RATE_LIMITING_CACHE_REDIS_ADDR_WRITE", value = "redis://${var.rate_limiting_cache_endpoint_write}/2" },
+        { name = "RPC_PROXY_PROVIDER_CACHE_REDIS_ADDR", value = "redis://${var.provider_cache_endpoint}/3" },
 
         { name = "RPC_PROXY_RATE_LIMITING_MAX_TOKENS", value = tostring(var.rate_limiting_max_tokens) },
         { name = "RPC_PROXY_RATE_LIMITING_REFILL_INTERVAL_SEC", value = tostring(var.rate_limiting_refill_interval) },

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -146,6 +146,11 @@ variable "rate_limiting_cache_endpoint_write" {
   type        = string
 }
 
+variable "provider_cache_endpoint" {
+  description = "Non-RPC providers responses caching endpoint"
+  type        = string
+}
+
 variable "ofac_blocked_countries" {
   description = "The list of countries under OFAC sanctions"
   type        = string

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -129,6 +129,9 @@ dashboard.new(
     panels.non_rpc.endpoints_latency(ds, vars, 'OneInch')      { gridPos: pos._4 },
     panels.non_rpc.endpoints_latency(ds, vars, 'Coinbase')     { gridPos: pos._4 },
 
+  row.new('Non-RPC providers Cache'),
+    panels.non_rpc.cache_latency(ds, vars)      { gridPos: pos._2 },
+
   row.new('Projects registry'),
     panels.projects.rejected_projects(ds, vars)         { gridPos: pos._4 },
     panels.projects.quota_limited_projects(ds, vars)    { gridPos: pos._4 },

--- a/terraform/monitoring/panels/non_rpc/cache_latency.libsonnet
+++ b/terraform/monitoring/panels/non_rpc/cache_latency.libsonnet
@@ -1,0 +1,20 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars)::
+    panels.timeseries(
+      title       = 'Cache latency',
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+
+    .addTarget(targets.prometheus(
+      datasource  = ds.prometheus,
+      expr          = 'sum(rate(non_rpc_providers_cache_latency_tracker_sum[$__rate_interval])) / sum(rate(non_rpc_providers_cache_latency_tracker_count[$__rate_interval]))',
+      legendFormat  = '__auto',
+    ))
+}

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -87,5 +87,6 @@ local redis  = panels.aws.redis;
 
   non_rpc: {
     endpoints_latency: (import 'non_rpc/endpoints_latency.libsonnet').new,
+    cache_latency: (import 'non_rpc/cache_latency.libsonnet').new,
   },
 }

--- a/terraform/res_ecs.tf
+++ b/terraform/res_ecs.tf
@@ -58,6 +58,7 @@ module "ecs" {
   identity_cache_endpoint_write      = module.redis.endpoint
   rate_limiting_cache_endpoint_read  = module.redis.endpoint
   rate_limiting_cache_endpoint_write = module.redis.endpoint
+  provider_cache_endpoint            = module.redis.endpoint
   ofac_blocked_countries             = var.ofac_blocked_countries
   postgres_url                       = module.postgres.database_url
 


### PR DESCRIPTION
# Description

This PR is the follow-up for #782 and adds the Grafana panel for the non-RPC providers' cache latency for monitoring purposes.

## How Has This Been Tested?

* The new panel was manually applied to the Grafana.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
