### PR TITLE
fix(tests): increasing jest tests timeout

### DIFF
--- a/integration/jestconfig.integration.json
+++ b/integration/jestconfig.integration.json
@@ -5,5 +5,5 @@
   },
   "testRegex": "./.*\\.test\\.ts$",
   "collectCoverageFrom": ["src/**/*.{ts,js}"],
-  "testTimeout": 10000
+  "testTimeout": 30000
 }


### PR DESCRIPTION
# Description

This PR increases the Jest tests timeout from 10 seconds to 30 seconds. 
For the Solana fulfilled address we are using the address with multiple subaccounts which sometimes leads to the uncached response from the provider can take ~12-15 seconds causes tests to fail due to timeout.

## How Has This Been Tested?

* Not tested.
<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
