### PR TITLE
fix(tests): changing Solana fulfilled address and removing name zone variable

### DIFF
--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -105,12 +105,9 @@ jobs:
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           RPC_URL: ${{ inputs.stage-url }}
-          NAMES_MAIN_ZONE: ${{ secrets.NAMES_MAIN_ZONE }}
       - name: Yarn Integration Tests
         if: ${{ inputs.stage == 'prod' }}
         run: yarn integration
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           RPC_URL: ${{ inputs.stage-url }}
-          NAMES_MAIN_ZONE: ${{ secrets.NAMES_MAIN_ZONE }}
-          

--- a/integration/balance.test.ts
+++ b/integration/balance.test.ts
@@ -4,7 +4,7 @@ describe('Account balance', () => {
   const { baseUrl, projectId, httpClient } = getTestSetup();
 
   const fulfilled_eth_address = '0xf3ea39310011333095CFCcCc7c4Ad74034CABA63'
-  const fulfilled_solana_address = 'ThDDM64EYViLM1trknxJTBcuWRh2eGuecLG3sVj8VV7'
+  const fulfilled_solana_address = '5PUrktzVvJPNFYpxNzFkGp4a5Dcj1Dduif5dAzuUUhsr'
 
   const empty_eth_address = '0x5b6262592954B925B510651462b63ddEbcc22eaD'
   const empty_solana_address = '7ar3r6Mau1Bk7pGLWHCMj1C1bk2eCDwGWTP77j9MXTtd'

--- a/integration/names.test.ts
+++ b/integration/names.test.ts
@@ -15,7 +15,7 @@ describe('Account profile names', () => {
   // Generate a random name
   const randomString = Array.from({ length: 10 }, 
     () => (Math.random().toString(36)[2] || '0')).join('')
-  const zone =  process.env.NAMES_MAIN_ZONE;
+  const zone =  'reown.id';
   const name = `integration-test-${randomString}.${zone}`;
 
   // Create a message to sign


### PR DESCRIPTION
# Description

This PR changed the Solana fulfilled address for tests from `ThDD...8VV7` to `5PUr...Uhsr`. The reason for this change is that `ThDD...8VV7` is an account that is actively used for thousands of transactions, which causes a delay in response. 
We don't need such a huge account for tests, that's why we are changing to the `5PUr...Uhsr` that has a dozen transactions of activity.
Also, this PR removes the `MAIN_ZONE` variable and hardcoding the main zone in the test.

## How Has This Been Tested?

* Tested by running the integration tests locally.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
