### PR TITLE
feat(cosigner): updating the request schema to the ERC7715

### DIFF
--- a/src/handlers/sessions/get.rs
+++ b/src/handlers/sessions/get.rs
@@ -9,6 +9,7 @@ use {
         response::{IntoResponse, Response},
         Json,
     },
+    serde_json::json,
     std::{sync::Arc, time::SystemTime},
     wc::future::FutureExt,
 };
@@ -43,5 +44,7 @@ async fn handler_internal(
     let storage_permissions_item =
         serde_json::from_str::<StoragePermissionsItem>(&storage_permissions_item)?;
 
-    Ok(Json(storage_permissions_item.permissions).into_response())
+    let response = json!({"context": storage_permissions_item.context});
+
+    Ok(Json(response).into_response())
 }

--- a/src/handlers/sessions/mod.rs
+++ b/src/handlers/sessions/mod.rs
@@ -1,6 +1,7 @@
 use {
     crate::utils::crypto::UserOperation,
     serde::{Deserialize, Serialize},
+    serde_json::Value,
 };
 
 pub mod context;
@@ -13,9 +14,17 @@ pub mod revoke;
 /// Payload to create a new permission
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NewPermissionPayload {
-    pub permission: PermissionItem,
+    pub expiry: usize,
+    pub signer: PermissionTypeData,
+    pub permissions: Vec<PermissionTypeData>,
+    pub policies: Vec<PermissionTypeData>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PermissionTypeData {
+    pub r#type: String,
+    pub data: Value,
+}
 // Payload to get permission by PCI
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GetPermissionsRequest {
@@ -23,46 +32,16 @@ pub struct GetPermissionsRequest {
     pci: String,
 }
 
-/// Permission item schema
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PermissionItem {
-    permission_type: String,
-    data: String,
-    required: bool,
-    on_chain_validated: bool,
-}
-
 /// Permissions Context item schema
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct PermissionContextItem {
-    pci: String,
-    context: PermissionSubContext,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PermissionSubContext {
-    signer: PermissionContextSigner,
-    expiry: usize,
-    signer_data: PermissionSubContextSignerData,
-    factory: String,
-    factory_data: String,
-    permissions_context: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PermissionContextSigner {
-    r#type: String,
-    data: PermissionContextSignerData,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PermissionContextSignerData {
-    ids: Vec<String>,
+pub struct ActivatePermissionPayload {
+    pub pci: String,
+    pub expiry: usize,
+    pub signer: PermissionTypeData,
+    pub permissions: Vec<PermissionTypeData>,
+    pub policies: Vec<PermissionTypeData>,
+    pub context: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -75,8 +54,11 @@ pub struct PermissionSubContextSignerData {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StoragePermissionsItem {
-    permissions: PermissionItem,
-    context: Option<PermissionContextItem>,
+    expiry: usize,
+    signer: PermissionTypeData,
+    permissions: Vec<PermissionTypeData>,
+    policies: Vec<PermissionTypeData>,
+    context: Option<String>,
     verification_key: String,
     signing_key: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,7 +340,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         .route("/v1/sessions/:address", post(handlers::sessions::create::handler))
         .route("/v1/sessions/:address", get(handlers::sessions::list::handler))
         .route("/v1/sessions/:address/:pci", get(handlers::sessions::get::handler))
-        .route("/v1/sessions/:address/context", post(handlers::sessions::context::handler))
+        .route("/v1/sessions/:address/activate", post(handlers::sessions::context::handler))
         .route("/v1/sessions/:address/revoke", post(handlers::sessions::revoke::handler))
         .route("/v1/sessions/:address/sign", post(handlers::sessions::cosign::handler))
         // Bundler


### PR DESCRIPTION
# Description

This PR makes changes to the CoSigner endpoints according to our [updated SPEC draft](https://www.notion.so/walletconnect/Ready-for-review-Co-signer-API-spec-v2-9a1cdcf24cee4a6b8b126213c0b2eef2).

The following changes were made:
* Permissions schema was changed to the ERC7715,
* Keys encoding using the Hex instead of the Base64,
* Renaming the context endpoint to the activation,
* Returning the signature instead of the walletService call in the sign endpoint.

## How Has This Been Tested?

* Manually tested at the moment.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
