### PR TITLE
fix(providers): responding with HTTP 503 on provider non-success response

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -508,6 +508,14 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response(),
+            Self::OnRampProviderError => (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(new_error_response(
+                        "".to_string(),
+                        "OnRamp provider is temporarily unavailable".to_string(),
+                    )),
+                )
+                    .into_response(),
             Self::PortfolioProviderError => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(new_error_response(
@@ -532,7 +540,14 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response(),
-
+            Self::ConversionProviderError => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(new_error_response(
+                    "".to_string(),
+                    "Convertion provider is temporarily unavailable".to_string(),
+                )),
+            )
+                .into_response(),
             // Any other errors considering as 500
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/providers/coinbase.rs
+++ b/src/providers/coinbase.rs
@@ -122,7 +122,7 @@ impl HistoryProvider for CoinbaseProvider {
             Some("transactions".to_string()),
         );
 
-        if response.status() != reqwest::StatusCode::OK {
+        if !response.status().is_success() {
             error!(
                 "Error on Coinbase transactions response. Status is not OK: {:?}",
                 response.status(),
@@ -199,7 +199,7 @@ impl OnRampProvider for CoinbaseProvider {
             Some("buy_options".to_string()),
         );
 
-        if response.status() != reqwest::StatusCode::OK {
+        if !response.status().is_success() {
             error!(
                 "Error on CoinBase buy options response. Status is not OK: {:?}",
                 response.status(),
@@ -228,7 +228,7 @@ impl OnRampProvider for CoinbaseProvider {
             Some("buy_quote".to_string()),
         );
 
-        if response.status() != reqwest::StatusCode::OK {
+        if !response.status().is_success() {
             error!(
                 "Error on CoinBase buy quotes response. Status is not OK: {:?}",
                 response.status(),


### PR DESCRIPTION
# Description

This PR added a proper HTTP 503 (Temporarily unavailable) response instead of HTTP 500 (Server error) when the OneInch and Coinbase endpoints response was not successful.

## How Has This Been Tested?

* Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
