### PR TITLE
feat(providers): adding `pimlico_getUserOperationGasPrice` to the bundler supported operations.

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -739,6 +739,8 @@ pub enum SupportedBundlerOps {
     EthEstimateUserOperationGas,
     #[serde(rename = "pm_sponsorUserOperation")]
     PmSponsorUserOperation,
+    #[serde(rename = "pm_getUserOperationGasPrice")]
+    PmGetUserOperationGasPrice,
 }
 
 /// Provider for the bundler operations

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -737,10 +737,11 @@ pub enum SupportedBundlerOps {
     EthSendUserOperation,
     #[serde(rename = "eth_estimateUserOperationGas")]
     EthEstimateUserOperationGas,
+    /// Paymaster sponsor UserOp
     #[serde(rename = "pm_sponsorUserOperation")]
     PmSponsorUserOperation,
-    #[serde(rename = "pm_getUserOperationGasPrice")]
-    PmGetUserOperationGasPrice,
+    #[serde(rename = "pimlico_getUserOperationGasPrice")]
+    PimlicoGetUserOperationGasPrice,
 }
 
 /// Provider for the bundler operations

--- a/src/providers/pimlico.rs
+++ b/src/providers/pimlico.rs
@@ -74,6 +74,9 @@ impl BundlerOpsProvider for PimlicoProvider {
             SupportedBundlerOps::WalletGetCallsStatus => "wallet_getCallsStatus".into(),
             SupportedBundlerOps::WalletShowCallsStatus => "wallet_showCallsStatus".into(),
             SupportedBundlerOps::PmSponsorUserOperation => "pm_sponsorUserOperation".into(),
+            SupportedBundlerOps::PmGetUserOperationGasPrice => {
+                "pimlico_getUserOperationGasPrice".into()
+            }
         }
     }
 }

--- a/src/providers/pimlico.rs
+++ b/src/providers/pimlico.rs
@@ -74,7 +74,7 @@ impl BundlerOpsProvider for PimlicoProvider {
             SupportedBundlerOps::WalletGetCallsStatus => "wallet_getCallsStatus".into(),
             SupportedBundlerOps::WalletShowCallsStatus => "wallet_showCallsStatus".into(),
             SupportedBundlerOps::PmSponsorUserOperation => "pm_sponsorUserOperation".into(),
-            SupportedBundlerOps::PmGetUserOperationGasPrice => {
+            SupportedBundlerOps::PimlicoGetUserOperationGasPrice => {
                 "pimlico_getUserOperationGasPrice".into()
             }
         }


### PR DESCRIPTION
# Description

This PR adds the `pimlico_getUserOperationGasPrice` as a supported operation to the bundler proxy.

## How Has This Been Tested?

* Tested manually.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
