### PR TITLE
fix(providers): considering `HTTP 402` as rate limited for GetBlock

### DIFF
--- a/src/providers/getblock.rs
+++ b/src/providers/getblock.rs
@@ -40,6 +40,7 @@ impl Provider for GetBlockProvider {
 impl RateLimited for GetBlockProvider {
     async fn is_rate_limited(&self, response: &mut Response) -> bool {
         response.status() == http::StatusCode::TOO_MANY_REQUESTS
+            || response.status() == http::StatusCode::PAYMENT_REQUIRED
     }
 }
 


### PR DESCRIPTION
# Description

This PR adds handling of the `HTTP 402 Payment required` response from the GetBlock provider as rate-limited since this error code returns when we reach the plan limits.

## How Has This Been Tested?

* No tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
